### PR TITLE
remove control C-0044 (hostPort) from attack tracks

### DIFF
--- a/controls/C-0044-containerhostport.json
+++ b/controls/C-0044-containerhostport.json
@@ -6,20 +6,6 @@
             "security",
             "compliance",
             "devops"
-        ],
-        "attackTracks": [
-            {
-                "attackTrack": "workload-external-track",
-                "categories": [
-                    "Initial Access"
-                ]
-            },
-            {
-                "attackTrack": "service-destruction",
-                "categories": [
-                    "Initial Access"
-                ]
-            }
         ]
     },
     "description": "Configuring hostPort requires a particular port number. If two objects specify the same HostPort, they could not be deployed to the same node. It may prevent the second object from starting, even if Kubernetes will try reschedule it on another node, provided there are available nodes with sufficient amount of resources. Also, if the number of replicas of such workload is higher than the number of nodes, the deployment will consistently fail.",


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR removes control C-0044 from the attack tracks in the 'controls/C-0044-containerhostport.json' file. The control was previously associated with the 'workload-external-track' and 'service-destruction' attack tracks under the 'Initial Access' category. After this change, the control will no longer be associated with these attack tracks.

___
## PR Main Files Walkthrough:
`controls/C-0044-containerhostport.json`: The 'attackTracks' section, which previously contained references to 'workload-external-track' and 'service-destruction' under the 'Initial Access' category, has been removed from the file.

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->
