### PR TITLE
cis-v1.23-t1.0.1 controls - move scope from cloud to cluster

### DIFF
--- a/controls/C-0092-ensurethattheapiserverpodspecificationfilepermissionsaresetto600ormorerestrictive.json
+++ b/controls/C-0092-ensurethattheapiserverpodspecificationfilepermissionsaresetto600ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0093-ensurethattheapiserverpodspecificationfileownershipissettorootroot.json
+++ b/controls/C-0093-ensurethattheapiserverpodspecificationfileownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0094-ensurethatthecontrollermanagerpodspecificationfilepermissionsaresetto600ormorerestrictive.json
+++ b/controls/C-0094-ensurethatthecontrollermanagerpodspecificationfilepermissionsaresetto600ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0095-ensurethatthecontrollermanagerpodspecificationfileownershipissettorootroot.json
+++ b/controls/C-0095-ensurethatthecontrollermanagerpodspecificationfileownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0096-ensurethattheschedulerpodspecificationfilepermissionsaresetto600ormorerestrictive.json
+++ b/controls/C-0096-ensurethattheschedulerpodspecificationfilepermissionsaresetto600ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0097-ensurethattheschedulerpodspecificationfileownershipissettorootroot.json
+++ b/controls/C-0097-ensurethattheschedulerpodspecificationfileownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0098-ensurethattheetcdpodspecificationfilepermissionsaresetto600ormorerestrictive.json
+++ b/controls/C-0098-ensurethattheetcdpodspecificationfilepermissionsaresetto600ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0099-ensurethattheetcdpodspecificationfileownershipissettorootroot.json
+++ b/controls/C-0099-ensurethattheetcdpodspecificationfileownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0100-ensurethatthecontainernetworkinterfacefilepermissionsaresetto600ormorerestrictive.json
+++ b/controls/C-0100-ensurethatthecontainernetworkinterfacefilepermissionsaresetto600ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0101-ensurethatthecontainernetworkinterfacefileownershipissettorootroot.json
+++ b/controls/C-0101-ensurethatthecontainernetworkinterfacefileownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0102-ensurethattheetcddatadirectorypermissionsaresetto700ormorerestrictive.json
+++ b/controls/C-0102-ensurethattheetcddatadirectorypermissionsaresetto700ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0103-ensurethattheetcddatadirectoryownershipissettoetcdetcd.json
+++ b/controls/C-0103-ensurethattheetcddatadirectoryownershipissettoetcdetcd.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0104-ensurethattheadminconffilepermissionsaresetto600.json
+++ b/controls/C-0104-ensurethattheadminconffilepermissionsaresetto600.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0105-ensurethattheadminconffileownershipissettorootroot.json
+++ b/controls/C-0105-ensurethattheadminconffileownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0106-ensurethattheschedulerconffilepermissionsaresetto600ormorerestrictive.json
+++ b/controls/C-0106-ensurethattheschedulerconffilepermissionsaresetto600ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0107-ensurethattheschedulerconffileownershipissettorootroot.json
+++ b/controls/C-0107-ensurethattheschedulerconffileownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0108-ensurethatthecontrollermanagerconffilepermissionsaresetto600ormorerestrictive.json
+++ b/controls/C-0108-ensurethatthecontrollermanagerconffilepermissionsaresetto600ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0109-ensurethatthecontrollermanagerconffileownershipissettorootroot.json
+++ b/controls/C-0109-ensurethatthecontrollermanagerconffileownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0110-ensurethatthekubernetespkidirectoryandfileownershipissettorootroot.json
+++ b/controls/C-0110-ensurethatthekubernetespkidirectoryandfileownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0111-ensurethatthekubernetespkicertificatefilepermissionsaresetto600ormorerestrictive.json
+++ b/controls/C-0111-ensurethatthekubernetespkicertificatefilepermissionsaresetto600ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0112-ensurethatthekubernetespkikeyfilepermissionsaresetto600.json
+++ b/controls/C-0112-ensurethatthekubernetespkikeyfilepermissionsaresetto600.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0113-ensurethattheapiserveranonymousauthargumentissettofalse.json
+++ b/controls/C-0113-ensurethattheapiserveranonymousauthargumentissettofalse.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0114-ensurethattheapiservertokenauthfileparameterisnotset.json
+++ b/controls/C-0114-ensurethattheapiservertokenauthfileparameterisnotset.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0115-ensurethattheapiserverdenyserviceexternalipsisnotset.json
+++ b/controls/C-0115-ensurethattheapiserverdenyserviceexternalipsisnotset.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0116-ensurethattheapiserverkubeletclientcertificateandkubeletclientkeyargumentsaresetasappropriate.json
+++ b/controls/C-0116-ensurethattheapiserverkubeletclientcertificateandkubeletclientkeyargumentsaresetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0117-ensurethattheapiserverkubeletcertificateauthorityargumentissetasappropriate.json
+++ b/controls/C-0117-ensurethattheapiserverkubeletcertificateauthorityargumentissetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0118-ensurethattheapiserverauthorizationmodeargumentisnotsettoalwaysallow.json
+++ b/controls/C-0118-ensurethattheapiserverauthorizationmodeargumentisnotsettoalwaysallow.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0119-ensurethattheapiserverauthorizationmodeargumentincludesnode.json
+++ b/controls/C-0119-ensurethattheapiserverauthorizationmodeargumentincludesnode.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0120-ensurethattheapiserverauthorizationmodeargumentincludesrbac.json
+++ b/controls/C-0120-ensurethattheapiserverauthorizationmodeargumentincludesrbac.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0121-ensurethattheadmissioncontrolplugineventratelimitisset.json
+++ b/controls/C-0121-ensurethattheadmissioncontrolplugineventratelimitisset.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0122-ensurethattheadmissioncontrolpluginalwaysadmitisnotset.json
+++ b/controls/C-0122-ensurethattheadmissioncontrolpluginalwaysadmitisnotset.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0123-ensurethattheadmissioncontrolpluginalwayspullimagesisset.json
+++ b/controls/C-0123-ensurethattheadmissioncontrolpluginalwayspullimagesisset.json
@@ -22,7 +22,7 @@
     "default_value": "By default, `AlwaysPullImages` is not set.",
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0124-ensurethattheadmissioncontrolpluginsecuritycontextdenyissetifpodsecuritypolicyisnotused.json
+++ b/controls/C-0124-ensurethattheadmissioncontrolpluginsecuritycontextdenyissetifpodsecuritypolicyisnotused.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0125-ensurethattheadmissioncontrolpluginserviceaccountisset.json
+++ b/controls/C-0125-ensurethattheadmissioncontrolpluginserviceaccountisset.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0126-ensurethattheadmissioncontrolpluginnamespacelifecycleisset.json
+++ b/controls/C-0126-ensurethattheadmissioncontrolpluginnamespacelifecycleisset.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0127-ensurethattheadmissioncontrolpluginnoderestrictionisset.json
+++ b/controls/C-0127-ensurethattheadmissioncontrolpluginnoderestrictionisset.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0128-ensurethattheapiserversecureportargumentisnotsetto0.json
+++ b/controls/C-0128-ensurethattheapiserversecureportargumentisnotsetto0.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0129-ensurethattheapiserverprofilingargumentissettofalse.json
+++ b/controls/C-0129-ensurethattheapiserverprofilingargumentissettofalse.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0130-ensurethattheapiserverauditlogpathargumentisset.json
+++ b/controls/C-0130-ensurethattheapiserverauditlogpathargumentisset.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0131-ensurethattheapiserverauditlogmaxageargumentissetto30orasappropriate.json
+++ b/controls/C-0131-ensurethattheapiserverauditlogmaxageargumentissetto30orasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0132-ensurethattheapiserverauditlogmaxbackupargumentissetto10orasappropriate.json
+++ b/controls/C-0132-ensurethattheapiserverauditlogmaxbackupargumentissetto10orasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0133-ensurethattheapiserverauditlogmaxsizeargumentissetto100orasappropriate.json
+++ b/controls/C-0133-ensurethattheapiserverauditlogmaxsizeargumentissetto100orasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0134-ensurethattheapiserverrequesttimeoutargumentissetasappropriate.json
+++ b/controls/C-0134-ensurethattheapiserverrequesttimeoutargumentissetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0135-ensurethattheapiserverserviceaccountlookupargumentissettotrue.json
+++ b/controls/C-0135-ensurethattheapiserverserviceaccountlookupargumentissettotrue.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0136-ensurethattheapiserverserviceaccountkeyfileargumentissetasappropriate.json
+++ b/controls/C-0136-ensurethattheapiserverserviceaccountkeyfileargumentissetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0137-ensurethattheapiserveretcdcertfileandetcdkeyfileargumentsaresetasappropriate.json
+++ b/controls/C-0137-ensurethattheapiserveretcdcertfileandetcdkeyfileargumentsaresetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0138-ensurethattheapiservertlscertfileandtlsprivatekeyfileargumentsaresetasappropriate.json
+++ b/controls/C-0138-ensurethattheapiservertlscertfileandtlsprivatekeyfileargumentsaresetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0139-ensurethattheapiserverclientcafileargumentissetasappropriate.json
+++ b/controls/C-0139-ensurethattheapiserverclientcafileargumentissetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0140-ensurethattheapiserveretcdcafileargumentissetasappropriate.json
+++ b/controls/C-0140-ensurethattheapiserveretcdcafileargumentissetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0141-ensurethattheapiserverencryptionproviderconfigargumentissetasappropriate.json
+++ b/controls/C-0141-ensurethattheapiserverencryptionproviderconfigargumentissetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0142-ensurethatencryptionprovidersareappropriatelyconfigured.json
+++ b/controls/C-0142-ensurethatencryptionprovidersareappropriatelyconfigured.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0143-ensurethattheapiserveronlymakesuseofstrongcryptographicciphers.json
+++ b/controls/C-0143-ensurethattheapiserveronlymakesuseofstrongcryptographicciphers.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0144-ensurethatthecontrollermanagerterminatedpodgcthresholdargumentissetasappropriate.json
+++ b/controls/C-0144-ensurethatthecontrollermanagerterminatedpodgcthresholdargumentissetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0145-ensurethatthecontrollermanagerprofilingargumentissettofalse.json
+++ b/controls/C-0145-ensurethatthecontrollermanagerprofilingargumentissettofalse.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0146-ensurethatthecontrollermanageruseserviceaccountcredentialsargumentissettotrue.json
+++ b/controls/C-0146-ensurethatthecontrollermanageruseserviceaccountcredentialsargumentissettotrue.json
@@ -22,7 +22,7 @@
     "default_value": "By default, `--use-service-account-credentials` is set to false.",
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0147-ensurethatthecontrollermanagerserviceaccountprivatekeyfileargumentissetasappropriate.json
+++ b/controls/C-0147-ensurethatthecontrollermanagerserviceaccountprivatekeyfileargumentissetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0148-ensurethatthecontrollermanagerrootcafileargumentissetasappropriate.json
+++ b/controls/C-0148-ensurethatthecontrollermanagerrootcafileargumentissetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0149-ensurethatthecontrollermanagerrotatekubeletservercertificateargumentissettotrue.json
+++ b/controls/C-0149-ensurethatthecontrollermanagerrotatekubeletservercertificateargumentissettotrue.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-          "cloud"
+          "cluster"
         ]
       }
 }

