### PR TITLE
fix C-0236 assisted remediation

### DIFF
--- a/rules/verify-image-signature/raw.rego
+++ b/rules/verify-image-signature/raw.rego
@@ -9,13 +9,14 @@ deny[msga] {
     verified_keys := [trusted_key | trusted_key = data.postureControlInputs.trustedCosignPublicKeys[_]; cosign.verify(container.image, trusted_key)]
     count(verified_keys) == 0
 
+	path := sprintf("spec.containers[%v].image", [i])
 
 	msga := {
 		"alertMessage": sprintf("signature not verified for image: %v", [container.image]),
 		"alertScore": 7,
 		"fixPaths": [],
-		"reviewPaths": [container.image],
-		"failedPaths": [container.image],
+		"reviewPaths": [path],
+		"failedPaths": [path],
 		"packagename": "armo_builtins",
 		"alertObject": {
 			"k8sApiObjects": [pod]
@@ -32,12 +33,14 @@ deny[msga] {
 	verified_keys := [trusted_key | trusted_key = data.postureControlInputs.trustedCosignPublicKeys[_]; cosign.verify(container.image, trusted_key)]
     count(verified_keys) == 0
 
+	path := sprintf("spec.template.spec.containers[%v].image", [i])
+
     msga := {
 		"alertMessage": sprintf("signature not verified for image: %v", [container.image]),
 		"alertScore": 7,
 		"fixPaths": [],
-		"reviewPaths": [container.image],
-		"failedPaths": [container.image],
+		"reviewPaths": [path],
+		"failedPaths": [path],
 		"packagename": "armo_builtins",
 		"alertObject": {
 			"k8sApiObjects": [wl]
@@ -54,12 +57,14 @@ deny[msga] {
     verified_keys := [trusted_key | trusted_key = data.postureControlInputs.trustedCosignPublicKeys[_]; cosign.verify(container.image, trusted_key)]
     count(verified_keys) == 0
 
+	path := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].image", [i])
+
     msga := {
 		"alertMessage": sprintf("signature not verified for image: %v", [container.image]),
 		"alertScore": 7,
 		"fixPaths": [],
-		"reviewPaths": [container.image],
-		"failedPaths": [container.image],
+		"reviewPaths": [path],
+		"failedPaths": [path],
 		"packagename": "armo_builtins",
 		"alertObject": {
 			"k8sApiObjects": [wl]


### PR DESCRIPTION
## Type
bug_fix


___

## Description
This PR addresses a bug in the `rules/verify-image-signature/raw.rego` file. The main changes include:
- The paths for the `reviewPaths` and `failedPaths` fields in the alert message have been corrected. Instead of directly assigning the `container.image` value, a `sprintf` function is now used to generate a more specific path string, which includes the index of the container in the array.
- This change has been applied in three different sections of the code, each dealing with a different Kubernetes object kind: Pod, CronJob, and a generic workload.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug_fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>raw.rego&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        rules/verify-image-signature/raw.rego<br><br>

**The changes in this file are focused on fixing the paths for <br>the `reviewPaths` and `failedPaths` fields in the alert <br>message. Previously, these fields were directly assigned the <br>`container.image` value. Now, a `sprintf` function is used <br>to generate a more specific path string, which includes the <br>index of the container in the array. This change is applied <br>in three different sections of the code, each dealing with a <br>different Kubernetes object kind: Pod, CronJob, and a <br>generic workload.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/558/files#diff-84e11abdf7c428e967b7eb3933ccf2cb53b97bdf16130c3a25f8c8e559c8ab96"> +11/-6</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->
