### PR TITLE
CI(workflows): Use submodule workflows

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -99,6 +99,7 @@ jobs:
 
   # test kubescape with regolibrary artifacts 
   ks-and-rego-test:
+    needs: [build-and-rego-test]
     steps:
     - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
       name: checkout repo content
@@ -107,7 +108,6 @@ jobs:
         token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
     - uses: ./workflows/.github/workflows/kubescape-cli-e2e-tests.yaml
-      needs: [build-and-rego-test]
       with:
         DOWNLOAD_ARTIFACT_KEY_NAME: ${{ needs.build-and-rego-test.outputs.REGO_ARTIFACT_KEY_NAME }}
         BINARY_TESTS: '[  "scan_nsa", 

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -29,14 +29,22 @@ jobs:
 
   # main job of testing and building the env. 
   test_pr_checks:
+    name: Test PR checks
+    runs-on: ubuntu-latest
     needs: [markdown-link-check]
     permissions:
       pull-requests: write
-    uses: kubescape/workflows/.github/workflows/go-basic-tests.yaml@main
-    with:
-      GO_VERSION: 1.19
-      BUILD_PATH: github.com/kubescape/regolibrary/gitregostore/...
-    secrets: inherit
+    steps:
+    - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
+      name: checkout repo content
+      with:
+        submodules: recursive
+        token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+    - uses: ./workflows/.github/workflows/go-basic-tests.yaml
+      with:
+        GO_VERSION: 1.19
+        BUILD_PATH: github.com/kubescape/regolibrary/gitregostore/...
+
 
   build-and-rego-test:
     name: Build and test rego artifacts
@@ -102,7 +110,6 @@ jobs:
     name: test rego artifatcs with kubescape
     runs-on: ubuntu-latest
     needs: [build-and-rego-test]
-    # secrets: inherit
     steps:
     - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
       name: checkout repo content

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -102,7 +102,7 @@ jobs:
     name: test rego artifatcs with kubescape
     runs-on: ubuntu-latest
     needs: [build-and-rego-test]
-    secrets: inherit
+    # secrets: inherit
     steps:
     - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
       name: checkout repo content

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -49,6 +49,7 @@ jobs:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
         name: checkout repo content
         with:
+          submodules: recursive
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
         
       # Test using Golang OPA hot rule compilation
@@ -98,7 +99,7 @@ jobs:
 
   # test kubescape with regolibrary artifacts 
   ks-and-rego-test:
-    uses: kubescape/workflows/.github/workflows/kubescape-cli-e2e-tests.yaml@main
+    uses: ./workflows/.github/workflows/kubescape-cli-e2e-tests.yaml
     needs: [build-and-rego-test]
     with:
       DOWNLOAD_ARTIFACT_KEY_NAME: ${{ needs.build-and-rego-test.outputs.REGO_ARTIFACT_KEY_NAME }}

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -29,21 +29,14 @@ jobs:
 
   # main job of testing and building the env. 
   test_pr_checks:
-    name: Test PR checks
-    runs-on: ubuntu-latest
     needs: [markdown-link-check]
     permissions:
       pull-requests: write
-    steps:
-    - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
-      name: checkout repo content
-      with:
-        submodules: recursive
-        token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-    - uses: ./workflows/.github/workflows/go-basic-tests.yaml
-      with:
-        GO_VERSION: 1.19
-        BUILD_PATH: github.com/kubescape/regolibrary/gitregostore/...
+    uses: kubescape/workflows/.github/workflows/go-basic-tests.yaml@main
+    with:
+      GO_VERSION: 1.19
+      BUILD_PATH: github.com/kubescape/regolibrary/gitregostore/...
+    secrets: inherit
 
 
   build-and-rego-test:

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -99,6 +99,8 @@ jobs:
 
   # test kubescape with regolibrary artifacts 
   ks-and-rego-test:
+    name: test rego artifatcs with kubescape
+    runs-on: ubuntu-latest
     needs: [build-and-rego-test]
     secrets: inherit
     steps:

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -99,22 +99,29 @@ jobs:
 
   # test kubescape with regolibrary artifacts 
   ks-and-rego-test:
