### PR TITLE
adding maintainers file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,12 @@
+# Maintainers
+
+The following table lists the project core maintainers:
+
+| Name | GitHub | Organization | Added/Renewed On |
+| --- | --- | --- |------------------|
+| [Yiscah Levy Silas](https://www.linkedin.com/in/yiscah-levy-silas/) | [@YiscahLevySilas1](https://github.com/YiscahLevySilas1) | [ARMO](https://www.armosec.io/) | 2021-09-01       |
+| [Daniel Grunberger](https://www.linkedin.com/in/daniel-grunberger-719685188/) | [@Daniel-GrunbergerCA](https://github.com/Daniel-GrunbergerCA) | [ARMO](https://www.armosec.io/) | 2021-09-01       |
+| [Yuval Leibovich](https://www.linkedin.com/in/yuval-leibovich-42ab9661/) | [@yuleib](https://github.com/yuleib) | [ARMO](https://www.armosec.io/) | 2022-11-01       |
+| [Alessio Greggi](https://www.linkedin.com/in/alegrey91/) | [@alegrey91](https://github.com/alegrey91) | [ARMO](https://www.armosec.io/) | 2023-02-01       |
+| [Ben Hirschberg](https://www.linkedin.com/in/benyamin-ben-hirschberg-66141890) | [@slashben](https://github.com/slashben) | [ARMO](https://www.armosec.io/) | 2021-09-01       |
+| [David Wertenteil](https://www.linkedin.com/in/david-wertenteil-0ba277b9) | [@dwertent](https://github.com/dwertent) | [ARMO](https://www.armosec.io/) | 2021-09-01       |


### PR DESCRIPTION
## PR Type:
Documentation

___
## PR Description:
This PR introduces a new file, MAINTAINERS.md, which lists the core maintainers of the Kubescape project. The file includes the names, GitHub profiles, organizations, and the dates they were added or renewed.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`MAINTAINERS.md`: Added a new file that lists the core maintainers of the Kubescape project, their GitHub profiles, organizations, and the dates they were added or renewed.
</details>
