### PR TITLE
Revert "Use cluster scope instead of AKS"

### DIFF
--- a/controls/C-0239-preferusingdedicatedaksserviceaccounts.json
+++ b/controls/C-0239-preferusingdedicatedaksserviceaccounts.json
@@ -19,7 +19,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "AKS"
         ]
     }
 }

--- a/controls/C-0240-ensurenetworkpolicyisenabledandsetasappropriate.json
+++ b/controls/C-0240-ensurenetworkpolicyisenabledandsetasappropriate.json
@@ -19,7 +19,7 @@
     "default_value": "By default, Network Policy is disabled.",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "AKS"
         ]
     }
 }

--- a/controls/C-0241-useazurerbacforkubernetesauthorization.json
+++ b/controls/C-0241-useazurerbacforkubernetesauthorization.json
@@ -17,7 +17,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "AKS"
         ]
     }
 }

--- a/controls/C-0242-hostilemultitenantworkloads.json
+++ b/controls/C-0242-hostilemultitenantworkloads.json
@@ -19,7 +19,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "AKS"
         ]
     }
 }

--- a/controls/C-0243-ensureimagevulnerabilityscanningusingazuredefenderimagescanningorathirdpartyprovider.json
+++ b/controls/C-0243-ensureimagevulnerabilityscanningusingazuredefenderimagescanningorathirdpartyprovider.json
@@ -19,7 +19,7 @@
     "default_value": "Images are not scanned by Default.",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "AKS"
         ]
     }
 }

--- a/controls/C-0244-ensurekubernetessecretsareencrypted.json
+++ b/controls/C-0244-ensurekubernetessecretsareencrypted.json
@@ -19,7 +19,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "AKS"
         ]
     }
 }

--- a/controls/C-0245-encrypttraffictohttpsloadbalancerswithtlscertificates.json
+++ b/controls/C-0245-encrypttraffictohttpsloadbalancerswithtlscertificates.json
@@ -19,7 +19,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "AKS"
         ]
     }
 }

--- a/controls/C-0247-restrictaccesstothecontrolplaneendpoint.json
+++ b/controls/C-0247-restrictaccesstothecontrolplaneendpoint.json
@@ -19,7 +19,7 @@
     "default_value": "By default, Endpoint Private Access is disabled.",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "AKS"
         ]
     }
 }

--- a/controls/C-0248-ensureclustersarecreatedwithprivatenodes.json
+++ b/controls/C-0248-ensureclustersarecreatedwithprivatenodes.json
@@ -19,7 +19,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "AKS"
         ]
     }
 }

--- a/controls/C-0249-restrictuntrustedworkloads.json
+++ b/controls/C-0249-restrictuntrustedworkloads.json
@@ -20,7 +20,7 @@
     "default_value": "ACI is not a default component of the AKS",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "AKS"
         ]
     }
 }

--- a/controls/C-0250-minimizeclusteraccesstoreadonlyforazurecontainerregistryacr.json
+++ b/controls/C-0250-minimizeclusteraccesstoreadonlyforazurecontainerregistryacr.json
@@ -19,7 +19,7 @@
   "default_value": "",
   "scanningScope": {
     "matches": [
-      "cluster"
+      "AKS"
     ]
   }
 }

--- a/controls/C-0252-ensureclustersarecreatedwithprivateendpointenabledandpublicaccessdisabled.json
+++ b/controls/C-0252-ensureclustersarecreatedwithprivateendpointenabledandpublicaccessdisabled.json
@@ -19,7 +19,7 @@
     "default_value": "",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "AKS"
         ]
     }
 }

--- a/controls/C-0254-enableauditlogs.json
+++ b/controls/C-0254-enableauditlogs.json
@@ -19,7 +19,7 @@
     "default_value": "By default, cluster control plane logs aren't sent to be Logged.",
     "scanningScope": {
         "matches": [
-            "cluster"
+            "AKS"
         ]
     }
 }

--- a/frameworks/cis-aks-t1.2.0.json
+++ b/frameworks/cis-aks-t1.2.0.json
@@ -7,7 +7,7 @@
     },
     "scanningScope": {
         "matches": [
-            "cluster"
+            "AKS"
         ]
     },
     "typeTags": ["compliance"],


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR reverts the scanning scope in multiple control files from 'cluster' to 'AKS'. This change is made to align with the recent release of Kubescape that supports the proper scanning scope.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`controls/C-0239-preferusingdedicatedaksserviceaccounts.json`: Reverted the scanning scope from 'cluster' to 'AKS'.
`controls/C-0240-ensurenetworkpolicyisenabledandsetasappropriate.json`: Reverted the scanning scope from 'cluster' to 'AKS'.
`controls/C-0241-useazurerbacforkubernetesauthorization.json`: Reverted the scanning scope from 'cluster' to 'AKS'.
`controls/C-0242-hostilemultitenantworkloads.json`: Reverted the scanning scope from 'cluster' to 'AKS'.
`controls/C-0243-ensureimagevulnerabilityscanningusingazuredefenderimagescanningorathirdpartyprovider.json`: Reverted the scanning scope from 'cluster' to 'AKS'.
`controls/C-0244-ensurekubernetessecretsareencrypted.json`: Reverted the scanning scope from 'cluster' to 'AKS'.
`controls/C-0245-encrypttraffictohttpsloadbalancerswithtlscertificates.json`: Reverted the scanning scope from 'cluster' to 'AKS'.
`controls/C-0247-restrictaccesstothecontrolplaneendpoint.json`: Reverted the scanning scope from 'cluster' to 'AKS'.
`controls/C-0248-ensureclustersarecreatedwithprivatenodes.json`: Reverted the scanning scope from 'cluster' to 'AKS'.
`controls/C-0249-restrictuntrustedworkloads.json`: Reverted the scanning scope from 'cluster' to 'AKS'.
</details>

___
## User Description:
Reverts kubescape/regolibrary#532

Now that we released Kubescape with the proper support.
