### PR TITLE
WIP: fix: modify regex to check tag with only chars

### DIFF
--- a/rules/image-pull-policy-is-not-set-to-always/raw.rego
+++ b/rules/image-pull-policy-is-not-set-to-always/raw.rego
@@ -4,56 +4,56 @@ package armo_builtins
 deny[msga] {
     pod := input[_]
     pod.kind == "Pod"
-	container := pod.spec.containers[i]
+    container := pod.spec.containers[i]
     is_bad_container(container)
-	paths = [sprintf("spec.containers[%v].image", [format_int(i, 10)]), sprintf("spec.containers[%v].imagePullPolicy", [format_int(i, 10)])]
-	msga := {
-		"alertMessage": sprintf("container: %v in pod: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, pod.metadata.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 2,
-		"failedPaths": paths,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
-	}
+    paths = [sprintf("spec.containers[%v].image", [format_int(i, 10)]), sprintf("spec.containers[%v].imagePullPolicy", [format_int(i, 10)])]
+    msga := {
+        "alertMessage": sprintf("container: %v in pod: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, pod.metadata.name]),
+        "packagename": "armo_builtins",
+        "alertScore": 2,
+        "failedPaths": paths,
+        "fixPaths":[],
+        "alertObject": {
+            "k8sApiObjects": [pod]
+        }
+    }
 }
 
 deny[msga] {
     wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-	spec_template_spec_patterns[wl.kind]
-	container := wl.spec.template.spec.containers[i]
-	paths = [sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)]), sprintf("spec.template.spec.containers[%v].imagePullPolicy", [format_int(i, 10)])]
+    spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+    spec_template_spec_patterns[wl.kind]
+    container := wl.spec.template.spec.containers[i]
+    paths = [sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)]), sprintf("spec.template.spec.containers[%v].imagePullPolicy", [format_int(i, 10)])]
     is_bad_container(container)
-	msga := {
-		"alertMessage": sprintf("container: %v in %v: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, wl.kind, wl.metadata.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 2,
-		"failedPaths": paths,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
-	}
+    msga := {
+        "alertMessage": sprintf("container: %v in %v: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, wl.kind, wl.metadata.name]),
+        "packagename": "armo_builtins",
+        "alertScore": 2,
+        "failedPaths": paths,
+        "fixPaths":[],
+        "alertObject": {
+            "k8sApiObjects": [wl]
+        }
+    }
 }
 
 deny[msga] {
     wl := input[_]
-	wl.kind == "CronJob"
-	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
-	paths = [sprintf("spec.jobTemplate.spec.template.spec.containers[%v].image", [format_int(i, 10)]), sprintf("spec.jobTemplate.spec.template.spec.containers[%v].imagePullPolicy", [format_int(i, 10)])]
+    wl.kind == "CronJob"
+    container := wl.spec.jobTemplate.spec.template.spec.containers[i]
+    paths = [sprintf("spec.jobTemplate.spec.template.spec.containers[%v].image", [format_int(i, 10)]), sprintf("spec.jobTemplate.spec.template.spec.containers[%v].imagePullPolicy", [format_int(i, 10)])]
     is_bad_container(container)
-	msga := {
-		"alertMessage": sprintf("container: %v in cronjob: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, wl.metadata.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 2,
-		"failedPaths": paths,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
-	}
+    msga := {
+        "alertMessage": sprintf("container: %v in cronjob: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, wl.metadata.name]),
+        "packagename": "armo_builtins",
+        "alertScore": 2,
+        "failedPaths": paths,
+        "fixPaths":[],
+        "alertObject": {
+            "k8sApiObjects": [wl]
+        }
+    }
 }
 
 # image tag is latest
@@ -101,6 +101,7 @@ is_tag_image_only_letters(image) {
     version := regex.find_all_string_submatch_n(reg, image, -1)
     v := version[_]
     img := v[_]
-	reg1 := "^:[a-zA-Z]{1,127}$"
-	re_match(reg1, img)
+    print(img)
+    reg1 := "^:[a-zA-Z]$"
+    re_match(reg1, img)
 }


### PR DESCRIPTION
## Overview
The previous regex seemed not working properly. We are now able to check image tags composed only by characters.

## Related issues/PRs:
Fix #351 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes