### PR TITLE
fix control C-0050

### DIFF
--- a/rules/resources-cpu-limit-and-request/raw.rego
+++ b/rules/resources-cpu-limit-and-request/raw.rego
@@ -350,7 +350,7 @@ compare_max(max, given) {
 	endswith(given, "Mi")
 	split_max :=  split(max, "Mi")[0]
 	split_given :=  split(given, "Mi")[0]
-	split_given > split_max
+	to_number(split_given) > to_number(split_max)
 }
 
 compare_max(max, given) {
@@ -358,7 +358,7 @@ compare_max(max, given) {
 	endswith(given, "M")
 	split_max :=  split(max, "M")[0]
 	split_given :=  split(given, "M")[0]
-	split_given > split_max
+	to_number(split_given) > to_number(split_max)
 }
 
 compare_max(max, given) {
@@ -366,13 +366,13 @@ compare_max(max, given) {
 	endswith(given, "m")
 	split_max :=  split(max, "m")[0]
 	split_given :=  split(given, "m")[0]
-	split_given > split_max
+	to_number(split_given) > to_number(split_max)
 }
 
 compare_max(max, given) {
 	not is_special_measure(max)
 	not is_special_measure(given)
-	given > max
+	to_number(given) > to_number(max)
 }
 
 
@@ -384,7 +384,7 @@ compare_min(min, given) {
 	endswith(given, "Mi")
 	split_min :=  split(min, "Mi")[0]
 	split_given :=  split(given, "Mi")[0]
-	split_given < split_min
+	to_number(split_given) < to_number(split_min)
 }
 
 compare_min(min, given) {
@@ -392,7 +392,7 @@ compare_min(min, given) {
 	endswith(given, "M")
 	split_min :=  split(min, "M")[0]
 	split_given :=  split(given, "M")[0]
-	split_given < split_min
+	to_number(split_given) < to_number(split_min)
 }
 
 compare_min(min, given) {
@@ -400,13 +400,15 @@ compare_min(min, given) {
 	endswith(given, "m")
 	split_min :=  split(min, "m")[0]
 	split_given :=  split(given, "m")[0]
-	split_given < split_min
+	to_number(split_given) < to_number(split_min)
+
 }
 
 compare_min(min, given) {
 	not is_special_measure(min)
 	not is_special_measure(given)
-	given < min
+	to_number(given) < to_number(min)
+
 }
 
 


### PR DESCRIPTION
## Type
Bug fix

___
## Description
This PR addresses an issue in the comparison logic of control C-0050. Previously, the comparison was done as a string comparison, which could lead to incorrect results. This has been fixed by converting the values to numbers before performing the comparison. The changes are applied to both `compare_max` and `compare_min` functions.

___
## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>raw.rego&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        rules/resources-cpu-limit-and-request/raw.rego<br><br>
        <strong>The comparison logic in the `compare_max` and `compare_min` <br>functions has been updated. The values are now converted to <br>numbers before the comparison is performed. This ensures <br>that the comparison is done correctly, even when the values <br>are represented as strings.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/554/files#diff-0da57c845155ba7e258430dd162d090b07620de725d0fa9c60d5a2f6e2bec86d"> +10/-8</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>