### PR TITLE
Adding CVE-2023-3676 check

### DIFF
--- a/rules/CVE-2023-3676/raw.rego
+++ b/rules/CVE-2023-3676/raw.rego
@@ -1,0 +1,15 @@
+package armo_builtins
+
+deny[msg] {                                                                 
+    input.request.kind.kind == "Pod"
+    path := input.request.object.spec.containers.volumeMounts.subPath                 
+    not startswith(path, "$(")                                     
+    msga := {
+			"alertMessage": "You may be vulnerable to CVE-2023-3676",
+			"failedPaths": [path],
+			"fixPaths":[],
+			"alertObject": { 
+                "k8SApiObjects": [input[_]],
+            },
+		}     
+}

--- a/rules/CVE-2023-3676/rule.metadata.json
+++ b/rules/CVE-2023-3676/rule.metadata.json
@@ -1,0 +1,25 @@
+{
+    "name": "CVE-2023-3676",
+    "attributes": {
+      "armoBuiltin": true
+    },
+    "ruleLanguage": "Rego",
+    "match": [
+      {
+        "apiGroups": [
+          "apps"
+        ],
+        "apiVersions": [
+          "v1"
+        ],
+        "resources": [
+          "Pod"
+        ]
+      }
+    ],
+    "ruleDependencies": [
+    ],
+    "description": "Check for CVE-2023-3676",
+    "remediation": "Update kubelet version",
+    "ruleQuery": "armo_builtins"
+}

--- a/rules/CVE-2023-3676/test/pod/input/pod.yaml
+++ b/rules/CVE-2023-3676/test/pod/input/pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: wintest
+spec:
+  containers:
+  - name: test
+    image: raesene/windows-powertools
+    command:
+    - powershell.exe
+    - -command
+    - "start-sleep -seconds 600"
+    volumeMounts:
+    - name: test
+      mountPath: c:\var
+      subPath: $(Start-process cmd)
+  volumes:
+  - name: test
+    hostPath:
+      path: c:\var
+  hostNetwork: true
+  nodeSelector:
+    kubernetes.io/os: windows


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new security rule to check for the vulnerability CVE-2023-3676. The rule is implemented in Rego language and checks for specific conditions in Kubernetes Pod specifications. A test case with a Pod manifest is also included to verify the rule's functionality.

___
## PR Main Files Walkthrough:
`rules/CVE-2023-3676/raw.rego`: A new Rego rule has been added. This rule checks if the 'kind' of the object is a 'Pod' and if the 'subPath' of 'volumeMounts' in the Pod's spec does not start with "$(". If these conditions are met, a warning message is generated indicating potential vulnerability to CVE-2023-3676.
`rules/CVE-2023-3676/rule.metadata.json`: Metadata for the new rule has been added. It includes the rule's name, attributes, language, match criteria, dependencies, description, remediation, and rule query.
`rules/CVE-2023-3676/test/pod/input/pod.yaml`: A test case has been added. It includes a Pod manifest with a specific 'subPath' in 'volumeMounts' that should trigger the new rule, serving as a test for the rule's functionality.

___
## User Description:
## Overview
Adding rule for CVE-3676
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->
