### PR TITLE
Add Regal linter config, and fix reported issues

### DIFF
--- a/rules/.regal/config.yaml
+++ b/rules/.regal/config.yaml
@@ -1,0 +1,21 @@
+rules:
+  idiomatic:
+    custom-has-key-construct:
+      # This should be enabled, but the version of OPA used here is
+      # too old to recognize the object.keys built-in function
+      level: ignore
+  style:
+    avoid-get-and-list-prefix:
+      level: ignore
+    external-reference:
+      level: ignore
+    line-length:
+      level: ignore
+    opa-fmt:
+      level: ignore
+    prefer-snake-case:
+      level: ignore
+    todo-comment:
+      level: ignore
+    use-assignment-operator:
+      level: ignore

--- a/rules/Ensure-that-the-kubeconfig-file-permissions-are-set-to-644-or-more-restrictive/raw.rego
+++ b/rules/Ensure-that-the-kubeconfig-file-permissions-are-set-to-644-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -11,7 +12,7 @@ deny[msg] {
 	file_obj_path := ["data", "kubeConfigFile"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test. num. configured from Octal (644) to Decimal num.    
+	# Actual permissions test. num. configured from Octal (644) to Decimal num.
 	allowed_perms := 420
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 
@@ -24,7 +25,7 @@ deny[msg] {
 		"metadata"
 	])
 
-	alert := sprintf("The permissions of %s are too permissive. maximum allowed: %o. actual: %o", 
+	alert := sprintf("The permissions of %s are too permissive. maximum allowed: %o. actual: %o",
 	[file.path, allowed_perms, file.permissions])
 
 	msg := {

--- a/rules/audit-policy-content/raw.rego
+++ b/rules/audit-policy-content/raw.rego
@@ -105,7 +105,7 @@ are_audit_file_rules_valid(rules) if {
 	# Policy file must contain every resource
 	some resource, config in seeked_resources_with_audit_level
 
-	# Every seeked resource mu have valid audit levels 
+	# Every seeked resource mu have valid audit levels
 	not test_all_rules_against_one_seeked_resource(resource, config, rules)
 }
 
@@ -117,7 +117,7 @@ test_all_rules_against_one_seeked_resource(seeked_resource, value_of_seeked_reso
 	# Move forward only if there are some
 	rules_count > 0
 
-	# Check if rules concerning seeked resource have valid audit levels 
+	# Check if rules concerning seeked resource have valid audit levels
 	valid_rules := [rule | rule := rules_with_seeked_resource[_]; validate_rule_audit_level(rule, value_of_seeked_resource)]
 	valid_rules_count := count(valid_rules)
 
@@ -129,7 +129,7 @@ test_all_rules_against_one_seeked_resource(seeked_resource, value_of_seeked_reso
 }
 
 is_rule_concering_seeked_resource(rule, seeked_resource) if {
-	rule.resources[_].resources[_] == seeked_resource
+	seeked_resource in rule.resources[_].resources
 }
 
 # Sample single rule:

--- a/rules/container-image-repository/raw.rego
+++ b/rules/container-image-repository/raw.rego
@@ -1,7 +1,6 @@
 package armo_builtins
-import data
+
 import future.keywords.if
-# import data.kubernetes.api.client as client
 
 untrusted_image_repo[msga] {
 	pod := input[_]
@@ -75,7 +74,7 @@ image_in_allowed_list(image){
 }
 
 
-# docker_host_wrapper - wrap an image without a host with a docker hub host 'docker.io'. 
+# docker_host_wrapper - wrap an image without a host with a docker hub host 'docker.io'.
 # An image that doesn't contain '/' is assumed to not having a host and therefore associated with docker hub.
 docker_host_wrapper(image) := result if {
 	not contains(image, "/")

--- a/rules/deny-RCE-vuln-image-pods/raw.rego
+++ b/rules/deny-RCE-vuln-image-pods/raw.rego
@@ -1,6 +1,7 @@
 package armo_builtins
-import data.cautils as cautils
-    
+
+import data.cautils
+
 # ========= RCE : no service score 5 ================
 deny[msga] {
 	pod := input[_]
@@ -164,7 +165,7 @@ deny[msga] {
 				"vulnerabilities" : [vulnerabilities]
 			}
 		},
-    
+
     }
 }
 # cronjobs

--- a/rules/deny-vuln-image-pods/raw.rego
+++ b/rules/deny-vuln-image-pods/raw.rego
@@ -1,6 +1,7 @@
 package armo_builtins
-import data.cautils as cautils
-    
+
+import data.cautils
+
 deny[msga] {
 	pod := input[_]
 	pod.kind == "Pod"
@@ -97,7 +98,7 @@ deny[msga] {
 	np_or_lb := {"NodePort", "LoadBalancer"}
 	np_or_lb[service.spec.type]
 	cautils.is_subobject(service.spec.selector,labels)
-	
+
 
     msga := {
         "alertMessage": sprintf("%v: %v/%v has vulnerabilities", [wl.kind, wl.metadata.namespace, wl.metadata.name]),

--- a/rules/ensure-endpointpublicaccess-is-disabled-on-private-nodes-eks/raw.rego
+++ b/rules/ensure-endpointpublicaccess-is-disabled-on-private-nodes-eks/raw.rego
@@ -1,19 +1,20 @@
 package armo_builtins
 
+import future.keywords.in
 
 # Check if EndpointPublicAccess in enabled on a private node for EKS. A private node is a node with no public ips access.
 deny[msga] {
 	cluster_config := input[_]
 	cluster_config.apiVersion == "eks.amazonaws.com/v1"
 	cluster_config.kind == "ClusterDescribe"
-    cluster_config.metadata.provider == "eks"	
-	config = cluster_config.data
+    cluster_config.metadata.provider == "eks"
+	config := cluster_config.data
 
 	config.Cluster.ResourcesVpcConfig.EndpointPublicAccess == true
 
 	# filter out private nodes
-	config.Cluster.ResourcesVpcConfig.PublicAccessCidrs[_] == "0.0.0.0/0"
-	
+	"0.0.0.0/0" in config.Cluster.ResourcesVpcConfig.PublicAccessCidrs
+
 	msga := {
 		"alertMessage": "endpointPublicAccess is enabled on a private node",
 		"alertScore": 3,

--- a/rules/ensure-external-secrets-storage-is-in-use/raw.rego
+++ b/rules/ensure-external-secrets-storage-is-in-use/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
-import data.kubernetes.api.client as client
-import data
+
 import future.keywords.in
 
+import data.kubernetes.api.client
 
 # deny workloads that doesn't support external service provider (secretProviderClass)
 # reference - https://secrets-store-csi-driver.sigs.k8s.io/concepts.html

--- a/rules/ensure-https-loadbalancers-encrypted-with-tls-aws/filter.rego
+++ b/rules/ensure-https-loadbalancers-encrypted-with-tls-aws/filter.rego
@@ -1,6 +1,6 @@
 package armo_builtins
-import data.kubernetes.api.client as client
-import data
+
+import data.kubernetes.api.client
 
 deny[msga] {
 	obj := input[_]
@@ -8,4 +8,3 @@ deny[msga] {
 	obj.spec.type == "LoadBalancer"
 	msga := {"alertObject": {"k8sApiObjects": [obj]}}
 }
-

--- a/rules/ensure-https-loadbalancers-encrypted-with-tls-aws/raw.rego
+++ b/rules/ensure-https-loadbalancers-encrypted-with-tls-aws/raw.rego
@@ -1,6 +1,6 @@
 package armo_builtins
-import data.kubernetes.api.client as client
-import data
+
+import data.kubernetes.api.client
 
 # deny LoadBalancer services that are configured for ssl connection (port: 443), but don't have TLS certificate set.
 deny[msga] {
@@ -12,7 +12,7 @@ deny[msga] {
 	# filterring LoadBalancers
 	wl := 	input[_]
 	wl.kind == wl_kind
-	wl.spec.type == wl_type	
+	wl.spec.type == wl_type
 
 	#  filterring loadbalancers with port 443.
 	wl.spec.ports[_].port == 443

--- a/rules/ensure-network-policy-is-enabled-eks/raw.rego
+++ b/rules/ensure-network-policy-is-enabled-eks/raw.rego
@@ -1,5 +1,6 @@
 package armo_builtins
 
+import future.keywords.in
 
 # EKS supports Calico and Cilium add-ons, both supports Network Policy.
 # Deny if at least on of them is not in the list of CNINames.
@@ -10,13 +11,12 @@ deny[msg] {
 
     is_CNIInfos(obj)
 
-	not contains(obj.data.CNINames, "Calico")
-	not contains(obj.data.CNINames, "Cilium")
-
+	not "Calico" in obj.data.CNINames
+	not "Cilium" in obj.data.CNINames
 
 	# filter out irrelevant host-sensor data
     obj_filtered := json.filter(obj, ["apiVersion", "kind", "metadata", "data/CNINames"])
-    
+
     msg := {
 		"alertMessage": "CNI doesn't support Network Policies.",
 		"alertScore": 2,
@@ -32,8 +32,4 @@ deny[msg] {
 is_CNIInfos(obj) {
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 	obj.kind == "CNIInfo"
-}
-
-contains(ls, elem) {
-  ls[_] = elem
 }

--- a/rules/ensure-that-the-API-server-pod-specification-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-API-server-pod-specification-file-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-API-server-pod-specification-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-API-server-pod-specification-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,17 +1,18 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
 	obj = input[_]
 	is_control_plane_info(obj)
-	
+
 	file_obj_path := ["data", "APIServerInfo", "specsFile"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 
@@ -22,7 +23,7 @@ deny[msg] {
 		"apiVersion",
 		"kind",
 		"metadata",
-	]) 
+	])
 
 	alert := sprintf("the permissions of %s are too permissive. maximum allowed: %o. actual: %o", [file.path, allowed_perms, file.permissions])
 	msg := {

--- a/rules/ensure-that-the-Container-Network-Interface-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-Container-Network-Interface-file-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-Container-Network-Interface-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-Container-Network-Interface-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -12,7 +13,7 @@ deny[msg] {
 	files := object.get(obj, file_obj_path, false)
 	file := files[file_index]
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/ensure-that-the-Kubernetes-PKI-certificate-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-Kubernetes-PKI-certificate-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -13,7 +14,7 @@ deny[msg] {
 	file := files[file_index]
 	endswith(file.path, ".crt")
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/ensure-that-the-Kubernetes-PKI-directory-and-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-Kubernetes-PKI-directory-and-file-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-Kubernetes-PKI-key-file-permissions-are-set-to-600/raw.rego
+++ b/rules/ensure-that-the-Kubernetes-PKI-key-file-permissions-are-set-to-600/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -13,7 +14,7 @@ deny[msg] {
 	file := files[file_index]
 	endswith(file.path, ".key")
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/ensure-that-the-admin.conf-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-admin.conf-file-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-admin.conf-file-permissions-are-set-to-600/raw.rego
+++ b/rules/ensure-that-the-admin.conf-file-permissions-are-set-to-600/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -11,7 +12,7 @@ deny[msg] {
 	file_obj_path := ["data", "adminConfigFile"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/ensure-that-the-api-server-encryption-provider-config-argument-is-set-as-appropriate/raw.rego
+++ b/rules/ensure-that-the-api-server-encryption-provider-config-argument-is-set-as-appropriate/raw.rego
@@ -2,7 +2,7 @@ package armo_builtins
 
 import future.keywords.in
 
-# Encryption config is not set at all 
+# Encryption config is not set at all
 deny[msg] {
 	obj = input[_]
 	is_api_server(obj)
@@ -32,7 +32,7 @@ deny[msg] {
 
 	# Check if the config conver secrets
 	count({true | "secrets" in config_file_content.resources[_].resources}) == 0
-	
+
 	# Add name to the failed object so that
 	# it fit the format of the alert object
 	failed_obj := json.patch(config_file_content, [{
@@ -65,6 +65,6 @@ is_control_plane_info(obj) {
 	obj.kind == "ControlPlaneInfo"
 }
 
-decode_config_file(content) := data {
-	data := yaml.unmarshal(content)
+decode_config_file(content) := parsed {
+	parsed := yaml.unmarshal(content)
 } else := json.unmarshal(content)

--- a/rules/ensure-that-the-api-server-encryption-providers-are-appropriately-configured/raw.rego
+++ b/rules/ensure-that-the-api-server-encryption-providers-are-appropriately-configured/raw.rego
@@ -46,8 +46,8 @@ is_control_plane_info(obj) {
 	obj.kind == "ControlPlaneInfo"
 }
 
-decode_config_file(content) := data {
-	data := yaml.unmarshal(content)
+decode_config_file(content) := parsed {
+	parsed := yaml.unmarshal(content)
 } else := json.unmarshal(content)
 
 has_key(x, k) {

--- a/rules/ensure-that-the-api-server-service-account-lookup-argument-is-set-to-true/raw.rego
+++ b/rules/ensure-that-the-api-server-service-account-lookup-argument-is-set-to-true/raw.rego
@@ -26,8 +26,11 @@ is_api_server(obj) {
 }
 
 # Assume flag set only once
-invalid_flag(cmd) = result {
-	result = get_result(cmd[i], i)
+invalid_flag(cmd) := invalid_flags[0] {
+	invalid_flags := [flag |
+		some i, c in cmd
+		flag := get_result(c, i)
+	]
 }
 
 get_result(cmd, i) = result {

--- a/rules/ensure-that-the-certificate-authorities-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-certificate-authorities-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -11,7 +12,7 @@ deny[msg] {
 	file_obj_path := ["data", "clientCAFile"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/ensure-that-the-client-certificate-authorities-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-client-certificate-authorities-file-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-cni-in-use-supports-network-policies/raw.rego
+++ b/rules/ensure-that-the-cni-in-use-supports-network-policies/raw.rego
@@ -1,5 +1,6 @@
 package armo_builtins
 
+import future.keywords.in
 
 # Deny CNIs that don't support Network Policies.
 
@@ -13,7 +14,7 @@ deny[msg] {
 
 	# filter out irrelevant host-sensor data
     obj_filtered := json.filter(obj, ["apiVersion", "kind", "metadata", "data/CNINames"])
-    
+
     msg := {
 		"alertMessage": "CNI doesn't support Network Policies.",
 		"alertScore": 2,
@@ -34,17 +35,12 @@ is_CNIInfo(obj) {
 
 # deny if Flannel is running without calico
 network_policy_not_supported(CNIs) {
-	contains(CNIs, "Flannel")
-	not contains(CNIs, "Calico")
+	"Flannel" in CNIs
+	not "Calico" in CNIs
 }
 
 # deny if aws is running without any other CNI
 network_policy_not_supported(CNIs) {
-	contains(CNIs, "aws")
+	"aws" in CNIs
 	count(CNIs) < 2
-}
-
-
-contains(ls, elem) {
-  ls[_] = elem
 }

--- a/rules/ensure-that-the-controller-manager-pod-specification-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-controller-manager-pod-specification-file-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-controller-manager-pod-specification-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-controller-manager-pod-specification-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -11,7 +12,7 @@ deny[msg] {
 	file_obj_path := ["data", "controllerManagerInfo", "specsFile"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 
@@ -22,7 +23,7 @@ deny[msg] {
 		"apiVersion",
 		"kind",
 		"metadata",
-	]) 
+	])
 
 	alert := sprintf("the permissions of %s are too permissive. maximum allowed: %o. actual: %o", [file.path, allowed_perms, file.permissions])
 	msg := {

--- a/rules/ensure-that-the-controller-manager.conf-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-controller-manager.conf-file-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-controller-manager.conf-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-controller-manager.conf-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -11,7 +12,7 @@ deny[msg] {
 	file_obj_path := ["data", "controllerManagerInfo", "configFile"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/ensure-that-the-etcd-data-directory-ownership-is-set-to-etcd-etcd/raw.rego
+++ b/rules/ensure-that-the-etcd-data-directory-ownership-is-set-to-etcd-etcd/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-etcd-data-directory-permissions-are-set-to-700-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-etcd-data-directory-permissions-are-set-to-700-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -11,7 +12,7 @@ deny[msg] {
 	file_obj_path := ["data", "etcdDataDir"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 448 # == 0o700
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/ensure-that-the-etcd-pod-specification-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-etcd-pod-specification-file-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-etcd-pod-specification-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-etcd-pod-specification-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -11,7 +12,7 @@ deny[msg] {
 	file_obj_path := ["data", "etcdConfigFile"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/ensure-that-the-kubeconfig-kubelet.conf-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-kubeconfig-kubelet.conf-file-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-kubeconfig-kubelet.conf-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-kubeconfig-kubelet.conf-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -11,7 +12,7 @@ deny[msg] {
 	file_obj_path := ["data", "kubeConfigFile"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/ensure-that-the-kubelet-configuration-file-has-permissions-set-to-644-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-kubelet-configuration-file-has-permissions-set-to-644-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -11,7 +12,7 @@ deny[msg] {
 	file_obj_path := ["data", "configFile"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 420 # == 0o644
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/ensure-that-the-kubelet-configuration-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-kubelet-configuration-file-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-kubelet-service-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-kubelet-service-file-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-kubelet-service-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-kubelet-service-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -12,7 +13,7 @@ deny[msg] {
 	files := object.get(obj, file_obj_path, false)
 	file := files[file_index]
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/ensure-that-the-scheduler-pod-specification-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-scheduler-pod-specification-file-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-scheduler-pod-specification-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-scheduler-pod-specification-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -11,7 +12,7 @@ deny[msg] {
 	file_obj_path := ["data", "schedulerInfo", "specsFile"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/ensure-that-the-scheduler.conf-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-scheduler.conf-file-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/ensure-that-the-scheduler.conf-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-scheduler.conf-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -11,7 +12,7 @@ deny[msg] {
 	file_obj_path := ["data", "schedulerInfo", "configFile"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/etcd-encryption-native/raw.rego
+++ b/rules/etcd-encryption-native/raw.rego
@@ -1,6 +1,6 @@
 package armo_builtins
 
-import data.cautils as cautils
+import data.cautils
 
 # Check if encryption in etcd is enabled for native k8s
 deny[msga] {

--- a/rules/excessive_amount_of_vulnerabilities_pods/raw.rego
+++ b/rules/excessive_amount_of_vulnerabilities_pods/raw.rego
@@ -1,5 +1,4 @@
 package armo_builtins
-import data
 
 deny[msga] {
   pods    := [ x | x = input[_]; x.kind == "Pod" ]
@@ -8,9 +7,9 @@ deny[msga] {
   pod     := pods[_]
   vuln    := vulns[_]
 
-  # vuln data is relevant 
-  count(vuln.data) > 0 
-  
+  # vuln data is relevant
+  count(vuln.data) > 0
+
   # get container image name
   container := pod.spec.containers[i]
 
@@ -57,7 +56,7 @@ check_num_vulnerabilities(vuln) {
 
 check_num_vulnerabilities(vuln) {
   exists := count([ x | x = vuln.data[_]; x.severity == "High" ])
-  
+
   str_max := data.postureControlInputs.max_high_vulnerabilities[_]
   exists > to_number(str_max)
 }

--- a/rules/exec-into-container/raw.rego
+++ b/rules/exec-into-container/raw.rego
@@ -1,9 +1,9 @@
-
 package armo_builtins
-import data.cautils as cautils
+
+import data.cautils
 
 # input: clusterrolebindings + rolebindings
-# apiversion: rbac.authorization.k8s.io/v1 
+# apiversion: rbac.authorization.k8s.io/v1
 # returns subjects that can exec into container
 
 deny[msga] {
@@ -18,7 +18,7 @@ deny[msga] {
 
 	rolebinding.roleRef.kind == "Role"
 	rolebinding.roleRef.name == role.metadata.name
-	
+
    	subject := rolebinding.subjects[i]
     path := sprintf("subjects[%v]", [format_int(i, 10)])
 
@@ -38,7 +38,7 @@ deny[msga] {
 
 
 # input: clusterrolebindings + rolebindings
-# apiversion: rbac.authorization.k8s.io/v1 
+# apiversion: rbac.authorization.k8s.io/v1
 # returns subjects that can exec into container
 
 deny[msga] {
@@ -53,7 +53,7 @@ deny[msga] {
 
 	rolebinding.roleRef.kind == "ClusterRole"
 	rolebinding.roleRef.name == role.metadata.name
-	
+
     subject := rolebinding.subjects[i]
     path := sprintf("subjects[%v]", [format_int(i, 10)])
 
@@ -72,7 +72,7 @@ deny[msga] {
 }
 
 # input: clusterrolebindings + rolebindings
-# apiversion: rbac.authorization.k8s.io/v1 
+# apiversion: rbac.authorization.k8s.io/v1
 # returns subjects that can exec into container
 
 deny[msga] {
@@ -87,7 +87,7 @@ deny[msga] {
 
 	rolebinding.roleRef.kind == "ClusterRole"
 	rolebinding.roleRef.name == role.metadata.name
-	
+
     subject := rolebinding.subjects[i]
     path := sprintf("subjects[%v]", [format_int(i, 10)])
 
@@ -114,7 +114,7 @@ can_exec_to_pod_verb(rule)  {
 
 can_exec_to_pod_resource(rule)  {
 	cautils.list_contains(rule.resources, "pods/exec")
-	
+
 }
 can_exec_to_pod_resource(rule)  {
 	cautils.list_contains(rule.resources, "pods/*")

--- a/rules/exposed-sensitive-interfaces-v1/filter.rego
+++ b/rules/exposed-sensitive-interfaces-v1/filter.rego
@@ -1,6 +1,6 @@
 package armo_builtins
-import data.kubernetes.api.client as client
-import data
+
+import data.kubernetes.api.client
 
 deny[msga] {
 	wl := input[_]

--- a/rules/exposed-sensitive-interfaces-v1/raw.rego
+++ b/rules/exposed-sensitive-interfaces-v1/raw.rego
@@ -1,6 +1,6 @@
 package armo_builtins
-import data.kubernetes.api.client as client
-import data
+
+import data.kubernetes.api.client
 
 # loadbalancer
 deny[msga] {
@@ -18,7 +18,7 @@ deny[msga] {
 	service.spec.type == "LoadBalancer"
 
 	result := wl_connectedto_service(wl, service)
-    
+
     # externalIP := service.spec.externalIPs[_]
 	externalIP := service.status.loadBalancer.ingress[0].ip
 
@@ -47,12 +47,12 @@ deny[msga] {
 deny[msga] {
 	wl := input[_]
 	wl.kind == "Pod"
-    
+
     # see default-config-inputs.json for list values
     wl_names := data.postureControlInputs.sensitiveInterfaces
 	wl_name := wl_names[_]
 	contains(wl.metadata.name, wl_name)
-    
+
 	service := 	input[_]
 	service.kind == "Service"
 	service.spec.type == "NodePort"
@@ -75,7 +75,7 @@ deny[msga] {
             "externalObjects": wlvector
 		}
 	}
-} 
+}
 
 # nodePort
 # get a workload connected to that service, get nodeIP (hostIP?)
@@ -84,12 +84,12 @@ deny[msga] {
 	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "CronJob"}
 	spec_template_spec_patterns[wl.kind]
-    
+
     # see default-config-inputs.json for list values
     wl_names := data.postureControlInputs.sensitiveInterfaces
 	wl_name := wl_names[_]
 	contains(wl.metadata.name, wl_name)
-    
+
 	service := 	input[_]
 	service.kind == "Service"
 	service.spec.type == "NodePort"

--- a/rules/exposed-sensitive-interfaces/raw.rego
+++ b/rules/exposed-sensitive-interfaces/raw.rego
@@ -1,6 +1,6 @@
 package armo_builtins
-import data.kubernetes.api.client as client
-import data
+
+import data.kubernetes.api.client
 
 # loadbalancer
 deny[msga] {
@@ -12,7 +12,7 @@ deny[msga] {
 	workload_types = {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "Pod", "CronJob"}
 	workload_types[wl.kind]
 	result := wl_connectedto_service(wl, service)
-    
+
     # see default-config-inputs.json for list values
     services_names := data.postureControlInputs.servicesNames
 	services_names[service.metadata.name]
@@ -39,11 +39,11 @@ deny[msga] {
 	service := 	input[_]
 	service.kind == "Service"
 	service.spec.type == "NodePort"
-    
+
     # see default-config-inputs.json for list values
     services_names := data.postureControlInputs.servicesNames
 	services_names[service.metadata.name]
-    
+
 	pod := input[_]
 	pod.kind == "Pod"
 
@@ -60,7 +60,7 @@ deny[msga] {
 			"k8sApiObjects": [pod, service]
 		}
 	}
-} 
+}
 
 # nodePort
 # get a workload connected to that service, get nodeIP (hostIP?)
@@ -69,11 +69,11 @@ deny[msga] {
 	service := 	input[_]
 	service.kind == "Service"
 	service.spec.type == "NodePort"
-    
+
     # see default-config-inputs.json for list values
     services_names := data.postureControlInputs.servicesNames
 	services_names[service.metadata.name]
-    
+
 	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "CronJob"}
 	spec_template_spec_patterns[wl.kind]

--- a/rules/external-secret-storage/raw.rego
+++ b/rules/external-secret-storage/raw.rego
@@ -42,8 +42,8 @@ is_control_plane_info(obj) {
 	obj.kind == "ControlPlaneInfo"
 }
 
-decode_config_file(content) := data {
-	data := yaml.unmarshal(content)
+decode_config_file(content) := parsed {
+	parsed := yaml.unmarshal(content)
 } else := json.unmarshal(content)
 
 has_recommended_provider(resource) {

--- a/rules/has-critical-vulnerability/filter.rego
+++ b/rules/has-critical-vulnerability/filter.rego
@@ -1,14 +1,15 @@
 package armo_builtins
-import data.cautils as cautils
-    
+
+import data.cautils
+
 deny[msga] {
- 
+
 	# get pod and imageVulnerabilities
 	pods := [pod | pod= input[_]; pod.kind == "Pod"]
     vulns := [vuln | vuln = input[_]; vuln.kind == "ImageVulnerabilities"]
     pod := pods[_]
     vuln := vulns[_]
-    
+
 	# get container image name
 	container := pod.spec.containers[i]
 
@@ -42,7 +43,7 @@ deny[msga] {
 
 #handles majority of workload resources
 deny[msga] {
- 
+
     # get pod and imageVulnerabilities
 	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
 
@@ -50,7 +51,7 @@ deny[msga] {
     vulns := [vuln | vuln = input[_]; vuln.kind == "ImageVulnerabilities"]
     wl := wls[_]
     vuln := vulns[_]
-    
+
 	# get container image name
 	container := wl.spec.template.spec.containers[i]
 
@@ -83,12 +84,12 @@ deny[msga] {
 
 # handles cronjob
 deny[msga] {
- 
+
 	wls := [wl | wl= input[_]; wl.kind == "CronJob"]
     vulns := [vuln | vuln = input[_]; vuln.kind == "ImageVulnerabilities"]
     wl := wls[_]
     vuln := vulns[_]
-    
+
 	# get container image name
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
 

--- a/rules/has-critical-vulnerability/raw.rego
+++ b/rules/has-critical-vulnerability/raw.rego
@@ -1,14 +1,15 @@
 package armo_builtins
-import data.cautils as cautils
-    
+
+import data.cautils
+
 deny[msga] {
- 
+
 	# get pod and imageVulnerabilities
 	pods := [pod | pod= input[_]; pod.kind == "Pod"]
     vulns := [vuln | vuln = input[_]; vuln.kind == "ImageVulnerabilities"]
     pod := pods[_]
     vuln := vulns[_]
-    
+
 	# get container image name
 	container := pod.spec.containers[i]
 
@@ -46,7 +47,7 @@ deny[msga] {
 
 #handles majority of workload resources
 deny[msga] {
- 
+
     # get pod and imageVulnerabilities
 	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
 
@@ -54,7 +55,7 @@ deny[msga] {
     vulns := [vuln | vuln = input[_]; vuln.kind == "ImageVulnerabilities"]
     wl := wls[_]
     vuln := vulns[_]
-    
+
 	# get container image name
 	container := wl.spec.template.spec.containers[i]
 
@@ -92,12 +93,12 @@ deny[msga] {
 
 # handles cronjob
 deny[msga] {
- 
+
 	wls := [wl | wl= input[_]; wl.kind == "CronJob"]
     vulns := [vuln | vuln = input[_]; vuln.kind == "ImageVulnerabilities"]
     wl := wls[_]
     vuln := vulns[_]
-    
+
 	# get container image name
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
 
@@ -131,7 +132,7 @@ deny[msga] {
 		}
     }
 }
- 
+
 
 has_crirtical_vulnerability(vuln){
 	count(vuln.data) > 0

--- a/rules/has-image-signature/raw.rego
+++ b/rules/has-image-signature/raw.rego
@@ -1,5 +1,4 @@
 package armo_builtins
-import data
 
 deny[msga] {
 
@@ -51,7 +50,7 @@ deny[msga] {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-	
+
     not cosign.has_signature(container.image)
 
 	failedPath := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].image", [format_int(i, 10)])

--- a/rules/if-proxy-kubeconfig-file-exists-ensure-ownership-is-set-to-root-root/raw.rego
+++ b/rules/if-proxy-kubeconfig-file-exists-ensure-ownership-is-set-to-root-root/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources

--- a/rules/if-proxy-kubeconfig-file-exists-ensure-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/if-proxy-kubeconfig-file-exists-ensure-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -11,7 +12,7 @@ deny[msg] {
 	file_obj_path := ["data", "kubeConfigFile"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/if-the-kubelet-config.yaml-configuration-file-is-being-used-validate-permissions-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/if-the-kubelet-config.yaml-configuration-file-is-being-used-validate-permissions-set-to-600-or-more-restrictive/raw.rego
@@ -1,7 +1,8 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 deny[msg] {
 	# Filter out irrelevent resources
@@ -11,7 +12,7 @@ deny[msg] {
 	file_obj_path := ["data", "configFile"]
 	file := object.get(obj, file_obj_path, false)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/insecure-capabilities/raw.rego
+++ b/rules/insecure-capabilities/raw.rego
@@ -1,6 +1,6 @@
 package armo_builtins
-import data
-import data.cautils as cautils
+
+import data.cautils
 
 deny[msga] {
     pod := input[_]

--- a/rules/insecure-port-flag/filter.rego
+++ b/rules/insecure-port-flag/filter.rego
@@ -1,5 +1,6 @@
 package armo_builtins
-import data.cautils as cautils
+
+import data.cautils
 
 # Fails if pod has insecure-port flag enabled
 deny[msga] {
@@ -8,7 +9,7 @@ deny[msga] {
 	contains(pod.metadata.name, "kube-apiserver")
     container := pod.spec.containers[_]
 	msga := {
-		"alertMessage": sprintf("The API server container: %v has insecure-port flag enabled", [ container.name]),
+		"alertMessage": sprintf("The API server container: %v has insecure-port flag enabled", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [],

--- a/rules/insecure-port-flag/raw.rego
+++ b/rules/insecure-port-flag/raw.rego
@@ -1,5 +1,6 @@
 package armo_builtins
-import data.cautils as cautils
+
+import data.cautils
 
 # Fails if pod has insecure-port flag enabled
 deny[msga] {
@@ -19,7 +20,7 @@ deny[msga] {
 		}
 	}
 }
-	
+
 is_insecure_port_flag(container, i) = path {
 	command := container.command[j]
 	contains(command, "--insecure-port=1")

--- a/rules/k8s-audit-logs-enabled-cloud/raw.rego
+++ b/rules/k8s-audit-logs-enabled-cloud/raw.rego
@@ -1,6 +1,7 @@
 package armo_builtins
 
 import future.keywords.every
+import future.keywords.in
 
 # =============================== GKE ===============================
 # Check if audit logs is enabled for GKE
@@ -76,5 +77,5 @@ all_auditlogs_enabled(logSetups, types) {
 auditlogs_enabled(logSetups, type) {
 	logSetup := logSetups[_]
 	logSetup.Enabled == true
-	logSetup.Types[_] == type
+	type in logSetup.Types
 }

--- a/rules/k8s-audit-logs-enabled-native/raw.rego
+++ b/rules/k8s-audit-logs-enabled-native/raw.rego
@@ -1,5 +1,6 @@
 package armo_builtins
-import data.cautils as cautils
+
+import data.cautils
 
 # Check if audit logs is  enabled for native k8s
 deny[msga] {
@@ -7,9 +8,9 @@ deny[msga] {
     cmd := apiserverpod.spec.containers[0].command
 	audit_policy :=  [ command |command := cmd[_] ; contains(command, "--audit-policy-file=")]
     count(audit_policy) < 1
-	path := "spec.containers[0].command"	
+	path := "spec.containers[0].command"
 
-	
+
 	msga := {
 		"alertMessage": "audit logs is not enabled",
 		"alertScore": 9,
@@ -18,7 +19,7 @@ deny[msga] {
 		"fixPaths": [],
 		"alertObject": {
 			"k8sApiObjects": [apiserverpod],
-		
+
 		}
 	}
 }

--- a/rules/resources-cpu-limit-and-request/raw.rego
+++ b/rules/resources-cpu-limit-and-request/raw.rego
@@ -1,5 +1,4 @@
 package armo_builtins
-import data
 
 # Fails if pod does not have container with CPU-limit or request
 deny[msga] {
@@ -8,7 +7,7 @@ deny[msga] {
     container := pod.spec.containers[i]
 	not request_or_limit_cpu(container)
 
-	fixPaths := [{"path": sprintf("spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}, 
+	fixPaths := [{"path": sprintf("spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"},
 				{"path": sprintf("spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
@@ -31,7 +30,7 @@ deny[msga] {
     container := wl.spec.template.spec.containers[i]
     not request_or_limit_cpu(container)
 
-	fixPaths := [{"path": sprintf("spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}, 
+	fixPaths := [{"path": sprintf("spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"},
 				{"path": sprintf("spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
@@ -53,9 +52,9 @@ deny[msga] {
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
     not request_or_limit_cpu(container)
 
-	fixPaths := [{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}, 
+	fixPaths := [{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"},
 				{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
-	
+
     msga := {
 		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
@@ -132,7 +131,7 @@ deny[msga] {
 	resource != ""
 
 	failed_paths := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].%v", [format_int(i, 10), resource])
-	
+
     msga := {
 		"alertMessage": sprintf("Container: %v in %v: %v exceeds CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
@@ -188,7 +187,7 @@ is_max_limit_exceeded_cpu(cpu_limit) {
 
 is_min_limit_exceeded_cpu(cpu_limit) {
 	cpu_limit_min :=  data.postureControlInputs.cpu_limit_min[_]
-	compare_min(cpu_limit_min, cpu_limit) 
+	compare_min(cpu_limit_min, cpu_limit)
 }
 
 is_max_request_exceeded_cpu(cpu_req) {
@@ -198,7 +197,7 @@ is_max_request_exceeded_cpu(cpu_req) {
 
 is_min_request_exceeded_cpu(cpu_req) {
 	cpu_req_min := data.postureControlInputs.cpu_request_min[_]
-	compare_min(cpu_req_min, cpu_req) 
+	compare_min(cpu_req_min, cpu_req)
 }
 
 ##############

--- a/rules/rule-can-bash-cmd-inside-container/raw.rego
+++ b/rules/rule-can-bash-cmd-inside-container/raw.rego
@@ -1,9 +1,8 @@
 package armo_builtins
-import data.cautils as cautils
-import data
 
+import data.cautils
 
-# Fails if container has bash/cmd inside it 
+# Fails if container has bash/cmd inside it
 # Pods
 deny [msga] {
     pod := input[_]
@@ -12,7 +11,7 @@ deny [msga] {
 	scan := res[_]
     is_bash_container(scan)
 	path := sprintf("spec.containers[%v].image", [format_int(i, 10)])
-    
+
     msga := {
 		"alertMessage": sprintf("the following container: %v has bash/cmd inside it.", [container.name]),
 		"alertScore": 6,
@@ -40,7 +39,7 @@ deny [msga] {
 	scan := res[_]
     is_bash_container(scan)
 
-    
+
     msga := {
 		"alertMessage": sprintf("the following container: %v has bash/cmd inside it.", [container.name]),
 		"alertScore": 6,

--- a/rules/rule-can-create-bind-escalate-role/raw.rego
+++ b/rules/rule-can-create-bind-escalate-role/raw.rego
@@ -1,6 +1,7 @@
 
 package armo_builtins
-import data.cautils as cautils
+
+import data.cautils
 
 # ================= create/update ===============================
 
@@ -16,7 +17,7 @@ deny[msga] {
     rule:= role.rules[_]
     can_create_update_to_role_resource(rule)
     can_create_update_to_role_verb(rule)
-  
+
     rolebinding.roleRef.kind == "Role"
     rolebinding.roleRef.name == role.metadata.name
     subject := rolebinding.subjects[i]
@@ -143,7 +144,7 @@ deny [msga]{
     rolebinding := rolebindings[_]
 
     rule:= role.rules[_]
-    
+
     can_bind_to_role_resource(rule)
     can_bind_to_role_verb(rule)
 
@@ -183,7 +184,7 @@ can_bind_to_role_resource(rule)
     clusterrolebinding.roleRef.name == role.metadata.name
     subject := clusterrolebinding.subjects[i]
     path := sprintf("subjects[%v]", [format_int(i, 10)])
-    	
+
    msga := {
 		"alertMessage": sprintf("The following %v: %v, can bind roles/clusterroles", [subject.kind, subject.name]),
 		"alertScore": 3,
@@ -214,7 +215,7 @@ deny[msga] {
     rule:= role.rules[_]
     can_escalate_to_role_resource(rule)
     can_escalate_to_role_verb(rule)
-  
+
     rolebinding.roleRef.kind == "Role"
     rolebinding.roleRef.name == role.metadata.name
     subject := rolebinding.subjects[i]
@@ -281,7 +282,7 @@ deny [msga]{
     clusterrolebinding.roleRef.name == role.metadata.name
     subject := clusterrolebinding.subjects[i]
     path := sprintf("subjects[%v]", [format_int(i, 10)])
-    	
+
   	msga := {
 		"alertMessage": sprintf("The following %v: %v, can escalate rolebinding/clusterrolebinding", [subject.kind, subject.name]),
 		"alertScore": 3,

--- a/rules/rule-can-create-modify-pod/raw.rego
+++ b/rules/rule-can-create-modify-pod/raw.rego
@@ -1,10 +1,8 @@
-
 package armo_builtins
-import data.cautils as cautils
 
+import data.cautils
 
-
-# fails if user has create/modify access to pods 
+# fails if user has create/modify access to pods
 # RoleBinding to Role
 deny [msga] {
     roles := [role |  role= input[_]; role.kind == "Role"]
@@ -36,7 +34,7 @@ deny [msga] {
      }
 }
 
-# fails if user has create/modify access to pods 
+# fails if user has create/modify access to pods
 # RoleBinding to ClusterRole
 deny [msga]{
     roles := [role |  role= input[_]; role.kind == "ClusterRole"]
@@ -67,7 +65,7 @@ deny [msga]{
      }
 }
 
-# fails if user has create/modify access to pods 
+# fails if user has create/modify access to pods
 # ClusterRoleBinding to ClusterRole
 deny [msga]{
     roles := [role |  role= input[_]; role.kind == "ClusterRole"]

--- a/rules/rule-can-create-pod-kube-system/raw.rego
+++ b/rules/rule-can-create-pod-kube-system/raw.rego
@@ -1,6 +1,6 @@
-
 package armo_builtins
-import data.cautils as cautils
+
+import data.cautils
 
 # fails if user has create access to pods within kube-system namespace
 # RoleBinding to Role

--- a/rules/rule-can-delete-create-service/raw.rego
+++ b/rules/rule-can-delete-create-service/raw.rego
@@ -1,8 +1,6 @@
-
 package armo_builtins
-import data.cautils as cautils
 
-
+import data.cautils
 
 # fails if user has create/delete access to services
 # RoleBinding to Role

--- a/rules/rule-can-delete-k8s-events/raw.rego
+++ b/rules/rule-can-delete-k8s-events/raw.rego
@@ -1,5 +1,6 @@
 package armo_builtins
-import data.cautils as cautils
+
+import data.cautils
 
 # fails if user can delete events
 #RoleBinding to Role

--- a/rules/rule-can-delete-logs/raw.rego
+++ b/rules/rule-can-delete-logs/raw.rego
@@ -1,9 +1,8 @@
 package armo_builtins
-import data.cautils as cautils
 
+import data.cautils
 
-
-# fails if user can delete logs of pod 
+# fails if user can delete logs of pod
 #RoleBinding to Role
 deny [msga] {
     roles := [role |  role= input[_]; role.kind == "Role"]
@@ -35,7 +34,7 @@ deny [msga] {
 }
 
 
-# fails if user can delete logs of pod 
+# fails if user can delete logs of pod
 # RoleBinding to ClusterRole
 deny[msga] {
     roles := [role |  role= input[_]; role.kind == "ClusterRole"]
@@ -67,7 +66,7 @@ deny[msga] {
     }
 }
 
-# fails if user can delete logs of pod 
+# fails if user can delete logs of pod
 # ClusterRoleBinding to ClusterRole
 deny[msga] {
     roles := [role |  role= input[_]; role.kind == "ClusterRole"]

--- a/rules/rule-can-impersonate-users-groups/raw.rego
+++ b/rules/rule-can-impersonate-users-groups/raw.rego
@@ -1,7 +1,6 @@
-
 package armo_builtins
-import data.cautils as cautils
 
+import data.cautils
 
 deny[msga] {
 	 roles := [role |  role= input[_]; role.kind == "Role"]
@@ -15,7 +14,7 @@ deny[msga] {
 
 	rolebinding.roleRef.kind == "Role"
 	rolebinding.roleRef.name == role.metadata.name
-	
+
     subject := rolebinding.subjects[i]
     path := sprintf("subjects[%v]", [format_int(i, 10)])
 
@@ -46,7 +45,7 @@ deny[msga] {
 
 	rolebinding.roleRef.kind == "ClusterRole"
 	rolebinding.roleRef.name == role.metadata.name
-	
+
     subject := rolebinding.subjects[i]
     path := sprintf("subjects[%v]", [format_int(i, 10)])
 
@@ -78,7 +77,7 @@ deny[msga] {
 
 	rolebinding.roleRef.kind == "ClusterRole"
 	rolebinding.roleRef.name == role.metadata.name
-	
+
     subject := rolebinding.subjects[i]
     path := sprintf("subjects[%v]", [format_int(i, 10)])
 

--- a/rules/rule-can-list-get-secrets/raw.rego
+++ b/rules/rule-can-list-get-secrets/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
-import data.cautils as cautils
 
+import data.cautils
 
-# fails if user can list/get secrets 
+# fails if user can list/get secrets
 #RoleBinding to Role
 deny[msga] {
     roles := [role |  role= input[_]; role.kind == "Role"]
@@ -35,7 +35,7 @@ deny[msga] {
 }
 
 
-# fails if user can list/get secrets 
+# fails if user can list/get secrets
 #RoleBinding to ClusterRole
 deny[msga] {
     roles := [role |  role= input[_]; role.kind == "ClusterRole"]
@@ -68,7 +68,7 @@ deny[msga] {
     }
 }
 
-# fails if user can list/get secrets 
+# fails if user can list/get secrets
 # ClusterRoleBinding to ClusterRole
 deny[msga] {
     roles := [role |  role= input[_]; role.kind == "ClusterRole"]

--- a/rules/rule-can-portforward/raw.rego
+++ b/rules/rule-can-portforward/raw.rego
@@ -1,10 +1,9 @@
-
 package armo_builtins
-import data.cautils as cautils
 
+import data.cautils
 
 deny[msga] {
-	 roles := [role |  role= input[_]; role.kind == "Role"]
+	roles := [role |  role= input[_]; role.kind == "Role"]
     rolebindings := [rolebinding | rolebinding = input[_]; rolebinding.kind == "RoleBinding"]
     role:= roles[_]
     rolebinding := rolebindings[_]
@@ -15,7 +14,7 @@ deny[msga] {
 
 	rolebinding.roleRef.kind == "Role"
 	rolebinding.roleRef.name == role.metadata.name
-	
+
     subject := rolebinding.subjects[i]
     path := sprintf("subjects[%v]", [format_int(i, 10)])
 
@@ -46,7 +45,7 @@ deny[msga] {
 
 	rolebinding.roleRef.kind == "ClusterRole"
 	rolebinding.roleRef.name == role.metadata.name
-	
+
     subject := rolebinding.subjects[i]
     path := sprintf("subjects[%v]", [format_int(i, 10)])
 
@@ -78,7 +77,7 @@ deny[msga] {
 
 	rolebinding.roleRef.kind == "ClusterRole"
 	rolebinding.roleRef.name == role.metadata.name
-	
+
     subject := rolebinding.subjects[i]
     path := sprintf("subjects[%v]", [format_int(i, 10)])
 

--- a/rules/rule-can-update-configmap/raw.rego
+++ b/rules/rule-can-update-configmap/raw.rego
@@ -1,6 +1,6 @@
 package armo_builtins
-import data.cautils as cautils
 
+import data.cautils
 
 # Fails if user can modify all configmaps, or if he can modify the 'coredns' configmap (default for coredns)
 #RoleBinding to Role

--- a/rules/rule-credentials-configmap/raw.rego
+++ b/rules/rule-credentials-configmap/raw.rego
@@ -1,7 +1,4 @@
 package armo_builtins
-# import data.cautils as cautils
-# import data.kubernetes.api.client as client
-import data
 
 # fails if config map has keys with suspicious name
 deny[msga] {
@@ -12,11 +9,11 @@ deny[msga] {
     key_name := sensitive_key_names[_]
     map_secret := configmap.data[map_key]
     map_secret != ""
-    
+
     contains(lower(map_key), lower(key_name))
     # check that value wasn't allowed by user
     not is_allowed_value(map_secret)
-    
+
     path := sprintf("data[%v]", [map_key])
 
 	msga := {
@@ -72,7 +69,7 @@ deny[msga] {
     map_secret != ""
 
     decoded_secret := base64.decode(map_secret)
-    
+
     # check that value wasn't allowed by user
     not is_allowed_value(map_secret)
 

--- a/rules/rule-credentials-in-env-var/raw.rego
+++ b/rules/rule-credentials-in-env-var/raw.rego
@@ -1,7 +1,4 @@
 	package armo_builtins
-	# import data.cautils as cautils
-	# import data.kubernetes.api.client as client
-	import data
 
 	deny[msga] {
 		pod := input[_]
@@ -15,7 +12,7 @@
 		contains(lower(env.name), key_name)
 		env.value != ""
 		# check that value wasn't allowed by user
-		not is_allowed_value(env.value) 
+		not is_allowed_value(env.value)
 
 		is_not_reference(env)
 
@@ -47,11 +44,11 @@
 		contains(lower(env.name), key_name)
 		env.value != ""
 		# check that value wasn't allowed by user
-		not is_allowed_value(env.value) 
+		not is_allowed_value(env.value)
 
 		is_not_reference(env)
 
-		path := sprintf("spec.template.spec.containers[%v].env[%v].name", [format_int(i, 10), format_int(j, 10)])	
+		path := sprintf("spec.template.spec.containers[%v].env[%v].name", [format_int(i, 10), format_int(j, 10)])
 
 		msga := {
 			"alertMessage": sprintf("%v: %v has sensitive information in environment variables", [wl.kind, wl.metadata.name]),
@@ -78,10 +75,10 @@
 
 		env.value != ""
 		# check that value wasn't allowed by user
-		not is_allowed_value(env.value) 
-		
+		not is_allowed_value(env.value)
+
 		is_not_reference(env)
-		
+
 		path := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].name", [format_int(i, 10), format_int(j, 10)])
 
 		msga := {

--- a/rules/rule-excessive-delete-rights/raw.rego
+++ b/rules/rule-excessive-delete-rights/raw.rego
@@ -1,6 +1,6 @@
 package armo_builtins
-import data.cautils as cautils
 
+import data.cautils
 
 # fails if user can can delete important resources
 #RoleBinding to Role

--- a/rules/rule-identify-blocklisted-image-registries/raw.rego
+++ b/rules/rule-identify-blocklisted-image-registries/raw.rego
@@ -1,5 +1,5 @@
 package armo_builtins
-import data
+
 # Check for images from blocklisted repos
 
 untrustedImageRepo[msga] {

--- a/rules/rule-identify-old-k8s-registry/raw.rego
+++ b/rules/rule-identify-old-k8s-registry/raw.rego
@@ -1,5 +1,4 @@
 package armo_builtins
-import data
 
 deprecatedK8sRepo[msga] {
 	pod := input[_]

--- a/rules/rule-list-all-cluster-admins/raw.rego
+++ b/rules/rule-list-all-cluster-admins/raw.rego
@@ -1,5 +1,6 @@
 package armo_builtins
-import data.cautils as cautils
+
+import data.cautils
 
 # input: roles
 # apiversion: v1
@@ -51,7 +52,7 @@ deny[msga] {
 
 	rolebinding.roleRef.kind == "ClusterRole"
 	rolebinding.roleRef.name == role.metadata.name
-    
+
     subject := rolebinding.subjects[i]
     path := sprintf("subjects[%v]", [format_int(i, 10)])
 
@@ -86,7 +87,7 @@ deny[msga] {
 
 	rolebinding.roleRef.kind == "ClusterRole"
 	rolebinding.roleRef.name == role.metadata.name
-	
+
     subject := rolebinding.subjects[i]
     path := sprintf("subjects[%v]", [format_int(i, 10)])
 

--- a/rules/rule-name-similarity/raw.rego
+++ b/rules/rule-name-similarity/raw.rego
@@ -1,7 +1,4 @@
 package armo_builtins
-import data
-# import data.cautils as cautils
-# import data.kubernetes.api.client as client
 
 # input: pods
 # apiversion: v1
@@ -17,7 +14,7 @@ deny[msga] {
     wl_name := wl_known_names[_]
     contains(object.metadata.name, wl_name)
 	path := "metadata.name"
-	
+
 	msga := {
 		"alertMessage": sprintf("this %v has a similar name to %v", [object.kind, wl_name]),
 		"alertScore": 9,

--- a/rules/rule-secrets-in-env-var/raw.rego
+++ b/rules/rule-secrets-in-env-var/raw.rego
@@ -1,5 +1,4 @@
 package armo_builtins
-import data
 
 deny[msga] {
 	pod := input[_]
@@ -31,7 +30,7 @@ deny[msga] {
 	env := container.env[j]
 	env.valueFrom.secretKeyRef
 
-	path := sprintf("spec.template.spec.containers[%v].env[%v].name", [format_int(i, 10), format_int(j, 10)])	
+	path := sprintf("spec.template.spec.containers[%v].env[%v].name", [format_int(i, 10), format_int(j, 10)])
 
 	msga := {
 		"alertMessage": sprintf("%v: %v has secrets in environment variables", [wl.kind, wl.metadata.name]),
@@ -51,7 +50,7 @@ deny[msga] {
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
 	env := container.env[j]
 	env.valueFrom.secretKeyRef
-	
+
 	path := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].name", [format_int(i, 10), format_int(j, 10)])
 
 	msga := {

--- a/rules/strict-file-owners-root/raw.rego
+++ b/rules/strict-file-owners-root/raw.rego
@@ -1,14 +1,15 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 # Fail for every file in data.postureControlInputs.fileObjPath
 # if the owners of the file are not `root:root`.
-# Expect (supposed to be fixed per control, not user configurable): 
+# Expect (supposed to be fixed per control, not user configurable):
 # 	(required) data.postureControlInputs.fileObjPath - list of paths strings. The item delimiter is `.`.
-# 	(optional) data.postureControlInputs.kindFilter 
-# 	(optional) data.postureControlInputs.pathGlob 
+# 	(optional) data.postureControlInputs.kindFilter
+# 	(optional) data.postureControlInputs.pathGlob
 deny[msg] {
 	# Filter out irrelevent resources
 	obj = input[_]
@@ -26,7 +27,7 @@ deny[msg] {
 	file = files[file_index]
 	file_path_glob(file.path)
 
-	# Actual ownership test    
+	# Actual ownership test
 	cautils.is_not_strict_conf_ownership(file.ownership)
 
 	# Filter out irrelevant data from the alert object

--- a/rules/strict-file-permissions-600/raw.rego
+++ b/rules/strict-file-permissions-600/raw.rego
@@ -1,14 +1,15 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 # Fail for every file in data.postureControlInputs.fileObjPath
 # if the permissions of the file are more permissive that 600.
-# Expect (supposed to be fixed per control, not user configurable): 
+# Expect (supposed to be fixed per control, not user configurable):
 # 	(required) data.postureControlInputs.fileObjPath - list of paths strings. The item delimiter is `.`.
-# 	(optional) data.postureControlInputs.kindFilter 
-# 	(optional) data.postureControlInputs.pathGlob 
+# 	(optional) data.postureControlInputs.kindFilter
+# 	(optional) data.postureControlInputs.pathGlob
 deny[msg] {
 	# Filter out irrelevent resources
 	obj = input[_]
@@ -26,7 +27,7 @@ deny[msg] {
 	file = files[file_index]
 	file_path_glob(file.path)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 384 # 0o600 == 384
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/strict-file-permissions-700/raw.rego
+++ b/rules/strict-file-permissions-700/raw.rego
@@ -1,14 +1,15 @@
 package armo_builtins
 
-import data.cautils as cautils
 import future.keywords.in
+
+import data.cautils
 
 # Fail for every file in data.postureControlInputs.fileObjPath
 # if the permissions of the file are more permissive that 600.
-# Expect (supposed to be fixed per control, not user configurable): 
+# Expect (supposed to be fixed per control, not user configurable):
 # 	(required) data.postureControlInputs.fileObjPath - list of paths strings. The item delimiter is `.`.
-# 	(optional) data.postureControlInputs.kindFilter 
-# 	(optional) data.postureControlInputs.pathGlob 
+# 	(optional) data.postureControlInputs.kindFilter
+# 	(optional) data.postureControlInputs.pathGlob
 deny[msg] {
 	# Filter out irrelevent resources
 	obj = input[_]
@@ -26,7 +27,7 @@ deny[msg] {
 	file = files[file_index]
 	file_path_glob(file.path)
 
-	# Actual permissions test    
+	# Actual permissions test
 	allowed_perms := 448 # 0o700 == 448
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 

--- a/rules/verify-image-signature/raw.rego
+++ b/rules/verify-image-signature/raw.rego
@@ -1,12 +1,11 @@
 package armo_builtins
-import data
 
 deny[msga] {
 
     pod := input[_]
     pod.kind == "Pod"
 	container := pod.spec.containers[i]
-	
+
     verified_keys := [trusted_key | trusted_key = data.postureControlInputs.trustedCosignPublicKeys[_]; cosign.verify(container.image, trusted_key)]
     count(verified_keys) == 0
 
@@ -49,7 +48,7 @@ deny[msga] {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-	
+
     verified_keys := [trusted_key | trusted_key = data.postureControlInputs.trustedCosignPublicKeys[_]; cosign.verify(container.image, trusted_key)]
     count(verified_keys) == 0
 

--- a/testrunner/opaprocessor/processorhandler.go
+++ b/testrunner/opaprocessor/processorhandler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/open-policy-agent/opa/topdown"
 	"os"
 	"strings"
 
@@ -117,7 +118,9 @@ func RunSingleRego(rule *reporthandling.PolicyRule, inputObj []map[string]interf
 		return nil, err
 	}
 	modules[rule.Name] = rule.Rule
-	compiled, err := ast.CompileModules(modules)
+	compiled, err := ast.CompileModulesWithOpt(modules, ast.CompileOpts{
+		EnablePrintStatements: true,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -162,6 +165,8 @@ func (opap *OPAProcessor) regoEval(inputObj []map[string]interface{}, compiledRe
 		rego.Compiler(compiledRego),
 		rego.Input(inputObj),
 		rego.Store(store),
+		rego.EnablePrintStatements(true),
+		rego.PrintHook(topdown.NewPrintHook(os.Stdout)),
 	)
 
 	// Run evaluation


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

Kicking the tires of our new open source linter for Rego, [Regal](https://github.com/styrainc/regal), and wanted to test it against a real-world policy library. This was a great exercise, as it uncovered a few issues and quirks in Regal, which have now been fixed.

I figured that I'd share the results with you in a PR, so here we are.

This PR fixes a number of issues reported:

- [redundant-alias](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/redundant-alias.md)
- [redundant-data-import](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/redundant-data-import.md)
- [use-in-operator](https://github.com/StyraInc/regal/blob/main/docs/rules/style/use-in-operator.md)
- [rule-shadows-builtin](https://github.com/StyraInc/regal/blob/main/docs/rules/bugs/rule-shadows-builtin.md)
- [custom-in-construct](https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/custom-in-construct.md)

Provided is also a configuration for Regal that disables a number of rules mostly related to style, which someone might want to look into one day, but they are not critical.

If you like it, perhaps we could have it integrated into the CI pipeline to have the linter run on PRs, etc.

Finally, I added support for `print` statements in the test runner, as that greatly simplifies debugging the tests.