### PR TITLE
change node names + add description

### DIFF
--- a/attack-tracks/service-destruction.json
+++ b/attack-tracks/service-destruction.json
@@ -7,10 +7,12 @@
     "spec": {
         "version": "1.0",
         "data": {
-            "name": "Workload Exposure",
+            "name": "Initial Access",
+            "description": "An attacker can access the Kubernetes environment.",
             "subSteps": [
                 {
-                    "name": "Service Destruction"
+                    "name": "Denial of service",
+                    "description": "An attacker can overload the workload, making it unavailable."
                 }
             ]
         }

--- a/attack-tracks/workload-external-track.json
+++ b/attack-tracks/workload-external-track.json
@@ -7,29 +7,37 @@
     "spec": {
         "version": "1.0",
         "data": {
-            "name": "Workload Exposure",
+            "name": "Initial Access",
+            "description": "An attacker can access the Kubernetes environment.",
             "subSteps": [
                 {
-                    "name": "Vulnerable Image",
+                    "name": "Execution (Vulnerable Image)",
+                    "description": "An attacker can execute malicious code by exploiting vulnerable images.",
                     "checksVulnerabilities": true,
                     "subSteps": [
                         {
-                            "name": "Data Access"
+                            "name": "Data Collection",
+                            "description": "An attacker can gather data."
                         },
                         {
-                            "name": "Secret Access"
+                            "name": "Secret Access",
+                            "description": "An attacker can steal secrets."
                         },
                         {
-                            "name": "Credential access"
+                            "name": "Credential access",
+                            "description": "An attacker can steal account names and passwords."
                         },
                         {
-                            "name": "Potential Node exposure"
+                            "name": "Privilege Escalation (Node)",
+                            "description": "An attacker can gain permissions and access node resources."
                         },
                         {
-                            "name": "Persistence"
+                            "name": "Persistence",
+                            "description": "An attacker can create a foothold."
                         },
                         {
-                            "name": "Network"
+                            "name": "Lateral Movement (Network)",
+                            "description": "An attacker can move through the network."
                         }
                     ]
                 }

--- a/controls/C-0009-resourcelimits.json
+++ b/controls/C-0009-resourcelimits.json
@@ -9,7 +9,7 @@
             {
                 "attackTrack": "service-destruction",
                 "categories": [
-                    "Service Destruction"
+                    "Denial of service"
                 ]
             }
         ]

--- a/controls/C-0041-hostnetworkaccess.json
+++ b/controls/C-0041-hostnetworkaccess.json
@@ -10,7 +10,7 @@
             {
                 "attackTrack": "workload-external-track",
                 "categories": [
-                    "Network"
+                    "Lateral Movement (Network)"
                 ]
             }
         ]

--- a/controls/C-0044-containerhostport.json
+++ b/controls/C-0044-containerhostport.json
@@ -11,13 +11,13 @@
             {
                 "attackTrack": "workload-external-track",
                 "categories": [
-                    "Workload Exposure"
+                    "Initial Access"
                 ]
             },
             {
                 "attackTrack": "service-destruction",
                 "categories": [
-                    "Workload Exposure"
+                    "Initial Access"
                 ]
             }
         ]

--- a/controls/C-0045-writablehostpathmount.json
+++ b/controls/C-0045-writablehostpathmount.json
@@ -16,7 +16,7 @@
             {
                 "attackTrack": "workload-external-track",
                 "categories": [
-                    "Potential Node exposure"
+                    "Privilege Escalation (Node)"
                 ]
             }
         ]

--- a/controls/C-0046-insecurecapabilities.json
+++ b/controls/C-0046-insecurecapabilities.json
@@ -11,7 +11,7 @@
             {
                 "attackTrack": "workload-external-track",
                 "categories": [
-                    "Potential Node exposure"
+                    "Privilege Escalation (Node)"
                 ]
             }
         ]

--- a/controls/C-0048-hostpathmount.json
+++ b/controls/C-0048-hostpathmount.json
@@ -13,7 +13,7 @@
             {
                 "attackTrack": "workload-external-track",
                 "categories": [
-                    "Potential Node exposure"
+                    "Privilege Escalation (Node)"
                 ]
             }
         ]

