### PR TITLE
Use cluster scope instead of AKS

### DIFF
--- a/controls/C-0239-preferusingdedicatedaksserviceaccounts.json
+++ b/controls/C-0239-preferusingdedicatedaksserviceaccounts.json
@@ -19,7 +19,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "AKS"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0240-ensurenetworkpolicyisenabledandsetasappropriate.json
+++ b/controls/C-0240-ensurenetworkpolicyisenabledandsetasappropriate.json
@@ -19,7 +19,7 @@
     "default_value": "By default, Network Policy is disabled.",
     "scanningScope": {
         "matches": [
-            "AKS"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0241-useazurerbacforkubernetesauthorization.json
+++ b/controls/C-0241-useazurerbacforkubernetesauthorization.json
@@ -17,7 +17,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "AKS"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0242-hostilemultitenantworkloads.json
+++ b/controls/C-0242-hostilemultitenantworkloads.json
@@ -19,7 +19,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "AKS"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0243-ensureimagevulnerabilityscanningusingazuredefenderimagescanningorathirdpartyprovider.json
+++ b/controls/C-0243-ensureimagevulnerabilityscanningusingazuredefenderimagescanningorathirdpartyprovider.json
@@ -19,7 +19,7 @@
     "default_value": "Images are not scanned by Default.",
     "scanningScope": {
         "matches": [
-            "AKS"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0244-ensurekubernetessecretsareencrypted.json
+++ b/controls/C-0244-ensurekubernetessecretsareencrypted.json
@@ -19,7 +19,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "AKS"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0245-encrypttraffictohttpsloadbalancerswithtlscertificates.json
+++ b/controls/C-0245-encrypttraffictohttpsloadbalancerswithtlscertificates.json
@@ -19,7 +19,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "AKS"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0247-restrictaccesstothecontrolplaneendpoint.json
+++ b/controls/C-0247-restrictaccesstothecontrolplaneendpoint.json
@@ -19,7 +19,7 @@
     "default_value": "By default, Endpoint Private Access is disabled.",
     "scanningScope": {
         "matches": [
-            "AKS"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0248-ensureclustersarecreatedwithprivatenodes.json
+++ b/controls/C-0248-ensureclustersarecreatedwithprivatenodes.json
@@ -19,7 +19,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "AKS"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0249-restrictuntrustedworkloads.json
+++ b/controls/C-0249-restrictuntrustedworkloads.json
@@ -20,7 +20,7 @@
     "default_value": "ACI is not a default component of the AKS",
     "scanningScope": {
         "matches": [
-            "AKS"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0250-minimizeclusteraccesstoreadonlyforazurecontainerregistryacr.json
+++ b/controls/C-0250-minimizeclusteraccesstoreadonlyforazurecontainerregistryacr.json
@@ -19,7 +19,7 @@
   "default_value": "",
   "scanningScope": {
     "matches": [
-      "AKS"
+      "cluster"
     ]
   }
 }

--- a/controls/C-0252-ensureclustersarecreatedwithprivateendpointenabledandpublicaccessdisabled.json
+++ b/controls/C-0252-ensureclustersarecreatedwithprivateendpointenabledandpublicaccessdisabled.json
@@ -19,7 +19,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "AKS"
+            "cluster"
         ]
     }
 }

--- a/controls/C-0254-enableauditlogs.json
+++ b/controls/C-0254-enableauditlogs.json
@@ -19,7 +19,7 @@
     "default_value": "By default, cluster control plane logs aren't sent to be Logged.",
     "scanningScope": {
         "matches": [
-            "AKS"
+            "cluster"
         ]
     }
 }

--- a/frameworks/cis-aks-t1.2.0.json
+++ b/frameworks/cis-aks-t1.2.0.json
@@ -7,7 +7,7 @@
     },
     "scanningScope": {
         "matches": [
-            "AKS"
+            "cluster"
         ]
     },
     "typeTags": ["compliance"],


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR changes the scanning scope in the CIS-AKS controls from "AKS" to "cluster". This is a temporary solution for scanning the CIS-AKS on AKS clusters and should be reverted once the issue is fixed in Kubescape.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`controls/C-0239-preferusingdedicatedaksserviceaccounts.json`: Changed the scanning scope from "AKS" to "cluster".
`controls/C-0240-ensurenetworkpolicyisenabledandsetasappropriate.json`: Changed the scanning scope from "AKS" to "cluster".
`controls/C-0241-useazurerbacforkubernetesauthorization.json`: Changed the scanning scope from "AKS" to "cluster".
`controls/C-0242-hostilemultitenantworkloads.json`: Changed the scanning scope from "AKS" to "cluster".
`controls/C-0243-ensureimagevulnerabilityscanningusingazuredefenderimagescanningorathirdpartyprovider.json`: Changed the scanning scope from "AKS" to "cluster".
`controls/C-0244-ensurekubernetessecretsareencrypted.json`: Changed the scanning scope from "AKS" to "cluster".
`controls/C-0245-encrypttraffictohttpsloadbalancerswithtlscertificates.json`: Changed the scanning scope from "AKS" to "cluster".
`controls/C-0247-restrictaccesstothecontrolplaneendpoint.json`: Changed the scanning scope from "AKS" to "cluster".
`controls/C-0248-ensureclustersarecreatedwithprivatenodes.json`: Changed the scanning scope from "AKS" to "cluster".
`frameworks/cis-aks-t1.2.0.json`: Changed the scanning scope from "AKS" to "cluster".
</details>

___
## User Description:
## Overview
This is a temporary solution for scanning the CIS-AKS on aks clusters.
This PR should be reverted once we have this fixed in Kubescape.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->