--- a/controls/C-0150-ensurethatthecontrollermanagerbindaddressargumentissetto127001.json
+++ b/controls/C-0150-ensurethatthecontrollermanagerbindaddressargumentissetto127001.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0151-ensurethattheschedulerprofilingargumentissettofalse.json
+++ b/controls/C-0151-ensurethattheschedulerprofilingargumentissettofalse.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0152-ensurethattheschedulerbindaddressargumentissetto127001.json
+++ b/controls/C-0152-ensurethattheschedulerbindaddressargumentissetto127001.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0153-ensurethatthecertfileandkeyfileargumentsaresetasappropriate.json
+++ b/controls/C-0153-ensurethatthecertfileandkeyfileargumentsaresetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0154-ensurethattheclientcertauthargumentissettotrue.json
+++ b/controls/C-0154-ensurethattheclientcertauthargumentissettotrue.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0155-ensurethattheautotlsargumentisnotsettotrue.json
+++ b/controls/C-0155-ensurethattheautotlsargumentisnotsettotrue.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0156-ensurethatthepeercertfileandpeerkeyfileargumentsaresetasappropriate.json
+++ b/controls/C-0156-ensurethatthepeercertfileandpeerkeyfileargumentsaresetasappropriate.json
@@ -22,7 +22,7 @@
     "default_value": "**Note:** This recommendation is applicable only for etcd clusters. If you are using only one etcd server in your environment then this recommendation is not applicable. By default, peer communication over TLS is not configured.",
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0157-ensurethatthepeerclientcertauthargumentissettotrue.json
+++ b/controls/C-0157-ensurethatthepeerclientcertauthargumentissettotrue.json
@@ -22,7 +22,7 @@
     "default_value": "**Note:** This recommendation is applicable only for etcd clusters. If you are using only one etcd server in your environment then this recommendation is not applicable. By default, `--peer-client-cert-auth` argument is set to `false`.",
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0158-ensurethatthepeerautotlsargumentisnotsettotrue.json
+++ b/controls/C-0158-ensurethatthepeerautotlsargumentisnotsettotrue.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0159-ensurethatauniquecertificateauthorityisusedforetcd.json
+++ b/controls/C-0159-ensurethatauniquecertificateauthorityisusedforetcd.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0160-ensurethataminimalauditpolicyiscreated.json
+++ b/controls/C-0160-ensurethataminimalauditpolicyiscreated.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0161-ensurethattheauditpolicycoverskeysecurityconcerns.json
+++ b/controls/C-0161-ensurethattheauditpolicycoverskeysecurityconcerns.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0162-ensurethatthekubeletservicefilepermissionsaresetto600ormorerestrictive.json
+++ b/controls/C-0162-ensurethatthekubeletservicefilepermissionsaresetto600ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0163-ensurethatthekubeletservicefileownershipissettorootroot.json
+++ b/controls/C-0163-ensurethatthekubeletservicefileownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0164-ifproxykubeconfigfileexistsensurepermissionsaresetto600ormorerestrictive.json
+++ b/controls/C-0164-ifproxykubeconfigfileexistsensurepermissionsaresetto600ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0165-ifproxykubeconfigfileexistsensureownershipissettorootroot.json
+++ b/controls/C-0165-ifproxykubeconfigfileexistsensureownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0166-ensurethatthekubeconfigkubeletconffilepermissionsaresetto600ormorerestrictive.json
+++ b/controls/C-0166-ensurethatthekubeconfigkubeletconffilepermissionsaresetto600ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0167-ensurethatthekubeconfigkubeletconffileownershipissettorootroot.json
+++ b/controls/C-0167-ensurethatthekubeconfigkubeletconffileownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0168-ensurethatthecertificateauthoritiesfilepermissionsaresetto600ormorerestrictive.json
+++ b/controls/C-0168-ensurethatthecertificateauthoritiesfilepermissionsaresetto600ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0169-ensurethattheclientcertificateauthoritiesfileownershipissettorootroot.json
+++ b/controls/C-0169-ensurethattheclientcertificateauthoritiesfileownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0170-ifthekubeletconfigyamlconfigurationfileisbeingusedvalidatepermissionssetto600ormorerestrictive.json
+++ b/controls/C-0170-ifthekubeletconfigyamlconfigurationfileisbeingusedvalidatepermissionssetto600ormorerestrictive.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0171-ifthekubeletconfigyamlconfigurationfileisbeingusedvalidatefileownershipissettorootroot.json
+++ b/controls/C-0171-ifthekubeletconfigyamlconfigurationfileisbeingusedvalidatefileownershipissettorootroot.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0172-ensurethattheanonymousauthargumentissettofalse.json
+++ b/controls/C-0172-ensurethattheanonymousauthargumentissettofalse.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0173-ensurethattheauthorizationmodeargumentisnotsettoalwaysallow.json
+++ b/controls/C-0173-ensurethattheauthorizationmodeargumentisnotsettoalwaysallow.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0174-ensurethattheclientcafileargumentissetasappropriate.json
+++ b/controls/C-0174-ensurethattheclientcafileargumentissetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0175-verifythatthereadonlyportargumentissetto0.json
+++ b/controls/C-0175-verifythatthereadonlyportargumentissetto0.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0176-ensurethatthestreamingconnectionidletimeoutargumentisnotsetto0.json
+++ b/controls/C-0176-ensurethatthestreamingconnectionidletimeoutargumentisnotsetto0.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0177-ensurethattheprotectkerneldefaultsargumentissettotrue.json
+++ b/controls/C-0177-ensurethattheprotectkerneldefaultsargumentissettotrue.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0178-ensurethatthemakeiptablesutilchainsargumentissettotrue.json
+++ b/controls/C-0178-ensurethatthemakeiptablesutilchainsargumentissettotrue.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0179-ensurethatthehostnameoverrideargumentisnotset.json
+++ b/controls/C-0179-ensurethatthehostnameoverrideargumentisnotset.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0180-ensurethattheeventqpsargumentissetto0oralevelwhichensuresappropriateeventcapture.json
+++ b/controls/C-0180-ensurethattheeventqpsargumentissetto0oralevelwhichensuresappropriateeventcapture.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0181-ensurethatthetlscertfileandtlsprivatekeyfileargumentsaresetasappropriate.json
+++ b/controls/C-0181-ensurethatthetlscertfileandtlsprivatekeyfileargumentsaresetasappropriate.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0182-ensurethattherotatecertificatesargumentisnotsettofalse.json
+++ b/controls/C-0182-ensurethattherotatecertificatesargumentisnotsettofalse.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0183-verifythattherotatekubeletservercertificateargumentissettotrue.json
+++ b/controls/C-0183-verifythattherotatekubeletservercertificateargumentissettotrue.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0184-ensurethatthekubeletonlymakesuseofstrongcryptographicciphers.json
+++ b/controls/C-0184-ensurethatthekubeletonlymakesuseofstrongcryptographicciphers.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0185-ensurethattheclusteradminroleisonlyusedwhererequired.json
+++ b/controls/C-0185-ensurethattheclusteradminroleisonlyusedwhererequired.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0186-minimizeaccesstosecrets.json
+++ b/controls/C-0186-minimizeaccesstosecrets.json
@@ -23,7 +23,7 @@
     "default_value": "By default in a kubeadm cluster the following list of principals have `get` privileges on `secret` objects ```CLUSTERROLEBINDING                                    SUBJECT                             TYPE            SA-NAMESPACEcluster-admin                                         system:masters                      Group           system:controller:clusterrole-aggregation-controller  clusterrole-aggregation-controller  ServiceAccount  kube-systemsystem:controller:expand-controller                   expand-controller                   ServiceAccount  kube-systemsystem:controller:generic-garbage-collector           generic-garbage-collector           ServiceAccount  kube-systemsystem:controller:namespace-controller                namespace-controller                ServiceAccount  kube-systemsystem:controller:persistent-volume-binder            persistent-volume-binder            ServiceAccount  kube-systemsystem:kube-controller-manager                        system:kube-controller-manager      User ```",
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0186-minimizeaccesstosecrets.json
+++ b/controls/C-0186-minimizeaccesstosecrets.json
@@ -23,7 +23,8 @@
     "default_value": "By default in a kubeadm cluster the following list of principals have `get` privileges on `secret` objects ```CLUSTERROLEBINDING                                    SUBJECT                             TYPE            SA-NAMESPACEcluster-admin                                         system:masters                      Group           system:controller:clusterrole-aggregation-controller  clusterrole-aggregation-controller  ServiceAccount  kube-systemsystem:controller:expand-controller                   expand-controller                   ServiceAccount  kube-systemsystem:controller:generic-garbage-collector           generic-garbage-collector           ServiceAccount  kube-systemsystem:controller:namespace-controller                namespace-controller                ServiceAccount  kube-systemsystem:controller:persistent-volume-binder            persistent-volume-binder            ServiceAccount  kube-systemsystem:kube-controller-manager                        system:kube-controller-manager      User ```",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0187-minimizewildcarduseinrolesandclusterroles.json
