### PR TITLE
hot fix - rm cosign ctrls from all controls

### DIFF
--- a/frameworks/allcontrols.json
+++ b/frameworks/allcontrols.json
@@ -6,18 +6,6 @@
     },
     "activeControls": [
         {
-            "controlID": "C-0236",
-            "patch": {
-                "name": "Verify image signature"
-            }
-        },
-        {
-            "controlID": "C-0237",
-            "patch": {
-                "name": "Has image signature"
-            }
-        },
-        {
             "controlID": "C-0001",
             "patch": {
                 "name": "Forbidden Container Registries"


### PR DESCRIPTION
Remove cosign controls until we define a clear design about how and when they should work.
This is urgent as it is taking around 1-2s for each image scanned for KS to run these new functions, and we see error logs.