### PR TITLE
C-0004 & C-0050 - fix only missing configurations

### DIFF
--- a/rules/resources-cpu-limit-and-request/raw.rego
+++ b/rules/resources-cpu-limit-and-request/raw.rego
@@ -1,14 +1,14 @@
 package armo_builtins
 
-# Fails if pod does not have container with CPU-limit or request
+# ==================================== CPU requests =============================================
+# Fails if pod does not have container with CPU request
 deny[msga] {
     pod := input[_]
     pod.kind == "Pod"
     container := pod.spec.containers[i]
-	not request_or_limit_cpu(container)
+	not container.resources.requests.cpu
 
-	fixPaths := [{"path": sprintf("spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"},
-				{"path": sprintf("spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
+	fixPaths := [{"path": sprintf("spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
 		"alertMessage": sprintf("Container: %v does not have CPU-limit or request", [ container.name]),
@@ -22,16 +22,15 @@ deny[msga] {
 	}
 }
 
-# Fails if workload does not have container with CPU-limit or request
+# Fails if workload does not have container with CPU requests
 deny[msga] {
     wl := input[_]
 	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
 	spec_template_spec_patterns[wl.kind]
     container := wl.spec.template.spec.containers[i]
-    not request_or_limit_cpu(container)
+    not container.resources.requests.cpu
 
-	fixPaths := [{"path": sprintf("spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"},
-				{"path": sprintf("spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
+	fixPaths := [{"path": sprintf("spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
 		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
@@ -45,15 +44,14 @@ deny[msga] {
 	}
 }
 
-# Fails if cronjob does not have container with CPU-limit or request
+# Fails if cronjob does not have container with CPU requests
 deny[msga] {
   	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-    not request_or_limit_cpu(container)
+    not container.resources.requests.cpu
 
-	fixPaths := [{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"},
-				{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
+	fixPaths := [{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
     msga := {
 		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
@@ -67,6 +65,70 @@ deny[msga] {
 	}
 }
 
+# ==================================== CPU limits =============================================
+# Fails if pod does not have container with CPU-limits
+deny[msga] {
+    pod := input[_]
+    pod.kind == "Pod"
+    container := pod.spec.containers[i]
+	not container.resources.limits.cpu
+
+	fixPaths := [{"path": sprintf("spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
+
+	msga := {
+		"alertMessage": sprintf("Container: %v does not have CPU-limit or request", [ container.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [],
+		"fixPaths": fixPaths,
+		"alertObject": {
+			"k8sApiObjects": [pod]
+		}
+	}
+}
+
+# Fails if workload does not have container with CPU-limits
+deny[msga] {
+    wl := input[_]
+	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns[wl.kind]
+    container := wl.spec.template.spec.containers[i]
+    not container.resources.limits.cpu
+
+	fixPaths := [{"path": sprintf("spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
+
+	msga := {
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [],
+		"fixPaths": fixPaths,
+		"alertObject": {
+			"k8sApiObjects": [wl]
+		}
+	}
+}
+
+# Fails if cronjob does not have container with CPU-limits
+deny[msga] {
+  	wl := input[_]
+	wl.kind == "CronJob"
+	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
+    not container.resources.limits.cpu
+
+	fixPaths := [{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
+
+    msga := {
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [],
+		"fixPaths": fixPaths,
+		"alertObject": {
+			"k8sApiObjects": [wl]
+		}
+	}
+}
 
 
 

--- a/rules/resources-cpu-limit-and-request/test/cronjob/expected.json
+++ b/rules/resources-cpu-limit-and-request/test/cronjob/expected.json
@@ -2,8 +2,36 @@
     {
         "alertMessage": "Container: hello in CronJob: hello   does not have CPU-limit or request",
         "failedPaths": [],
-        "fixPaths" : [{"path": "spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu", "value": "YOUR_VALUE"}, 
-                        {"path": "spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu", "value": "YOUR_VALUE"}],
+        "fixPaths": [
+            {
+                "path": "spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu",
+                "value": "YOUR_VALUE"
+            }
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "batch/v1beta1",
+                    "kind": "CronJob",
+                    "metadata": {
+                        "name": "hello"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "alertMessage": "Container: hello in CronJob: hello   does not have CPU-limit or request",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu",
+                "value": "YOUR_VALUE"
+            }
+        ],
         "ruleStatus": "",
         "packagename": "armo_builtins",
         "alertScore": 7,

--- a/rules/resources-cpu-limit-and-request/test/pod-only-limits/expected.json
+++ b/rules/resources-cpu-limit-and-request/test/pod-only-limits/expected.json
@@ -1,0 +1,22 @@
+[
+    {
+        "alertMessage": "Container: log-aggregator does not have CPU-limit or request",
+        "failedPaths": [],
+        "fixPaths" : [{"path":"spec.containers[1].resources.limits.cpu", "value": "YOUR_VALUE"}],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "frontend"
+                    }
+                }
+            ]
+        }
+    }
+]
+

--- a/rules/resources-cpu-limit-and-request/test/pod-only-limits/input/pod.yaml
+++ b/rules/resources-cpu-limit-and-request/test/pod-only-limits/input/pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+  - name: log-aggregator
+    image: images.my-company.example/log-aggregator:v6
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"

--- a/rules/resources-cpu-limit-and-request/test/pod-only-requests/expected.json
+++ b/rules/resources-cpu-limit-and-request/test/pod-only-requests/expected.json
@@ -1,0 +1,21 @@
+[
+    {
+        "alertMessage": "Container: log-aggregator does not have CPU-limit or request",
+        "failedPaths": [],
+        "fixPaths" : [{"path": "spec.containers[1].resources.requests.cpu", "value": "YOUR_VALUE"}],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "frontend"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/resources-cpu-limit-and-request/test/pod-only-requests/input/pod.yaml
+++ b/rules/resources-cpu-limit-and-request/test/pod-only-requests/input/pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+  - name: log-aggregator
+    image: images.my-company.example/log-aggregator:v6
+    resources:
+      requests:
+        memory: "64Mi"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"

--- a/rules/resources-cpu-limit-and-request/test/pod/expected.json
+++ b/rules/resources-cpu-limit-and-request/test/pod/expected.json
@@ -2,8 +2,36 @@
     {
         "alertMessage": "Container: log-aggregator does not have CPU-limit or request",
         "failedPaths": [],
-        "fixPaths" : [{"path":"spec.containers[1].resources.limits.cpu", "value": "YOUR_VALUE"}, 
-                    {"path": "spec.containers[1].resources.requests.cpu", "value": "YOUR_VALUE"}],
+        "fixPaths": [
+            {
+                "path": "spec.containers[1].resources.limits.cpu",
+                "value": "YOUR_VALUE"
+            }
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "frontend"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "alertMessage": "Container: log-aggregator does not have CPU-limit or request",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.containers[1].resources.requests.cpu",
+                "value": "YOUR_VALUE"
+            }
+        ],
         "ruleStatus": "",
         "packagename": "armo_builtins",
         "alertScore": 7,

--- a/rules/resources-cpu-limit-and-request/test/workload/expected.json
+++ b/rules/resources-cpu-limit-and-request/test/workload/expected.json
@@ -1,26 +1,56 @@
-[{
-    "alertMessage": "Container: app in Deployment: test   does not have CPU-limit or request",
-    "failedPaths": [],
-    "fixPaths": [{
-        "path": "spec.template.spec.containers[0].resources.limits.cpu",
-        "value": "YOUR_VALUE"
-    }, {
-        "path": "spec.template.spec.containers[0].resources.requests.cpu",
-        "value": "YOUR_VALUE"
-    }],
-    "ruleStatus": "",
-    "packagename": "armo_builtins",
-    "alertScore": 7,
-    "alertObject": {
-        "k8sApiObjects": [{
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "metadata": {
-                "labels": {
-                    "purpose": "demonstrate-command"
-                },
-                "name": "test"
+[
+    {
+        "alertMessage": "Container: app in Deployment: test   does not have CPU-limit or request",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.template.spec.containers[0].resources.limits.cpu",
+                "value": "YOUR_VALUE"
             }
-        }]
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "purpose": "demonstrate-command"
+                        },
+                        "name": "test"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "alertMessage": "Container: app in Deployment: test   does not have CPU-limit or request",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.template.spec.containers[0].resources.requests.cpu",
+                "value": "YOUR_VALUE"
+            }
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "purpose": "demonstrate-command"
+                        },
+                        "name": "test"
+                    }
+                }
+            ]
+        }
     }
-}]
+]

--- a/rules/resources-memory-limit-and-request/test/cronjob/expected.json
+++ b/rules/resources-memory-limit-and-request/test/cronjob/expected.json
@@ -6,7 +6,27 @@
          {
             "path": "spec.jobTemplate.spec.template.spec.containers[0].resources.limits.memory",
             "value": "YOUR_VALUE"
-         },
+         }
+      ],
+      "ruleStatus": "",
+      "packagename": "armo_builtins",
+      "alertScore": 7,
+      "alertObject": {
+         "k8sApiObjects": [
+            {
+               "apiVersion": "batch/v1beta1",
+               "kind": "CronJob",
+               "metadata": {
+                  "name": "hello"
+               }
+            }
+         ]
+      }
+   },
+   {
+      "alertMessage": "Container: hello in CronJob: hello   does not have memory-limit or request",
+      "failedPaths": [],
+      "fixPaths": [
          {
             "path": "spec.jobTemplate.spec.template.spec.containers[0].resources.requests.memory",
             "value": "YOUR_VALUE"

--- a/rules/resources-memory-limit-and-request/test/pod-only-limits/expected.json
+++ b/rules/resources-memory-limit-and-request/test/pod-only-limits/expected.json
@@ -1,0 +1,20 @@
+[{
+    "alertMessage": "Container: log-aggregator does not have memory-limit or request",
+    "failedPaths": [],
+    "fixPaths": [{
+        "path": "spec.containers[1].resources.limits.memory",
+        "value": "YOUR_VALUE"
+    }],
+    "ruleStatus": "",
+    "packagename": "armo_builtins",
+    "alertScore": 7,
+    "alertObject": {
+        "k8sApiObjects": [{
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "frontend"
+            }
+        }]
+    }
+}]

--- a/rules/resources-memory-limit-and-request/test/pod-only-limits/input/pod.yaml
+++ b/rules/resources-memory-limit-and-request/test/pod-only-limits/input/pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+  - name: log-aggregator
+    image: images.my-company.example/log-aggregator:v6
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        cpu: "500m"

--- a/rules/resources-memory-limit-and-request/test/pod-only-requests/expected.json
+++ b/rules/resources-memory-limit-and-request/test/pod-only-requests/expected.json
@@ -1,0 +1,20 @@
+[{
+    "alertMessage": "Container: log-aggregator does not have memory-limit or request",
+    "failedPaths": [],
+    "fixPaths": [{
+        "path": "spec.containers[1].resources.requests.memory",
+        "value": "YOUR_VALUE"
+    }],
+    "ruleStatus": "",
+    "packagename": "armo_builtins",
+    "alertScore": 7,
+    "alertObject": {
+        "k8sApiObjects": [{
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "frontend"
+            }
+        }]
+    }
+}]

--- a/rules/resources-memory-limit-and-request/test/pod-only-requests/input/pod.yaml
+++ b/rules/resources-memory-limit-and-request/test/pod-only-requests/input/pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+  - name: log-aggregator
+    image: images.my-company.example/log-aggregator:v6
+    resources:
+      requests:
+         cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"

--- a/rules/resources-memory-limit-and-request/test/pod/expected.json
+++ b/rules/resources-memory-limit-and-request/test/pod/expected.json
@@ -1,23 +1,50 @@
-[{
-    "alertMessage": "Container: log-aggregator does not have memory-limit or request",
-    "failedPaths": [],
-    "fixPaths": [{
-        "path": "spec.containers[1].resources.limits.memory",
-        "value": "YOUR_VALUE"
-    }, {
-        "path": "spec.containers[1].resources.requests.memory",
-        "value": "YOUR_VALUE"
-    }],
-    "ruleStatus": "",
-    "packagename": "armo_builtins",
-    "alertScore": 7,
-    "alertObject": {
-        "k8sApiObjects": [{
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {
-                "name": "frontend"
+[
+    {
+        "alertMessage": "Container: log-aggregator does not have memory-limit or request",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.containers[1].resources.limits.memory",
+                "value": "YOUR_VALUE"
             }
-        }]
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "frontend"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "alertMessage": "Container: log-aggregator does not have memory-limit or request",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.containers[1].resources.requests.memory",
+                "value": "YOUR_VALUE"
+            }
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "frontend"
+                    }
+                }
+            ]
+        }
     }
-}]
+]

--- a/rules/resources-memory-limit-and-request/test/workload/expected.json
+++ b/rules/resources-memory-limit-and-request/test/workload/expected.json
@@ -6,7 +6,30 @@
          {
             "path": "spec.template.spec.containers[0].resources.limits.memory",
             "value": "YOUR_VALUE"
-         },
+         }
+      ],
+      "ruleStatus": "",
+      "packagename": "armo_builtins",
+      "alertScore": 7,
+      "alertObject": {
+         "k8sApiObjects": [
+            {
+               "apiVersion": "apps/v1",
+               "kind": "Deployment",
+               "metadata": {
+                  "labels": {
+                     "purpose": "demonstrate-command"
+                  },
+                  "name": "test"
+               }
+            }
+         ]
+      }
+   },
+   {
+      "alertMessage": "Container: app in Deployment: test   does not have memory-limit or request",
+      "failedPaths": [],
+      "fixPaths": [
          {
             "path": "spec.template.spec.containers[0].resources.requests.memory",
             "value": "YOUR_VALUE"


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses a bug where controls were sending a fixpath for both `resources.limits.cpu/memory` and `resources.requests.cpu/memory` even if only one was missing. The changes now ensure that only the missing path is sent. This is achieved by separating the checks for CPU and memory limits and requests in the `raw.rego` files. The PR also includes updates to the corresponding test files to reflect these changes.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`rules/resources-memory-limit-and-request/raw.rego`: The checks for memory limits and requests have been separated. Previously, the checks for memory limits and requests were combined, and if either was missing, a fixpath for both would be sent. Now, separate checks are performed for memory limits and requests, and only the missing path is sent.
`rules/resources-cpu-limit-and-request/raw.rego`: Similar to the changes in the memory limit and request checks, the checks for CPU limits and requests have been separated. This ensures that only the missing path is sent if either the CPU limit or request is missing.
`rules/resources-memory-limit-and-request/test/pod/expected.json`: The expected test results have been updated to reflect the changes in the memory limit and request checks. Separate alerts are now expected for missing memory limits and requests.
`rules/resources-cpu-limit-and-request/test/pod/expected.json`: The expected test results have been updated to reflect the changes in the CPU limit and request checks. Separate alerts are now expected for missing CPU limits and requests.
`rules/resources-memory-limit-and-request/test/workload/expected.json`: The expected test results for workload have been updated to reflect the changes in the memory limit and request checks. Separate alerts are now expected for missing memory limits and requests in workloads.
`rules/resources-cpu-limit-and-request/test/workload/expected.json`: The expected test results for workload have been updated to reflect the changes in the CPU limit and request checks. Separate alerts are now expected for missing CPU limits and requests in workloads.
`rules/resources-memory-limit-and-request/test/cronjob/expected.json`: The expected test results for cronjob have been updated to reflect the changes in the memory limit and request checks. Separate alerts are now expected for missing memory limits and requests in cronjobs.
`rules/resources-cpu-limit-and-request/test/cronjob/expected.json`: The expected test results for cronjob have been updated to reflect the changes in the CPU limit and request checks. Separate alerts are now expected for missing CPU limits and requests in cronjobs.
</details>

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
This PR fixes the bug [SUB-2918](https://cyberarmor-io.atlassian.net/browse/SUB-2918) - these controls were sending a fixpath for both `resources.limits.cpu/memory` and `resources.requests.cpu/memory` even if only one was missing. They will now only send the missing path.
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->