+++ b/controls/C-0187-minimizewildcarduseinrolesandclusterroles.json
@@ -23,8 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster",
-            "file"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0187-minimizewildcarduseinrolesandclusterroles.json
+++ b/controls/C-0187-minimizewildcarduseinrolesandclusterroles.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0188-minimizeaccesstocreatepods.json
+++ b/controls/C-0188-minimizeaccesstocreatepods.json
@@ -23,7 +23,7 @@
     "default_value": "By default in a kubeadm cluster the following list of principals have `create` privileges on `pod` objects ```CLUSTERROLEBINDING                                    SUBJECT                             TYPE            SA-NAMESPACEcluster-admin                                         system:masters                      Group           system:controller:clusterrole-aggregation-controller  clusterrole-aggregation-controller  ServiceAccount  kube-systemsystem:controller:daemon-set-controller               daemon-set-controller               ServiceAccount  kube-systemsystem:controller:job-controller                      job-controller                      ServiceAccount  kube-systemsystem:controller:persistent-volume-binder            persistent-volume-binder            ServiceAccount  kube-systemsystem:controller:replicaset-controller               replicaset-controller               ServiceAccount  kube-systemsystem:controller:replication-controller              replication-controller              ServiceAccount  kube-systemsystem:controller:statefulset-controller              statefulset-controller              ServiceAccount  kube-system```",
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0188-minimizeaccesstocreatepods.json
+++ b/controls/C-0188-minimizeaccesstocreatepods.json
@@ -23,7 +23,8 @@
     "default_value": "By default in a kubeadm cluster the following list of principals have `create` privileges on `pod` objects ```CLUSTERROLEBINDING                                    SUBJECT                             TYPE            SA-NAMESPACEcluster-admin                                         system:masters                      Group           system:controller:clusterrole-aggregation-controller  clusterrole-aggregation-controller  ServiceAccount  kube-systemsystem:controller:daemon-set-controller               daemon-set-controller               ServiceAccount  kube-systemsystem:controller:job-controller                      job-controller                      ServiceAccount  kube-systemsystem:controller:persistent-volume-binder            persistent-volume-binder            ServiceAccount  kube-systemsystem:controller:replicaset-controller               replicaset-controller               ServiceAccount  kube-systemsystem:controller:replication-controller              replication-controller              ServiceAccount  kube-systemsystem:controller:statefulset-controller              statefulset-controller              ServiceAccount  kube-system```",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0189-ensurethatdefaultserviceaccountsarenotactivelyused.json
