### PR TITLE
add missing delete paths

### DIFF
--- a/rules/rule-credentials-configmap/raw.rego
+++ b/rules/rule-credentials-configmap/raw.rego
@@ -49,6 +49,7 @@ deny[msga] {
 	msga := {
 		"alertMessage": sprintf("this configmap has sensitive information: %v", [configmap.metadata.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
        "failedPaths": [path],
         "fixPaths": [],
 		"packagename": "armo_builtins",
@@ -81,6 +82,7 @@ deny[msga] {
 	msga := {
 		"alertMessage": sprintf("this configmap has sensitive information: %v", [configmap.metadata.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
        "failedPaths": [path],
         "fixPaths": [],
 		"packagename": "armo_builtins",


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This pull request addresses the issue of missing delete paths in the rules for handling sensitive information in configmaps. The changes ensure that the delete paths are properly defined, enhancing the security and robustness of the system.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`rules/rule-credentials-configmap/raw.rego`: The 'deletePaths' field has been added to the alert message structure in two places. This field contains the path of the sensitive data in the configmap that needs to be deleted.
</details>

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->
