### PR TITLE
docs: fix broken links

### DIFF
--- a/.github/workflows/check-broken-links.yaml
+++ b/.github/workflows/check-broken-links.yaml
@@ -1,5 +1,4 @@
 name: Markdown link check
-
 on:
   push:
     branches: [master, dev]
@@ -7,8 +6,8 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Check links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        use-verbose-mode: 'yes'
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - name: Check links
+        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368
+        with:
+          use-verbose-mode: 'yes'

--- a/.github/workflows/check-broken-links.yaml
+++ b/.github/workflows/check-broken-links.yaml
@@ -1,0 +1,14 @@
+name: Markdown link check
+
+on:
+  push:
+    branches: [master, dev]
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check links
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-verbose-mode: 'yes'

--- a/.github/workflows/export-dev.yaml
+++ b/.github/workflows/export-dev.yaml
@@ -1,39 +1,31 @@
 name: update-csvs
-
 on:
   push:
-    branches: [ dev ]
-
+    branches: [dev]
 jobs:
   once:
     name: Build, Test, Create And Generate releaseDev
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v1
-
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with: 
-        go-version: 1.19
-
-    - name: Test Regoes
-      working-directory: testrunner
-      run: |
-        apt update && apt install -y cmake
-        GOPATH=$(go env GOPATH) make
-
-    
-    - name: Run export script
-      run: | 
-        OUTPUT=pre-release python ./scripts/export.py
-        rm -r releaseDev
-        cp -R pre-release releaseDev
-    - name: stage changed files
-      run: git add .
-
-    - name: Commit & Push changes
-      uses: Andro999b/push@v1.3
-      with:
-        branch: dev
-        github_token: ${{ secrets.GITHUB_TOKEN }} 
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
+      - name: Set up Go
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492
+        with:
+          go-version: 1.19
+      - name: Test Regoes
+        working-directory: testrunner
+        run: |
+          apt update && apt install -y cmake
+          GOPATH=$(go env GOPATH) make
+      - name: Run export script
+        run: |
+          OUTPUT=pre-release python ./scripts/export.py
+          rm -r releaseDev
+          cp -R pre-release releaseDev
+      - name: stage changed files
+        run: git add .
+      - name: Commit & Push changes
+        uses: Andro999b/push@c77535fe7a94645f7ceca83e48e6cc977620710e
+        with:
+          branch: dev
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/export.yaml
+++ b/.github/workflows/export.yaml
@@ -1,10 +1,8 @@
 name: export
-
 on:
   push:
-    branches: [master,main]
+    branches: [master, main]
     paths-ignore: ['**.md', 'releaseDev/**']
-    
 jobs:
   once:
     name: Build, Test, Create And Upload Release
@@ -12,25 +10,22 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6
         name: checkout repo content
-
       # Test using Golang OPA hot rule compilation
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492
         with:
           go-version: 1.19
-
       - name: Test Regoes
         working-directory: testrunner
         run: |
           apt update && apt install -y cmake
           GOPATH=$(go env GOPATH) make
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa
         with:
           python-version: 3.10.6
-
       # - name: Setup OPA binaries
       #   uses: open-policy-agent/setup-opa@v2
       #   with:
@@ -41,7 +36,7 @@ jobs:
       #     mkdir -p release
       #     pip install requests pyyaml
       #     python ./scripts/bundle.py . -o ./release --removed-out release/removed.json --edit-readme
-      
+
       # - name: Test OPA bundle
       #   working-directory: testrunner
       #   env:
@@ -50,11 +45,9 @@ jobs:
       #   run: |
       #     go test -v -tags="static" . -run TestRegoBundles
       #     rm ${SKIPPED_RULES}
-
       - name: Create Metadata Release Files
         run: |
           python ./scripts/export.py
-      
       # The next step kept here for only backward competability.
       # Release files should have extensions!
       - name: Strip Metadata Files Extensions (to be removed)
@@ -64,7 +57,7 @@ jobs:
           find -type f -name '*.csv' | while read f; do mv "$f" "${f%.csv}"; done
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -72,19 +65,17 @@ jobs:
           release_name: Release v1.0.${{ github.run_number }}
           draft: false
           prerelease: false
-
       - name: Upload Release Assets
         id: upload-release-assets
-        uses: dwenegar/upload-release-assets@v1
+        uses: dwenegar/upload-release-assets@5bc3024cf83521df8ebfadf00ad0c4614fd59148
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           release_id: ${{ steps.create_release.outputs.id }}
           assets_path: release
-      
       - name: Update readme
-        uses: Andro999b/push@v1.3
+        uses: Andro999b/push@c77535fe7a94645f7ceca83e48e6cc977620710e
         with:
           branch: master
-          github_token: ${{ secrets.GITHUB_TOKEN }} 
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           message: Update README.MD

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -1,9 +1,8 @@
 name: pr-tests