+++ b/controls/C-0189-ensurethatdefaultserviceaccountsarenotactivelyused.json
@@ -24,7 +24,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0189-ensurethatdefaultserviceaccountsarenotactivelyused.json
+++ b/controls/C-0189-ensurethatdefaultserviceaccountsarenotactivelyused.json
@@ -24,7 +24,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0190-ensurethatserviceaccounttokensareonlymountedwherenecessary.json
+++ b/controls/C-0190-ensurethatserviceaccounttokensareonlymountedwherenecessary.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0190-ensurethatserviceaccounttokensareonlymountedwherenecessary.json
+++ b/controls/C-0190-ensurethatserviceaccounttokensareonlymountedwherenecessary.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0191-limituseofthebindimpersonateandescalatepermissionsinthekubernetescluster.json
+++ b/controls/C-0191-limituseofthebindimpersonateandescalatepermissionsinthekubernetescluster.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0191-limituseofthebindimpersonateandescalatepermissionsinthekubernetescluster.json
+++ b/controls/C-0191-limituseofthebindimpersonateandescalatepermissionsinthekubernetescluster.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0192-ensurethattheclusterhasatleastoneactivepolicycontrolmechanisminplace.json
+++ b/controls/C-0192-ensurethattheclusterhasatleastoneactivepolicycontrolmechanisminplace.json
@@ -24,7 +24,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0192-ensurethattheclusterhasatleastoneactivepolicycontrolmechanisminplace.json
+++ b/controls/C-0192-ensurethattheclusterhasatleastoneactivepolicycontrolmechanisminplace.json
@@ -24,7 +24,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0193-minimizetheadmissionofprivilegedcontainers.json
+++ b/controls/C-0193-minimizetheadmissionofprivilegedcontainers.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0193-minimizetheadmissionofprivilegedcontainers.json
+++ b/controls/C-0193-minimizetheadmissionofprivilegedcontainers.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0194-minimizetheadmissionofcontainerswishingtosharethehostprocessidnamespace.json
+++ b/controls/C-0194-minimizetheadmissionofcontainerswishingtosharethehostprocessidnamespace.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0194-minimizetheadmissionofcontainerswishingtosharethehostprocessidnamespace.json
+++ b/controls/C-0194-minimizetheadmissionofcontainerswishingtosharethehostprocessidnamespace.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0195-minimizetheadmissionofcontainerswishingtosharethehostipcnamespace.json
+++ b/controls/C-0195-minimizetheadmissionofcontainerswishingtosharethehostipcnamespace.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0195-minimizetheadmissionofcontainerswishingtosharethehostipcnamespace.json
+++ b/controls/C-0195-minimizetheadmissionofcontainerswishingtosharethehostipcnamespace.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0196-minimizetheadmissionofcontainerswishingtosharethehostnetworknamespace.json
+++ b/controls/C-0196-minimizetheadmissionofcontainerswishingtosharethehostnetworknamespace.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0196-minimizetheadmissionofcontainerswishingtosharethehostnetworknamespace.json
+++ b/controls/C-0196-minimizetheadmissionofcontainerswishingtosharethehostnetworknamespace.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0197-minimizetheadmissionofcontainerswithallowprivilegeescalation.json
+++ b/controls/C-0197-minimizetheadmissionofcontainerswithallowprivilegeescalation.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0197-minimizetheadmissionofcontainerswithallowprivilegeescalation.json
+++ b/controls/C-0197-minimizetheadmissionofcontainerswithallowprivilegeescalation.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0198-minimizetheadmissionofrootcontainers.json
+++ b/controls/C-0198-minimizetheadmissionofrootcontainers.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0198-minimizetheadmissionofrootcontainers.json
+++ b/controls/C-0198-minimizetheadmissionofrootcontainers.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0199-minimizetheadmissionofcontainerswiththenet_rawcapability.json
+++ b/controls/C-0199-minimizetheadmissionofcontainerswiththenet_rawcapability.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0199-minimizetheadmissionofcontainerswiththenet_rawcapability.json
+++ b/controls/C-0199-minimizetheadmissionofcontainerswiththenet_rawcapability.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0200-minimizetheadmissionofcontainerswithaddedcapabilities.json
+++ b/controls/C-0200-minimizetheadmissionofcontainerswithaddedcapabilities.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0200-minimizetheadmissionofcontainerswithaddedcapabilities.json
+++ b/controls/C-0200-minimizetheadmissionofcontainerswithaddedcapabilities.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0201-minimizetheadmissionofcontainerswithcapabilitiesassigned.json
+++ b/controls/C-0201-minimizetheadmissionofcontainerswithcapabilitiesassigned.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0201-minimizetheadmissionofcontainerswithcapabilitiesassigned.json
+++ b/controls/C-0201-minimizetheadmissionofcontainerswithcapabilitiesassigned.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0202-minimizetheadmissionofwindowshostprocesscontainers.json
+++ b/controls/C-0202-minimizetheadmissionofwindowshostprocesscontainers.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-          "cluster"
+          "cluster",
+          "file"
         ]
       }
 }

