### PR TITLE
fix(exceptions): Exclude host scanner in kubescape namespace

### DIFF
--- a/exceptions/kubescape.json
+++ b/exceptions/kubescape.json
@@ -306,8 +306,6 @@
             
         ]
     },
-
-
     {
         "name": "exclude-kubescape-host-scanner-resources",
         "policyType": "postureExceptionPolicy",
@@ -324,6 +322,14 @@
                     "kind": "DaemonSet",
                     "name": "host-scanner",
                     "namespace": "kubescape-host-scanner"
+                }
+            },
+            {
+                "designatorType": "Attributes",
+                "attributes": {
+                    "kind": "DaemonSet",
+                    "name": "kubescape",
+                    "namespace": "host-scanner"
                 }
             }
         ],


### PR DESCRIPTION
## Overview
The host scanner will run in the `kubescape` namespace and not in the `kubescape-host-scanner` namespace, therefor, we should exclude the Deamonset running in the `kubescape` namespace.

I left the current exception policy for backward compatibility.
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