-
 on:
   pull_request:
-    branches: [ dev, master ]
-    types: [ opened ]
+    branches: [dev, master]
+    types: [opened]
     paths-ignore:
       # Do not run the pipeline if only Markdown files changed
       - '**.yaml'
@@ -12,27 +11,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.19
-
-    - name: golangci-lint
-      continue-on-error: true
-      uses: golangci/golangci-lint-action@v3
-      with:
-        version: latest
-        args: --timeout 10m ./...
-        only-new-issues: true
-
-    - name: Test
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: go test -v -race ./...
-        
-    - name: Build
-      run: go build -v github.com/kubescape/regolibrary/gitregostore/...
-
-
+      - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6
+      - name: Set up Go
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492
+        with:
+          go-version: 1.19
+      - name: golangci-lint
+        continue-on-error: true
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5
+        with:
+          version: latest
+          args: --timeout 10m ./...
+          only-new-issues: true
+      - name: Test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go test -v -race ./...
+      - name: Build
+        run: go build -v github.com/kubescape/regolibrary/gitregostore/...

--- a/.github/workflows/rego-tests.yaml
+++ b/.github/workflows/rego-tests.yaml
@@ -1,25 +1,20 @@
 name: test regos
-
 on:
   pull_request:
-    branches: [ dev, master ]
-    types: [ opened ]
-
+    branches: [dev, master]
+    types: [opened]
 jobs:
   once:
     name: Build, Test Regos
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v1
-
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with: 
-        go-version: 1.19
-
-    - name: Test Regoes
-      working-directory: testrunner
-      run: |
-        apt update && apt install -y cmake
-        GOPATH=$(go env GOPATH) make
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
+      - name: Set up Go
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492
+        with:
+          go-version: 1.19
+      - name: Test Regoes
+        working-directory: testrunner
+        run: |-
+          apt update && apt install -y cmake
+          GOPATH=$(go env GOPATH) make

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -1,29 +1,24 @@
 name: Updating documentation
-
 on:
   push:
-    branches: [ master ]
-
+    branches: [master]
 jobs:
   once:
     name: Upload to documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6
         name: checkout repo content
-
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa
         with:
-          python-version: 3.8 
-
+          python-version: 3.8
       - name: install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install requests
-        
-      - name: execute upload script 
+      - name: execute upload script
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}
-        run: |
+        run: |-
           python ./scripts/upload-readme.py

--- a/MITRE.md
+++ b/MITRE.md
@@ -8,14 +8,14 @@
 
 | Initial Access | Execution | Persistence | Privilege Escalation | Defense Evasion | Credential Access| Discovery | Lateral Movement | Collection | Impact |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | 