--- a/controls/C-0202-minimizetheadmissionofwindowshostprocesscontainers.json
+++ b/controls/C-0202-minimizetheadmissionofwindowshostprocesscontainers.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-          "cloud"
+          "cluster"
         ]
       }
 }

--- a/controls/C-0203-minimizetheadmissionofhostpathvolumes.json
+++ b/controls/C-0203-minimizetheadmissionofhostpathvolumes.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0203-minimizetheadmissionofhostpathvolumes.json
+++ b/controls/C-0203-minimizetheadmissionofhostpathvolumes.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0204-minimizetheadmissionofcontainerswhichusehostports.json
+++ b/controls/C-0204-minimizetheadmissionofcontainerswhichusehostports.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0204-minimizetheadmissionofcontainerswhichusehostports.json
+++ b/controls/C-0204-minimizetheadmissionofcontainerswhichusehostports.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0205-ensurethatthecniinusesupportsnetworkpolicies.json
+++ b/controls/C-0205-ensurethatthecniinusesupportsnetworkpolicies.json
@@ -22,7 +22,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0206-ensurethatallnamespaceshavenetworkpoliciesdefined.json
+++ b/controls/C-0206-ensurethatallnamespaceshavenetworkpoliciesdefined.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0206-ensurethatallnamespaceshavenetworkpoliciesdefined.json
+++ b/controls/C-0206-ensurethatallnamespaceshavenetworkpoliciesdefined.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0207-preferusingsecretsasfilesoversecretsasenvironmentvariables.json
+++ b/controls/C-0207-preferusingsecretsasfilesoversecretsasenvironmentvariables.json
@@ -26,7 +26,7 @@
     },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0207-preferusingsecretsasfilesoversecretsasenvironmentvariables.json
+++ b/controls/C-0207-preferusingsecretsasfilesoversecretsasenvironmentvariables.json
@@ -26,7 +26,8 @@
     },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0208-considerexternalsecretstorage.json
+++ b/controls/C-0208-considerexternalsecretstorage.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0209-createadministrativeboundariesbetweenresourcesusingnamespaces.json
+++ b/controls/C-0209-createadministrativeboundariesbetweenresourcesusingnamespaces.json
@@ -23,7 +23,7 @@
     "default_value": "By default, Kubernetes starts with two initial namespaces: 1. `default` - The default namespace for objects with no other namespace2. `kube-system` - The namespace for objects created by the Kubernetes system3. `kube-node-lease` - Namespace used for node heartbeats4. `kube-public` - Namespace used for public information in a cluster",
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0210-ensurethattheseccompprofileissettodockerdefaultinyourpoddefinitions.json
+++ b/controls/C-0210-ensurethattheseccompprofileissettodockerdefaultinyourpoddefinitions.json
@@ -23,7 +23,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0210-ensurethattheseccompprofileissettodockerdefaultinyourpoddefinitions.json
+++ b/controls/C-0210-ensurethattheseccompprofileissettodockerdefaultinyourpoddefinitions.json
@@ -23,7 +23,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0211-applysecuritycontexttoyourpodsandcontainers.json
+++ b/controls/C-0211-applysecuritycontexttoyourpodsandcontainers.json
@@ -45,7 +45,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0211-applysecuritycontexttoyourpodsandcontainers.json
+++ b/controls/C-0211-applysecuritycontexttoyourpodsandcontainers.json
@@ -45,7 +45,8 @@
    },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "cluster",
+            "file"
         ]
     }
 }

--- a/controls/C-0212-thedefaultnamespaceshouldnotbeused.json
+++ b/controls/C-0212-thedefaultnamespaceshouldnotbeused.json
@@ -39,7 +39,7 @@
    },
     "scanningScope": {
         "matches": [
-            "cloud"
+            "cluster"
         ]
     }
 }

