### PR TITLE
fix mulitple unrelated resources

### DIFF
--- a/rules/serviceaccount-token-mount/raw.rego
+++ b/rules/serviceaccount-token-mount/raw.rego
@@ -6,6 +6,7 @@ deny[msga] {
     spec := object.get(wl, beggining_of_path, [])
 
     sa := input[_]
+    sa.kind == "ServiceAccount"
     is_same_sa(spec, sa.metadata.name)
     is_same_namespace(sa.metadata , wl.metadata)
     has_service_account_binding(sa)


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR introduces a validation for the Service Account kind in the service account token mount rule. This is to ensure that only objects of kind "ServiceAccount" are processed, preventing unrelated resources from being erroneously connected as related resources. This addresses a bug where multiple objects that are not Service Accounts were connected as related resources.

___
## PR Main Files Walkthrough:
`rules/serviceaccount-token-mount/raw.rego`: Added a condition to check if the kind of the object is "ServiceAccount" before proceeding with the rest of the rule logic. This ensures that only Service Accounts are processed by the rule.

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
This PR validates the Service Account thus validating that the related resource is indeed related. 
This fixes [bug](https://cyberarmor-io.atlassian.net/browse/SUB-2266) of multiple objects that are not SA that are connected as related resources.
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->
