### PR TITLE
fix failpath

### DIFF
--- a/rules/exposure-to-internet/raw.rego
+++ b/rules/exposure-to-internet/raw.rego
@@ -84,6 +84,6 @@ svc_connected_to_ingress(svc, ingress) = result {
     rule := ingress.spec.rules[i]
     paths := rule.http.paths[j]
     svc.metadata.name == paths.backend.service.name
-    result := [sprintf("ingress.spec.rules[%d].http.paths[%d].backend.service.name", [i,j])]
+    result := [sprintf("spec.rules[%d].http.paths[%d].backend.service.name", [i,j])]
 }
 

--- a/rules/exposure-to-internet/test/failed_with_ingress/expected.json
+++ b/rules/exposure-to-internet/test/failed_with_ingress/expected.json
@@ -51,7 +51,7 @@
                     }
                 },
                 "failedPaths": [
-                    "ingress.spec.rules[0].http.paths[0].backend.service.name"
+                    "spec.rules[0].http.paths[0].backend.service.name"
                 ],
                 "fixPaths": null
             }


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This pull request addresses an issue with incorrect path references in the ingress rules. The changes involve modifying the path references in both the 'raw.rego' and 'expected.json' files to correctly point to the 'spec.rules' instead of 'ingress.spec.rules'.

___
## PR Main Files Walkthrough:
`rules/exposure-to-internet/raw.rego`: The path reference in the 'svc_connected_to_ingress' function has been corrected from 'ingress.spec.rules' to 'spec.rules'.
`rules/exposure-to-internet/test/failed_with_ingress/expected.json`: The path reference in the 'failedPaths' array has been corrected from 'ingress.spec.rules' to 'spec.rules'.

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->
