### PR TITLE
add missing paths

### DIFF
--- a/rules/exec-into-container/raw.rego
+++ b/rules/exec-into-container/raw.rego
@@ -61,6 +61,7 @@ deny[msga] {
 	msga := {
 		"alertMessage": sprintf("the following %v: %v, can exec into  containers", [subject.kind, subject.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
 		"alertObject": {
@@ -95,6 +96,7 @@ deny[msga] {
     msga := {
 		"alertMessage": sprintf("the following %v: %v, can exec into  containers", [subject.kind, subject.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
   		"alertObject": {

--- a/rules/image-pull-policy-is-not-set-to-always/raw.rego
+++ b/rules/image-pull-policy-is-not-set-to-always/raw.rego
@@ -11,6 +11,7 @@ deny[msga] {
 		"alertMessage": sprintf("container: %v in pod: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, pod.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 2,
+		"reviewPaths": paths,
 		"failedPaths": paths,
 		"fixPaths":[],
 		"alertObject": {
@@ -30,6 +31,7 @@ deny[msga] {
 		"alertMessage": sprintf("container: %v in %v: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 2,
+		"reviewPaths": paths,
 		"failedPaths": paths,
 		"fixPaths":[],
 		"alertObject": {
@@ -48,6 +50,7 @@ deny[msga] {
 		"alertMessage": sprintf("container: %v in cronjob: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 2,
+		"reviewPaths": paths,
 		"failedPaths": paths,
 		"fixPaths":[],
 		"alertObject": {

--- a/rules/immutable-container-filesystem/raw.rego
+++ b/rules/immutable-container-filesystem/raw.rego
@@ -70,8 +70,8 @@ deny[msga] {
 # Default of readOnlyRootFilesystem is false. This field is only in container spec and not pod spec
 is_mutable_filesystem(container, start_of_path, i) = [failed_path, fixPath]  {
 	container.securityContext.readOnlyRootFilesystem == false
-	failed_path = sprintf("%vcontainers[%v].securityContext.readOnlyRootFilesystem", [start_of_path, format_int(i, 10)])
-	fixPath = ""
+	fixPath = {"path": sprintf("%vcontainers[%v].securityContext.readOnlyRootFilesystem", [start_of_path, format_int(i, 10)]), "value": "true"}
+	failed_path = ""
  }
 
  is_mutable_filesystem(container, start_of_path, i)  = [failed_path, fixPath] {

--- a/rules/immutable-container-filesystem/test/workloads/expected.json
+++ b/rules/immutable-container-filesystem/test/workloads/expected.json
@@ -1,7 +1,10 @@
 [{
     "alertMessage": "container :mysql in Deployment: my-deployment has  mutable filesystem",
-    "failedPaths": ["spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem"],
-    "fixPaths": [],
+    "failedPaths": [],
+    "fixPaths": [{
+        "path": "spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem",
+        "value": "true"
+    }],
     "ruleStatus": "",
     "packagename": "armo_builtins",
     "alertScore": 7,

--- a/rules/rule-can-impersonate-users-groups/raw.rego
+++ b/rules/rule-can-impersonate-users-groups/raw.rego
@@ -53,6 +53,7 @@ deny[msga] {
 	msga := {
 		"alertMessage": sprintf("the following %v: %v,  can impersonate users", [subject.kind, subject.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
 		"alertObject": {
@@ -85,6 +86,7 @@ deny[msga] {
     msga := {
 		"alertMessage": sprintf("the following %v: %v, can impersonate users", [subject.kind, subject.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
   		"alertObject": {

--- a/rules/rule-can-list-get-secrets/raw.rego
+++ b/rules/rule-can-list-get-secrets/raw.rego
@@ -59,6 +59,7 @@ deny[msga] {
 	    "alertMessage": sprintf("The following %v: %v can read secrets", [subject.kind, subject.name]),
 		"alertScore": 9,
 		"packagename": "armo_builtins",
+		"deletePaths": [path],
        "failedPaths": [path],
           "alertObject": {
 			"k8sApiObjects": [role,rolebinding],
@@ -91,6 +92,7 @@ deny[msga] {
 	    "alertMessage": sprintf("The following %v: %v can read secrets", [subject.kind, subject.name]),
 		"alertScore": 9,
 		"packagename": "armo_builtins",
+		"deletePaths": [path],
        "failedPaths": [path],
         "alertObject": {
 			"k8sApiObjects": [role,clusterrolebinding],

--- a/rules/rule-can-portforward/raw.rego
+++ b/rules/rule-can-portforward/raw.rego
@@ -53,6 +53,7 @@ deny[msga] {
 	msga := {
 		"alertMessage": sprintf("the following %v: %v, can do port forwarding", [subject.kind, subject.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
 		"alertObject": {
@@ -85,6 +86,7 @@ deny[msga] {
     msga := {
 		"alertMessage": sprintf("the following %v: %v, can do port forwarding", [subject.kind, subject.name]),
 		"alertScore": 9,
+		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
   		"alertObject": {

--- a/rules/rule-can-ssh-to-pod/raw.rego
+++ b/rules/rule-can-ssh-to-pod/raw.rego
@@ -49,6 +49,7 @@ deny[msga] {
 		"alertMessage": sprintf("%v: %v is exposed by SSH services: %v", [wl.kind, wl.metadata.name, service]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
+		"deletePaths": [path],
 		"failedPaths": [path],
         "alertObject": {
 			"k8sApiObjects": [wl,service]
@@ -72,6 +73,7 @@ deny[msga] {
 		"alertMessage": sprintf("%v: %v is exposed by SSH services: %v", [wl.kind, wl.metadata.name, service]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
+		"deletePaths": [path],
 		"failedPaths": [path],
         "alertObject": {
 			"k8sApiObjects": [wl,service]

--- a/rules/rule-can-update-configmap/raw.rego
+++ b/rules/rule-can-update-configmap/raw.rego
@@ -71,6 +71,7 @@ deny[msga] {
     	msga := {
 	     "alertMessage": sprintf("The following %v: %v can modify 'coredns' configmap", [subject.kind, subject.name]),
 		"alertScore": 6,
+		"deletePaths": [path],
          "failedPaths": [path],
 		"packagename": "armo_builtins",
           "alertObject": {
@@ -112,6 +113,7 @@ deny[msga] {
     	msga := {
 	     "alertMessage": sprintf("The following %v: %v can modify 'coredns'  configmap", [subject.kind, subject.name]),
 		"alertScore": 6,
+		"deletePaths": [path],
          "failedPaths": [path],
 		"packagename": "armo_builtins",
           "alertObject": {

--- a/rules/rule-credentials-in-env-var/raw.rego
+++ b/rules/rule-credentials-in-env-var/raw.rego
@@ -55,6 +55,7 @@
 			"alertMessage": sprintf("%v: %v has sensitive information in environment variables", [wl.kind, wl.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
+			"deletePaths": [path],
 			"failedPaths": [path],
 			"packagename": "armo_builtins",
 			"alertObject": {
@@ -86,6 +87,7 @@
 			"alertMessage": sprintf("Cronjob: %v has sensitive information in environment variables", [wl.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
+			"deletePaths": [path],
 			"failedPaths": [path],
 			"packagename": "armo_builtins",
 			"alertObject": {
@@ -116,6 +118,7 @@ deny[msga] {
 			"alertMessage": sprintf("Pod: %v has sensitive information in environment variables", [pod.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
+			"deletePaths": [path],
 			"failedPaths": [path],
 			"packagename": "armo_builtins",
 			"alertObject": {
@@ -147,6 +150,7 @@ deny[msga] {
 			"alertMessage": sprintf("%v: %v has sensitive information in environment variables", [wl.kind, wl.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
+			"deletePaths": [path],
 			"failedPaths": [path],
 			"packagename": "armo_builtins",
 			"alertObject": {
@@ -176,6 +180,7 @@ deny[msga] {
 			"alertMessage": sprintf("Cronjob: %v has sensitive information in environment variables", [wl.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
+			"deletePaths": [path],
 			"failedPaths": [path],
 			"packagename": "armo_builtins",
 			"alertObject": {


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This pull request enhances the existing checks for image pull policies in Kubernetes configurations. Specifically, it adds missing 'reviewPaths' to the alert messages generated when a container has the 'latest' tag on its image but the imagePullPolicy is not set to 'Always'. This addition will provide more context and clarity for users reviewing these alerts.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`rules/image-pull-policy-is-not-set-to-always/raw.rego`: The 'reviewPaths' field has been added to the alert messages in three checks: for pods, workloads, and cronjobs. This field contains the paths to the relevant container's image and imagePullPolicy in the Kubernetes configuration.
</details>

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->