--- a/controls/C-0211-applysecuritycontexttoyourpodsandcontainers.json
+++ b/controls/C-0211-applysecuritycontexttoyourpodsandcontainers.json
@@ -19,7 +19,7 @@
             {
                 "attackTrack": "workload-external-track",
                 "categories": [
-                    "Potential Node exposure"
+                    "Privilege Escalation (Node)"
                 ]
             }
         ]

--- a/controls/C-0256-exposuretointernet.json
+++ b/controls/C-0256-exposuretointernet.json
@@ -9,13 +9,13 @@
             {
                 "attackTrack": "workload-external-track",
                 "categories": [
-                    "Workload Exposure"
+                    "Initial Access"
                 ]
             },
             {
                 "attackTrack": "service-destruction",
                 "categories": [
-                    "Workload Exposure"
+                    "Initial Access"
                 ]
             }
         ]

--- a/controls/C-0257-pvcaccess.json
+++ b/controls/C-0257-pvcaccess.json
@@ -9,7 +9,7 @@
             {
                 "attackTrack": "workload-external-track",
                 "categories": [
-                    "Data Access"
+                    "Data Collection"
                 ]
             }
         ]

--- a/controls/C-0258-configmapaccess.json
+++ b/controls/C-0258-configmapaccess.json
@@ -9,7 +9,7 @@
             {
                 "attackTrack": "workload-external-track",
                 "categories": [
-                    "Data Access"
+                    "Data Collection"
                 ]
             }
         ]

--- a/controls/C-0260-missingnetworkpolicy.json
+++ b/controls/C-0260-missingnetworkpolicy.json
@@ -9,7 +9,7 @@
             {
                 "attackTrack": "workload-external-track",
                 "categories": [
-                    "Network"
+                    "Lateral Movement (Network)"
                 ]
             }
         ]


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR involves renaming of node names and adding descriptions to improve the clarity and understanding of the code. The changes are made across multiple files, mainly in 'attack-tracks' and 'controls' directories. The node names have been changed to more accurately represent their functionality, and descriptions have been added for better understanding of each node's purpose.

___
## PR Main Files Walkthrough:
`attack-tracks/service-destruction.json`: Renamed the node from 'Workload Exposure' to 'Initial Access' and added a description. Also, renamed the substep from 'Service Destruction' to 'Denial of service' and added a description.
`attack-tracks/workload-external-track.json`: Renamed the node from 'Workload Exposure' to 'Initial Access' and added a description. Also, renamed and added descriptions for all substeps.
`controls/C-0009-resourcelimits.json`: Updated the category from 'Service Destruction' to 'Denial of service' in the attackTracks section.
`controls/C-0041-hostnetworkaccess.json`: Updated the category from 'Network' to 'Lateral Movement (Network)' in the attackTracks section.
`controls/C-0044-containerhostport.json`: Updated the category from 'Workload Exposure' to 'Initial Access' in the attackTracks section for both attackTrack entries.
`controls/C-0045-writablehostpathmount.json`: Updated the category from 'Potential Node exposure' to 'Privilege Escalation (Node)' in the attackTracks section.
`controls/C-0046-insecurecapabilities.json`: Updated the category from 'Potential Node exposure' to 'Privilege Escalation (Node)' in the attackTracks section.
`controls/C-0048-hostpathmount.json`: Updated the category from 'Potential Node exposure' to 'Privilege Escalation (Node)' in the attackTracks section.
`controls/C-0211-applysecuritycontexttoyourpodsandcontainers.json`: Updated the category from 'Potential Node exposure' to 'Privilege Escalation (Node)' in the attackTracks section.
`controls/C-0256-exposuretointernet.json`: Updated the category from 'Workload Exposure' to 'Initial Access' in the attackTracks section for both attackTrack entries.

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
changes according to requirments in [SUB-2541](https://cyberarmor-io.atlassian.net/browse/SUB-2541)
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->
