### PR TITLE
Making sure that service and ingress are in the same namespace

### DIFF
--- a/controls/C-0256-exposuretointernet.json
+++ b/controls/C-0256-exposuretointernet.json
@@ -28,8 +28,7 @@
     "baseScore": 7.0,
     "scanningScope": {
         "matches": [
-            "cluster",
-            "file"
+            "cluster"
         ]
     }
 }

--- a/rules/exposure-to-internet/raw.rego
+++ b/rules/exposure-to-internet/raw.rego
@@ -59,11 +59,16 @@ deny[msga] {
         "alertObject": {
             "k8sApiObjects": [wl]
         },
-        "relatedObjects": [{
-            "object": ingress,
+        "relatedObjects": [
+		{
+	            "object": ingress,
 		    "reviewPaths": result,
-            "failedPaths": result,
-        }]
+	            "failedPaths": result,
+	        },
+		{
+	            "object": svc,
+		}
+        ]
     }
 } 
 

--- a/rules/exposure-to-internet/raw.rego
+++ b/rules/exposure-to-internet/raw.rego
@@ -35,6 +35,10 @@ deny[msga] {
     
     svc := input[_]
     svc.kind == "Service"
+
+    # Make sure that they belong to the same namespace
+    svc.metadata.namespace == ingress.metadata.namespace
+
     # avoid duplicate alerts
     # if service is already exposed through NodePort or LoadBalancer workload will fail on that
     not is_exposed_service(svc)

--- a/rules/exposure-to-internet/test/failed_with_ingress/expected.json
+++ b/rules/exposure-to-internet/test/failed_with_ingress/expected.json
@@ -23,7 +23,8 @@
                     "apiVersion": "networking.k8s.io/v1",
                     "kind": "Ingress",
                     "metadata": {
-                        "name": "my-ingress"
+                        "name": "my-ingress",
+                        "namespace": "default"
                     },
                     "spec": {
                         "ingressClassName": "nginx",
@@ -54,6 +55,28 @@
                     "spec.rules[0].http.paths[0].backend.service.name"
                 ],
                 "fixPaths": null
+            },
+            {
+                "object": {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "name": "my-service",
+                        "namespace": "default"
+                    },
+                    "spec": {
+                        "ports": [
+                            {
+                                "port": 80,
+                                "targetPort": 80
+                            }
+                        ],
+                        "selector": {
+                            "app": "my-app"
+                        },
+                        "type": "ClusterIP"
+                    }
+                }
             }
         ]
     }

--- a/rules/exposure-to-internet/test/failed_with_ingress/input/ingress.yaml
+++ b/rules/exposure-to-internet/test/failed_with_ingress/input/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: my-ingress
+  namespace: default
 spec:
   ingressClassName: nginx
   rules:

--- a/rules/exposure-to-internet/test/failed_with_ingress/input/service.yaml
+++ b/rules/exposure-to-internet/test/failed_with_ingress/input/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: my-service
+  namespace: default
 spec:
   selector:
     app: my-app


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses a bug in the 'exposure-to-internet' rule where the service and ingress were not verified to belong to the same namespace. This led to false positives in scans. The fix ensures that the service and ingress are in the same namespace, thus reducing the chance of false positives.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`rules/exposure-to-internet/raw.rego`: Added a condition to verify that the service and ingress belong to the same namespace. This is done by comparing the 'namespace' metadata of both the service and the ingress.
</details>

___
## User Description:
## Overview
Rule "exposure-to-internet" did not verify  that the service and ingress are in the same namespace when matching them one to another.

This caused false positives in scans.