-    uses: ./workflows/.github/workflows/kubescape-cli-e2e-tests.yaml
-    needs: [build-and-rego-test]
-    with:
-      DOWNLOAD_ARTIFACT_KEY_NAME: ${{ needs.build-and-rego-test.outputs.REGO_ARTIFACT_KEY_NAME }}
-      BINARY_TESTS: '[  "scan_nsa", 
-                        "scan_mitre", 
-                        "scan_with_exceptions", 
-                        "scan_repository", 
-                        "scan_local_file", 
-                        "scan_local_glob_files", 
-                        "scan_nsa_and_submit_to_backend", 
-                        "scan_mitre_and_submit_to_backend", 
-                        "scan_local_repository_and_submit_to_backend", 
-                        "scan_repository_from_url_and_submit_to_backend", 
-                        "host_scanner",
-                        "scan_local_list_of_files"
-                      ]'
-      DOWNLOAD_ARTIFACT_PATH: ${{ needs.build-and-rego-test.outputs.REGO_ARTIFACT_PATH }}
-    secrets: inherit
+    steps:
+    - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
+      name: checkout repo content
+      with:
+        submodules: recursive
+        token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
+    - uses: ./workflows/.github/workflows/kubescape-cli-e2e-tests.yaml
+      needs: [build-and-rego-test]
+      with:
+        DOWNLOAD_ARTIFACT_KEY_NAME: ${{ needs.build-and-rego-test.outputs.REGO_ARTIFACT_KEY_NAME }}
+        BINARY_TESTS: '[  "scan_nsa", 
+                          "scan_mitre", 
+                          "scan_with_exceptions", 
+                          "scan_repository", 
+                          "scan_local_file", 
+                          "scan_local_glob_files", 
+                          "scan_nsa_and_submit_to_backend", 
+                          "scan_mitre_and_submit_to_backend", 
+                          "scan_local_repository_and_submit_to_backend", 
+                          "scan_repository_from_url_and_submit_to_backend", 
+                          "host_scanner",
+                          "scan_local_list_of_files"
+                        ]'
+        DOWNLOAD_ARTIFACT_PATH: ${{ needs.build-and-rego-test.outputs.REGO_ARTIFACT_PATH }}
+      secrets: inherit

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -100,6 +100,7 @@ jobs:
   # test kubescape with regolibrary artifacts 
   ks-and-rego-test:
     needs: [build-and-rego-test]
+    secrets: inherit
     steps:
     - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
       name: checkout repo content
@@ -124,4 +125,3 @@ jobs:
                           "scan_local_list_of_files"
                         ]'
         DOWNLOAD_ARTIFACT_PATH: ${{ needs.build-and-rego-test.outputs.REGO_ARTIFACT_PATH }}
-      secrets: inherit

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "testrunner/git2go"]
 	path = testrunner/git2go
 	url = https://github.com/libgit2/git2go.git
+[submodule "workflows"]
+	path = workflows
+	url = https://github.com/kubescape/workflows.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "workflows"]
 	path = workflows
 	url = https://github.com/kubescape/workflows.git
-	branch = master
+	branch = main

--- a/controls/C-0001-forbiddencontainerregistries.json
+++ b/controls/C-0001-forbiddencontainerregistries.json
@@ -29,4 +29,5 @@
     "controlID": "C-0001",
     "baseScore": 7.0,
     "example": "@controls/examples/c001.yaml"
+    
 }


### PR DESCRIPTION
## Overview
We want the forked repositories to simulate as much as possible the workflows running in the Kubescape organization.
We noticed that the secrets are not passed to the workflows_call when the workflow is in the Kubescape org and the workflow caller is from a different org.

For this reason, I added the workflows as a submodule, so now the workflow will checkout and run locally all of the desired tests.

## Additional Information
[Here](https://github.com/dwertent/regolibrary/actions/runs/4845101203) is an example.

It is important to mention that this is not the final workaround, we will need to find a better solution for our issue.
The main reason is, this workaround will solve only if the workflow is not calling other workflows from the `workflows` repository. But when others are called, this will not work because the path is not `./.github/workflows/<file>`, the path is `./workflows/.github/workflows/<file>`.
[Here](https://github.com/dwertent/regolibrary/commit/09f855bc578f2f3d4fb2ed103996cb381d51ef5d) is a PR demonstrating when it [does not work](https://github.com/dwertent/regolibrary/actions/runs/4845067224/jobs/8633745998).

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