-|Using Cloud credentials|[Exec into container](/controls/execintocontainer.json)|[Backdoor container](/controls/backdoorcontainer.json)|[Privileged container](/controls/privilegedcontainer.json)|[Clear container logs](/controls/clearcontainerlogs.json)|[List k8s secrets](/controls/ListKubernetessecrets.json)|[Access the K8S API server](/controls/accessthek8sAPIserver.json)|Access cloud resources|[Image from private registry](/controls/imagefromPrivateRegistry.json)|[Data Destruction](/controls/datadestruction.json) ||
-|[Compromised Image in registry](/controls/compromisedimagesinregistry.json)| [bash/cmd inside container](/controls/bash-cmdinsidecontainer.json)|[Writable hostPath mount](/controls/writablehostPathmount.json)|[Cluster-admin binding](/controls/cluster-adminbinding.json)|[Delete K8S events](/controls/deleteKubernetesevents.json)|[Mount service principal](/controls/mountserviceprincipal.json)|[Access Kubelet API](/controls/accesskubeletAPI.json)|[Container service account](/controls/accesscontainerserviceaccount.json)||[Resources Hijacking](/controls/resourcehijacking.json)||
-|kubeconfig file|[New container](/controls/newcontainer.json)|[kubernetes CronJob](/controls/kubernetescronJob.json)|[hostPath mount](/controls/hostPathmount.json)|[Pod/Container name similarity](/controls/namesimilarity.json)|[Access container service account](/controls/accesscontainerserviceaccount.json)|[Network mapping](/controls/networkmapping.json)|[Cluster internal networking](/controls/clusterInternalnetworking.json)||Denial of service||
-|[Application vulnerability](/controls/vulnerableapplication.json)|[Application Exploit (RCE)](/controls/applicationexploitRCE.json)|[Malicious admission controller](/controls/maliciousadmissioncontroller-mutating.json)|Access cloud resources| Connect from Proxy server| [Application credentials in configuration files](/controls/Applicationscredentialsinconfigurationfiles.json)|[Access kubernetes dashboard](/controls/accessk8sdashboard.json)|[Application credentials in configuration](/controls/Applicationscredentialsinconfigurationfiles.json)|||||
-|Exposed Dashboard|[SSH server running insider container](/controls/SSHserverrunninginsidecontainer.json)||||Access managed identity credentials|[instance Metadata API](/controls/instancemetadataAPI..json)|[Writable volume mounts on the host](/controls/writablehostPathmount.json)||||
-|[Exposed sensitive interface](/controls/exposedsensitiveinterfaces.json)|[Sidecar injection](/controls/sidecarinjection.json)||||[Malicious admission controller](/controls/maliciousadmissioncontroller-validating.json)||[Access kubernetes dashboard](/controls/accessk8sdashboard.json)||||
-||||||||[access tiller endpoint](/controls/accesstillerendpoint.json)|||||
-||||||||[CoreDNS poisoning](/controls/coreDNSpoisoning.json)|||||
+|Using Cloud credentials|Exec into container|Backdoor container|Privileged container|Clear container logs|List k8s secrets|Access the K8S API server|Access cloud resources|Image from private registry|Data Destruction||
+|Compromised Image in registry| bash/cmd inside container|Writable hostPath mount|Cluster-admin binding|Delete K8S events|Mount service principal|Access Kubelet API|Container service account||Resources Hijacking||
+|kubeconfig file|New container|kubernetes CronJob|hostPath mount|Pod/Container name similarity|Access container service account|Network mapping|Cluster internal networking||Denial of service||
+|Application vulnerability|Application Exploit (RCE)|Malicious admission controller|Access cloud resources| Connect from Proxy server|Application credentials in configuration files|Access kubernetes dashboard|Application credentials in configuration|||||
+|Exposed Dashboard|SSH server running insider container||||Access managed identity credentials|instance Metadata API|Writable volume mounts on the host||||
+|Exposed sensitive interface|Sidecar injection||||Malicious admission controller||Access kubernetes dashboard||||
+||||||||access tiller endpoint|||||
+||||||||CoreDNS poisoning|||||
 ||||||||ARP and IP spoofing|||||
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+<!-- markdown-link-check-disable -->
 [![Version](https://img.shields.io/github/v/release/kubescape/regolibrary)](releases)
 [![release-date](https://img.shields.io/github/release-date/kubescape/regolibrary)](releases)
+<!-- markdown-link-check-enable-->
 [![GitHub](https://img.shields.io/github/license/kubescape/kubescape)](https://github.com/kubescape/kubescape/blob/master/LICENSE)
 
 # Kubescape Regolibrary
@@ -165,13 +167,13 @@ Example of rule.metadata.json:
     See structure of a [rule response](https://github.com/kubescape/opa-utils/blob/master/reporthandling/datastructuresv1.go#L23)
 
 
-4. Add a test for the new rule (and run it!). Learn how to add a test [here](/rules-tests/README.md) and how to run it [here](/testrunner/README.md)
+4. Add a test for the new rule (and run it!). Learn how to add a test [here](testrunner/README.md#adding-new-rules) and how to run it [here](testrunner/README.md).
 
 5. Add `filter.rego` if needed - If it exists, the filter is run by Kubescape to calculate ‘all resources’ = the number of potential resources to fail. It affects the risk score. This is needed in cases where a rule asks for resources that wil not potentially fail. Example: if a rule asks for pods and service accounts to see if they are connected but only fails the pods, we would create a filter rego that returns only pods.
 
 
 ## OPA bundles
-The Kubescape regolibrary is [available](../../releases/latest) as an [OPA bundle](https://www.openpolicyagent.org/docs/latest/management-bundles), for both targets, WASM and Rego. 
+The Kubescape regolibrary is [available](https://github.com/kubescape/regolibrary/releases/latest) as an [OPA bundle](https://www.openpolicyagent.org/docs/latest/management-bundles), for both targets, WASM and Rego. 
 
 ### Using the bundles
 > Endpoint names are normalized to be used as a Rego package name. Here are some examples:

--- a/testrunner/README.md
+++ b/testrunner/README.md
@@ -1,13 +1,17 @@
 # Test-Runner for Rego Rules
+
 This package tests the OPA Rego rules.
 
 # Running the tests
-First you need to [setup the environment](#environment-setup). Then run
+
+You can easily test your custom rules by running this command:
 
 ```
 go test -v -tags=static rego_test.go -run TestAllRules
 ```
-Or
+
+or simply:
+
 ```
 make test
 ```


### PR DESCRIPTION
Here are some fixes for broken links I found during a documentation review.
Additionally, I added a github [action](https://github.com/marketplace/actions/markdown-link-check) to check for broken links, in order to avoid the same issue in the future.
In the end, there's also a little security improvement in the **ci/cd**, where all the workflows have been pinned to a specific version. For more details, please take a look to this project: https://github.com/sethvargo/ratchet