### PR TITLE
replace serviceaccountname with serviceAccountName

### DIFF
--- a/rules/rule-access-dashboard-wl-v1/raw.rego
+++ b/rules/rule-access-dashboard-wl-v1/raw.rego
@@ -14,8 +14,8 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"fixPaths": [],
-		"deletePaths": ["spec.serviceaccountname"],
-		"failedPaths": ["spec.serviceaccountname"],
+		"deletePaths": ["spec.serviceAccountName"],
+		"failedPaths": ["spec.serviceAccountName"],
 		"alertObject": {
 			"k8sApiObjects": [pod]
 		}
@@ -36,8 +36,8 @@ deny[msga] {
 	msga := {
 		"alertMessage": sprintf("%v: %v is associated with dashboard service account", [wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
-		"deletePaths": ["spec.template.spec.serviceaccountname"],
-		"failedPaths": ["spec.template.spec.serviceaccountname"],
+		"deletePaths": ["spec.template.spec.serviceAccountName"],
+		"failedPaths": ["spec.template.spec.serviceAccountName"],
 		"alertScore": 7,
 		"fixPaths": [],
 		"alertObject": {
@@ -61,8 +61,8 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"fixPaths": [],
-		"deletePaths": ["spec.jobTemplate.spec.template.spec.serviceaccountname"],
-		"failedPaths": ["spec.jobTemplate.spec.template.spec.serviceaccountname"],
+		"deletePaths": ["spec.jobTemplate.spec.template.spec.serviceAccountName"],
+		"failedPaths": ["spec.jobTemplate.spec.template.spec.serviceAccountName"],
 		"alertObject": {
 			"k8sApiObjects": [wl]
 		}

--- a/rules/rule-access-dashboard-wl-v1/test/cronjob/expected.json
+++ b/rules/rule-access-dashboard-wl-v1/test/cronjob/expected.json
@@ -1,6 +1,7 @@
 [{
     "alertMessage": "the following cronjob: hello is associated with dashboard service account",
-    "failedPaths": ["spec.jobTemplate.spec.template.spec.serviceaccountname"],
+    "failedPaths": ["spec.jobTemplate.spec.template.spec.serviceAccountName"],
+    "deletePaths": ["spec.jobTemplate.spec.template.spec.serviceAccountName"],
     "fixPaths": [],
     "ruleStatus": "",
     "packagename": "armo_builtins",

--- a/rules/rule-access-dashboard-wl-v1/test/pod/expected.json
+++ b/rules/rule-access-dashboard-wl-v1/test/pod/expected.json
@@ -1,6 +1,7 @@
 [{
     "alertMessage": "the following pods: frontend are associated with dashboard service account",
-    "failedPaths": ["spec.serviceaccountname"],
+    "failedPaths": ["spec.serviceAccountName"],
+    "deletePaths": ["spec.serviceAccountName"],
     "fixPaths": [],
     "ruleStatus": "",
     "packagename": "armo_builtins",

--- a/rules/rule-access-dashboard-wl-v1/test/workload/expected.json
+++ b/rules/rule-access-dashboard-wl-v1/test/workload/expected.json
@@ -1,6 +1,7 @@
 [{
     "alertMessage": "Deployment: test is associated with dashboard service account",
-    "failedPaths": ["spec.template.spec.serviceaccountname"],
+    "failedPaths": ["spec.template.spec.serviceAccountName"],
+    "deletePaths": ["spec.template.spec.serviceAccountName"],
     "fixPaths": [],
     "ruleStatus": "",
     "packagename": "armo_builtins",

--- a/rules/rule-access-dashboard/raw.rego
+++ b/rules/rule-access-dashboard/raw.rego
@@ -58,9 +58,9 @@ deny[msga] {
 
 deny[msga] {
     pod := input[_]
-    pod.spec.serviceaccountname == "kubernetes-dashboard"
+    pod.spec.serviceAccountName == "kubernetes-dashboard"
     not startswith(pod.metadata.name, "kubernetes-dashboard")
-	path := "spec.serviceaccountname"
+	path := "spec.serviceAccountName"
 	msga := {
 		"alertMessage": sprintf("the following pods: %s are associated with dashboard service account", [pod.metadata.name]),
 		"packagename": "armo_builtins",
@@ -81,9 +81,9 @@ deny[msga] {
     wl := input[_]
 	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
 	spec_template_spec_patterns[wl.kind]
-    wl.spec.template.spec.serviceaccountname == "kubernetes-dashboard"
+    wl.spec.template.spec.serviceAccountName == "kubernetes-dashboard"
     not startswith(wl.metadata.name, "kubernetes-dashboard")
-	path := "spec.template.spec.serviceaccountname"
+	path := "spec.template.spec.serviceAccountName"
 	msga := {
 		"alertMessage": sprintf("%v: %v is associated with dashboard service account", [wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
@@ -103,9 +103,9 @@ deny[msga] {
 deny[msga] {
     wl := input[_]
 	wl.kind == "CronJob"
-    wl.spec.jobTemplate.spec.template.spec.serviceaccountname == "kubernetes-dashboard"
+    wl.spec.jobTemplate.spec.template.spec.serviceAccountName == "kubernetes-dashboard"
     not startswith(wl.metadata.name, "kubernetes-dashboard")
-	path := "spec.jobTemplate.spec.template.spec.serviceaccountname"
+	path := "spec.jobTemplate.spec.template.spec.serviceAccountName"
 	msga := {
 		"alertMessage": sprintf("the following cronjob: %s is associated with dashboard service account", [wl.metadata.name]),
 		"packagename": "armo_builtins",


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR standardizes the attribute name for service account from 'serviceaccountname' to 'serviceAccountName' in various rules and tests. The changes are made in the following files:
- rules/rule-access-dashboard-wl-v1/raw.rego
- rules/rule-access-dashboard-wl-v1/test/cronjob/expected.json
- rules/rule-access-dashboard-wl-v1/test/pod/expected.json
- rules/rule-access-dashboard-wl-v1/test/workload/expected.json
- rules/rule-access-dashboard/raw.rego

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`rules/rule-access-dashboard-wl-v1/raw.rego`: Replaced 'serviceaccountname' with 'serviceAccountName' in the deny rules for pods, workloads, and cronjobs.
`rules/rule-access-dashboard-wl-v1/test/cronjob/expected.json`: Updated the 'failedPaths' and 'deletePaths' fields to reflect the new attribute name 'serviceAccountName'.
`rules/rule-access-dashboard-wl-v1/test/pod/expected.json`: Updated the 'failedPaths' and 'deletePaths' fields to reflect the new attribute name 'serviceAccountName'.
`rules/rule-access-dashboard-wl-v1/test/workload/expected.json`: Updated the 'failedPaths' and 'deletePaths' fields to reflect the new attribute name 'serviceAccountName'.
`rules/rule-access-dashboard/raw.rego`: Replaced 'serviceaccountname' with 'serviceAccountName' in the deny rules for pods, workloads, and cronjobs.
</details>

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->