--- a/rules/exec-into-container/raw.rego
+++ b/rules/exec-into-container/raw.rego
@@ -61,6 +61,7 @@ deny[msga] {
 	msga := {
 		"alertMessage": sprintf("the following %v: %v, can exec into  containers", [subject.kind, subject.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
 		"alertObject": {
@@ -95,6 +96,7 @@ deny[msga] {
     msga := {
 		"alertMessage": sprintf("the following %v: %v, can exec into  containers", [subject.kind, subject.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
   		"alertObject": {

--- a/rules/image-pull-policy-is-not-set-to-always/raw.rego
+++ b/rules/image-pull-policy-is-not-set-to-always/raw.rego
@@ -11,6 +11,7 @@ deny[msga] {
 		"alertMessage": sprintf("container: %v in pod: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, pod.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 2,
+		"reviewPaths": paths,
 		"failedPaths": paths,
 		"fixPaths":[],
 		"alertObject": {
@@ -30,6 +31,7 @@ deny[msga] {
 		"alertMessage": sprintf("container: %v in %v: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 2,
+		"reviewPaths": paths,
 		"failedPaths": paths,
 		"fixPaths":[],
 		"alertObject": {
@@ -48,6 +50,7 @@ deny[msga] {
 		"alertMessage": sprintf("container: %v in cronjob: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 2,
+		"reviewPaths": paths,
 		"failedPaths": paths,
 		"fixPaths":[],
 		"alertObject": {

--- a/rules/immutable-container-filesystem/raw.rego
+++ b/rules/immutable-container-filesystem/raw.rego
@@ -70,8 +70,8 @@ deny[msga] {
 # Default of readOnlyRootFilesystem is false. This field is only in container spec and not pod spec
 is_mutable_filesystem(container, start_of_path, i) = [failed_path, fixPath]  {
 	container.securityContext.readOnlyRootFilesystem == false
-	failed_path = sprintf("%vcontainers[%v].securityContext.readOnlyRootFilesystem", [start_of_path, format_int(i, 10)])
-	fixPath = ""
+	fixPath = {"path": sprintf("%vcontainers[%v].securityContext.readOnlyRootFilesystem", [start_of_path, format_int(i, 10)]), "value": "true"}
+	failed_path = ""
  }
 
  is_mutable_filesystem(container, start_of_path, i)  = [failed_path, fixPath] {

--- a/rules/immutable-container-filesystem/test/workloads/expected.json
+++ b/rules/immutable-container-filesystem/test/workloads/expected.json
@@ -1,7 +1,10 @@
 [{
     "alertMessage": "container :mysql in Deployment: my-deployment has  mutable filesystem",
-    "failedPaths": ["spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem"],
-    "fixPaths": [],
+    "failedPaths": [],
+    "fixPaths": [{
+        "path": "spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem",
+        "value": "true"
+    }],
     "ruleStatus": "",
     "packagename": "armo_builtins",
     "alertScore": 7,

--- a/rules/resources-cpu-limit-and-request/raw.rego
+++ b/rules/resources-cpu-limit-and-request/raw.rego
@@ -1,14 +1,14 @@
 package armo_builtins
 
-# Fails if pod does not have container with CPU-limit or request
+# ==================================== CPU requests =============================================
+# Fails if pod does not have container with CPU request
 deny[msga] {
     pod := input[_]
     pod.kind == "Pod"
     container := pod.spec.containers[i]
-	not request_or_limit_cpu(container)
+	not container.resources.requests.cpu
 
-	fixPaths := [{"path": sprintf("spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"},
-				{"path": sprintf("spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
+	fixPaths := [{"path": sprintf("spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
 		"alertMessage": sprintf("Container: %v does not have CPU-limit or request", [ container.name]),
@@ -22,16 +22,15 @@ deny[msga] {
 	}
 }
 
-# Fails if workload does not have container with CPU-limit or request
+# Fails if workload does not have container with CPU requests
 deny[msga] {
     wl := input[_]
 	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
 	spec_template_spec_patterns[wl.kind]
     container := wl.spec.template.spec.containers[i]
-    not request_or_limit_cpu(container)
+    not container.resources.requests.cpu
 
-	fixPaths := [{"path": sprintf("spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"},
-				{"path": sprintf("spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
+	fixPaths := [{"path": sprintf("spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
 		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
@@ -45,15 +44,14 @@ deny[msga] {
 	}
 }
 
-# Fails if cronjob does not have container with CPU-limit or request
+# Fails if cronjob does not have container with CPU requests
 deny[msga] {
   	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-    not request_or_limit_cpu(container)
+    not container.resources.requests.cpu
 
-	fixPaths := [{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"},
-				{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
+	fixPaths := [{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
     msga := {
 		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
@@ -67,6 +65,70 @@ deny[msga] {
 	}
 }
 
+# ==================================== CPU limits =============================================
+# Fails if pod does not have container with CPU-limits
+deny[msga] {
+    pod := input[_]
+    pod.kind == "Pod"
+    container := pod.spec.containers[i]
+	not container.resources.limits.cpu
+
+	fixPaths := [{"path": sprintf("spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
+
+	msga := {
+		"alertMessage": sprintf("Container: %v does not have CPU-limit or request", [ container.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [],
+		"fixPaths": fixPaths,
+		"alertObject": {
+			"k8sApiObjects": [pod]
+		}
+	}
+}
+
+# Fails if workload does not have container with CPU-limits
+deny[msga] {
+    wl := input[_]
+	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns[wl.kind]
+    container := wl.spec.template.spec.containers[i]
+    not container.resources.limits.cpu
+
+	fixPaths := [{"path": sprintf("spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
+
+	msga := {
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [],
+		"fixPaths": fixPaths,
+		"alertObject": {
+			"k8sApiObjects": [wl]
+		}
+	}
+}
+
+# Fails if cronjob does not have container with CPU-limits
+deny[msga] {
+  	wl := input[_]
+	wl.kind == "CronJob"
+	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
+    not container.resources.limits.cpu
+
+	fixPaths := [{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
+
+    msga := {
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [],
+		"fixPaths": fixPaths,
+		"alertObject": {
+			"k8sApiObjects": [wl]
+		}
+	}
+}
 
 
 

--- a/rules/resources-cpu-limit-and-request/test/cronjob/expected.json
+++ b/rules/resources-cpu-limit-and-request/test/cronjob/expected.json
@@ -2,8 +2,36 @@
     {
         "alertMessage": "Container: hello in CronJob: hello   does not have CPU-limit or request",
         "failedPaths": [],
-        "fixPaths" : [{"path": "spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu", "value": "YOUR_VALUE"}, 
-                        {"path": "spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu", "value": "YOUR_VALUE"}],
+        "fixPaths": [
+            {
+                "path": "spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu",
+                "value": "YOUR_VALUE"
+            }
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "batch/v1beta1",
+                    "kind": "CronJob",
+                    "metadata": {
+                        "name": "hello"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "alertMessage": "Container: hello in CronJob: hello   does not have CPU-limit or request",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu",
+                "value": "YOUR_VALUE"
+            }
+        ],
         "ruleStatus": "",
         "packagename": "armo_builtins",
         "alertScore": 7,

--- a/rules/resources-cpu-limit-and-request/test/pod-only-limits/expected.json
+++ b/rules/resources-cpu-limit-and-request/test/pod-only-limits/expected.json
@@ -1,0 +1,22 @@
+[
+    {
+        "alertMessage": "Container: log-aggregator does not have CPU-limit or request",
+        "failedPaths": [],
+        "fixPaths" : [{"path":"spec.containers[1].resources.limits.cpu", "value": "YOUR_VALUE"}],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "frontend"
+                    }
+                }
+            ]
+        }
+    }
+]
+

--- a/rules/resources-cpu-limit-and-request/test/pod-only-limits/input/pod.yaml
+++ b/rules/resources-cpu-limit-and-request/test/pod-only-limits/input/pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+  - name: log-aggregator
+    image: images.my-company.example/log-aggregator:v6
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"

--- a/rules/resources-cpu-limit-and-request/test/pod-only-requests/expected.json
+++ b/rules/resources-cpu-limit-and-request/test/pod-only-requests/expected.json
@@ -1,0 +1,21 @@
+[
+    {
+        "alertMessage": "Container: log-aggregator does not have CPU-limit or request",
+        "failedPaths": [],
+        "fixPaths" : [{"path": "spec.containers[1].resources.requests.cpu", "value": "YOUR_VALUE"}],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "frontend"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/resources-cpu-limit-and-request/test/pod-only-requests/input/pod.yaml
+++ b/rules/resources-cpu-limit-and-request/test/pod-only-requests/input/pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+  - name: log-aggregator
+    image: images.my-company.example/log-aggregator:v6
+    resources:
+      requests:
+        memory: "64Mi"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"

--- a/rules/resources-cpu-limit-and-request/test/pod/expected.json
+++ b/rules/resources-cpu-limit-and-request/test/pod/expected.json
@@ -2,8 +2,36 @@
     {
         "alertMessage": "Container: log-aggregator does not have CPU-limit or request",
         "failedPaths": [],
-        "fixPaths" : [{"path":"spec.containers[1].resources.limits.cpu", "value": "YOUR_VALUE"}, 
-                    {"path": "spec.containers[1].resources.requests.cpu", "value": "YOUR_VALUE"}],
+        "fixPaths": [
+            {
+                "path": "spec.containers[1].resources.limits.cpu",
+                "value": "YOUR_VALUE"
+            }
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "frontend"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "alertMessage": "Container: log-aggregator does not have CPU-limit or request",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.containers[1].resources.requests.cpu",
+                "value": "YOUR_VALUE"
+            }
+        ],
         "ruleStatus": "",
         "packagename": "armo_builtins",
         "alertScore": 7,

--- a/rules/resources-cpu-limit-and-request/test/workload/expected.json
+++ b/rules/resources-cpu-limit-and-request/test/workload/expected.json
@@ -1,26 +1,56 @@
-[{
-    "alertMessage": "Container: app in Deployment: test   does not have CPU-limit or request",
-    "failedPaths": [],
-    "fixPaths": [{
-        "path": "spec.template.spec.containers[0].resources.limits.cpu",
-        "value": "YOUR_VALUE"
-    }, {
-        "path": "spec.template.spec.containers[0].resources.requests.cpu",
-        "value": "YOUR_VALUE"
-    }],
-    "ruleStatus": "",
-    "packagename": "armo_builtins",
-    "alertScore": 7,
-    "alertObject": {
-        "k8sApiObjects": [{
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "metadata": {
-                "labels": {
-                    "purpose": "demonstrate-command"
-                },
-                "name": "test"
+[
+    {
+        "alertMessage": "Container: app in Deployment: test   does not have CPU-limit or request",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.template.spec.containers[0].resources.limits.cpu",
+                "value": "YOUR_VALUE"
             }
-        }]
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "purpose": "demonstrate-command"
+                        },
+                        "name": "test"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "alertMessage": "Container: app in Deployment: test   does not have CPU-limit or request",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.template.spec.containers[0].resources.requests.cpu",
+                "value": "YOUR_VALUE"
+            }
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "purpose": "demonstrate-command"
+                        },
+                        "name": "test"
+                    }
+                }
+            ]
+        }
     }
-}]
+]

--- a/rules/resources-memory-limit-and-request/test/cronjob/expected.json
+++ b/rules/resources-memory-limit-and-request/test/cronjob/expected.json
@@ -6,7 +6,27 @@
          {
             "path": "spec.jobTemplate.spec.template.spec.containers[0].resources.limits.memory",
             "value": "YOUR_VALUE"
-         },
+         }
+      ],
+      "ruleStatus": "",
+      "packagename": "armo_builtins",
+      "alertScore": 7,
+      "alertObject": {
+         "k8sApiObjects": [
+            {
+               "apiVersion": "batch/v1beta1",
+               "kind": "CronJob",
+               "metadata": {
+                  "name": "hello"
+               }
+            }
+         ]
+      }
+   },
+   {
+      "alertMessage": "Container: hello in CronJob: hello   does not have memory-limit or request",
+      "failedPaths": [],
+      "fixPaths": [
          {
             "path": "spec.jobTemplate.spec.template.spec.containers[0].resources.requests.memory",
             "value": "YOUR_VALUE"

--- a/rules/resources-memory-limit-and-request/test/pod-only-limits/expected.json
+++ b/rules/resources-memory-limit-and-request/test/pod-only-limits/expected.json
@@ -1,0 +1,20 @@
+[{
+    "alertMessage": "Container: log-aggregator does not have memory-limit or request",
+    "failedPaths": [],
+    "fixPaths": [{
+        "path": "spec.containers[1].resources.limits.memory",
+        "value": "YOUR_VALUE"
+    }],
+    "ruleStatus": "",
+    "packagename": "armo_builtins",
+    "alertScore": 7,
+    "alertObject": {
+        "k8sApiObjects": [{
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "frontend"
+            }
+        }]
+    }
+}]

--- a/rules/resources-memory-limit-and-request/test/pod-only-limits/input/pod.yaml
+++ b/rules/resources-memory-limit-and-request/test/pod-only-limits/input/pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+  - name: log-aggregator
+    image: images.my-company.example/log-aggregator:v6
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        cpu: "500m"

--- a/rules/resources-memory-limit-and-request/test/pod-only-requests/expected.json
+++ b/rules/resources-memory-limit-and-request/test/pod-only-requests/expected.json
@@ -1,0 +1,20 @@
+[{
+    "alertMessage": "Container: log-aggregator does not have memory-limit or request",
+    "failedPaths": [],
+    "fixPaths": [{
+        "path": "spec.containers[1].resources.requests.memory",
+        "value": "YOUR_VALUE"
+    }],
+    "ruleStatus": "",
+    "packagename": "armo_builtins",
+    "alertScore": 7,
+    "alertObject": {
+        "k8sApiObjects": [{
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "frontend"
+            }
+        }]
+    }
+}]

--- a/rules/resources-memory-limit-and-request/test/pod-only-requests/input/pod.yaml
+++ b/rules/resources-memory-limit-and-request/test/pod-only-requests/input/pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+  - name: log-aggregator
+    image: images.my-company.example/log-aggregator:v6
+    resources:
+      requests:
+         cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"

--- a/rules/resources-memory-limit-and-request/test/pod/expected.json
+++ b/rules/resources-memory-limit-and-request/test/pod/expected.json
@@ -1,23 +1,50 @@
-[{
-    "alertMessage": "Container: log-aggregator does not have memory-limit or request",
-    "failedPaths": [],
-    "fixPaths": [{
-        "path": "spec.containers[1].resources.limits.memory",
-        "value": "YOUR_VALUE"
-    }, {
-        "path": "spec.containers[1].resources.requests.memory",
-        "value": "YOUR_VALUE"
-    }],
-    "ruleStatus": "",
-    "packagename": "armo_builtins",
-    "alertScore": 7,
-    "alertObject": {
-        "k8sApiObjects": [{
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {
-                "name": "frontend"
+[
+    {
+        "alertMessage": "Container: log-aggregator does not have memory-limit or request",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.containers[1].resources.limits.memory",
+                "value": "YOUR_VALUE"
             }
-        }]
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "frontend"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "alertMessage": "Container: log-aggregator does not have memory-limit or request",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.containers[1].resources.requests.memory",
+                "value": "YOUR_VALUE"
+            }
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "frontend"
+                    }
+                }
+            ]
+        }
     }
-}]
+]

--- a/rules/resources-memory-limit-and-request/test/workload/expected.json
+++ b/rules/resources-memory-limit-and-request/test/workload/expected.json
@@ -6,7 +6,30 @@
          {
             "path": "spec.template.spec.containers[0].resources.limits.memory",
             "value": "YOUR_VALUE"
-         },
+         }
+      ],
+      "ruleStatus": "",
+      "packagename": "armo_builtins",
+      "alertScore": 7,
+      "alertObject": {
+         "k8sApiObjects": [
+            {
+               "apiVersion": "apps/v1",
+               "kind": "Deployment",
+               "metadata": {
+                  "labels": {
+                     "purpose": "demonstrate-command"
+                  },
+                  "name": "test"
+               }
+            }
+         ]
+      }
+   },
+   {
+      "alertMessage": "Container: app in Deployment: test   does not have memory-limit or request",
+      "failedPaths": [],
+      "fixPaths": [
          {
             "path": "spec.template.spec.containers[0].resources.requests.memory",
             "value": "YOUR_VALUE"

--- a/rules/rule-can-impersonate-users-groups/raw.rego
+++ b/rules/rule-can-impersonate-users-groups/raw.rego
@@ -53,6 +53,7 @@ deny[msga] {
 	msga := {
 		"alertMessage": sprintf("the following %v: %v,  can impersonate users", [subject.kind, subject.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
 		"alertObject": {
@@ -85,6 +86,7 @@ deny[msga] {
     msga := {
 		"alertMessage": sprintf("the following %v: %v, can impersonate users", [subject.kind, subject.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
   		"alertObject": {

--- a/rules/rule-can-list-get-secrets/raw.rego
+++ b/rules/rule-can-list-get-secrets/raw.rego
@@ -59,6 +59,7 @@ deny[msga] {
 	    "alertMessage": sprintf("The following %v: %v can read secrets", [subject.kind, subject.name]),
 		"alertScore": 9,
 		"packagename": "armo_builtins",
+		"deletePaths": [path],
        "failedPaths": [path],
           "alertObject": {
 			"k8sApiObjects": [role,rolebinding],
@@ -91,6 +92,7 @@ deny[msga] {
 	    "alertMessage": sprintf("The following %v: %v can read secrets", [subject.kind, subject.name]),
 		"alertScore": 9,
 		"packagename": "armo_builtins",
+		"deletePaths": [path],
        "failedPaths": [path],
         "alertObject": {
 			"k8sApiObjects": [role,clusterrolebinding],

--- a/rules/rule-can-portforward/raw.rego
+++ b/rules/rule-can-portforward/raw.rego
@@ -53,6 +53,7 @@ deny[msga] {
 	msga := {
 		"alertMessage": sprintf("the following %v: %v, can do port forwarding", [subject.kind, subject.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
 		"alertObject": {
@@ -85,6 +86,7 @@ deny[msga] {
     msga := {
 		"alertMessage": sprintf("the following %v: %v, can do port forwarding", [subject.kind, subject.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
   		"alertObject": {

--- a/rules/rule-can-ssh-to-pod/raw.rego
+++ b/rules/rule-can-ssh-to-pod/raw.rego
@@ -49,6 +49,7 @@ deny[msga] {
 		"alertMessage": sprintf("%v: %v is exposed by SSH services: %v", [wl.kind, wl.metadata.name, service]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
+		"deletePaths": [path],
 		"failedPaths": [path],
         "alertObject": {
 			"k8sApiObjects": [wl,service]
@@ -72,6 +73,7 @@ deny[msga] {
 		"alertMessage": sprintf("%v: %v is exposed by SSH services: %v", [wl.kind, wl.metadata.name, service]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
+		"deletePaths": [path],
 		"failedPaths": [path],
         "alertObject": {
 			"k8sApiObjects": [wl,service]

--- a/rules/rule-can-update-configmap/raw.rego
+++ b/rules/rule-can-update-configmap/raw.rego
@@ -71,6 +71,7 @@ deny[msga] {
     	msga := {
 	     "alertMessage": sprintf("The following %v: %v can modify 'coredns' configmap", [subject.kind, subject.name]),
 		"alertScore": 6,
+		"deletePaths": [path],
          "failedPaths": [path],
 		"packagename": "armo_builtins",
           "alertObject": {
@@ -112,6 +113,7 @@ deny[msga] {
     	msga := {
 	     "alertMessage": sprintf("The following %v: %v can modify 'coredns'  configmap", [subject.kind, subject.name]),
 		"alertScore": 6,
+		"deletePaths": [path],
          "failedPaths": [path],
 		"packagename": "armo_builtins",
           "alertObject": {

--- a/rules/rule-credentials-in-env-var/raw.rego
+++ b/rules/rule-credentials-in-env-var/raw.rego
@@ -55,6 +55,7 @@
 			"alertMessage": sprintf("%v: %v has sensitive information in environment variables", [wl.kind, wl.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
+			"deletePaths": [path],
 			"failedPaths": [path],
 			"packagename": "armo_builtins",
 			"alertObject": {
@@ -86,6 +87,7 @@
 			"alertMessage": sprintf("Cronjob: %v has sensitive information in environment variables", [wl.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
+			"deletePaths": [path],
 			"failedPaths": [path],
 			"packagename": "armo_builtins",
 			"alertObject": {
@@ -116,6 +118,7 @@ deny[msga] {
 			"alertMessage": sprintf("Pod: %v has sensitive information in environment variables", [pod.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
+			"deletePaths": [path],
 			"failedPaths": [path],
 			"packagename": "armo_builtins",
 			"alertObject": {
@@ -147,6 +150,7 @@ deny[msga] {
 			"alertMessage": sprintf("%v: %v has sensitive information in environment variables", [wl.kind, wl.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
+			"deletePaths": [path],
 			"failedPaths": [path],
 			"packagename": "armo_builtins",
 			"alertObject": {
@@ -176,6 +180,7 @@ deny[msga] {
 			"alertMessage": sprintf("Cronjob: %v has sensitive information in environment variables", [wl.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
+			"deletePaths": [path],
 			"failedPaths": [path],
 			"packagename": "armo_builtins",
 			"alertObject": {


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR addresses the issue of changing the scanning scope from 'cloud' to 'cluster' in various CIS controls. This change is reflected in multiple JSON files under the 'controls' directory. The change is aimed at enhancing the accuracy and relevance of the scanning process.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`controls/C-0188-minimizeaccesstocreatepods.json`: Changed the scanning scope from 'cloud' to 'cluster'.
`controls/C-0186-minimizeaccesstosecrets.json`: Changed the scanning scope from 'cloud' to 'cluster'.
`controls/C-0146-ensurethatthecontrollermanageruseserviceaccountcredentialsargumentissettotrue.json`: Changed the scanning scope from 'cloud' to 'cluster'.
`controls/C-0123-ensurethattheadmissioncontrolpluginalwayspullimagesisset.json`: Changed the scanning scope from 'cloud' to 'cluster'.
`controls/C-0209-createadministrativeboundariesbetweenresourcesusingnamespaces.json`: Changed the scanning scope from 'cloud' to 'cluster'.
`controls/C-0158-ensurethatthepeerautotlsargumentisnotsettotrue.json`: Changed the scanning scope from 'cloud' to 'cluster'.
`controls/C-0157-ensurethatthepeerclientcertauthargumentissettotrue.json`: Changed the scanning scope from 'cloud' to 'cluster'.
`controls/C-0191-limituseofthebindimpersonateandescalatepermissionsinthekubernetescluster.json`: Changed the scanning scope from 'cloud' to 'cluster'.
`controls/C-0156-ensurethatthepeercertfileandpeerkeyfileargumentsaresetasappropriate.json`: Changed the scanning scope from 'cloud' to 'cluster'.
`controls/C-0175-verifythatthereadonlyportargumentissetto0.json`: Changed the scanning scope from 'cloud' to 'cluster'.
</details>

___
## User Description:
https://github.com/kubescape/kubescape/issues/1420
