### PR TITLE
Improve c-0012

### DIFF
--- a/default-config-inputs.json
+++ b/default-config-inputs.json
@@ -49,7 +49,6 @@
             ],
             "max_critical_vulnerabilities": ["5"],
             "max_high_vulnerabilities": ["10"],
-            "sensitiveValuesAllowed": ["AllowedValue"],
             "sensitiveKeyNames": [
                 "aws_access_key_id",
                 "aws_secret_access_key",

--- a/rules/rule-credentials-configmap/raw.rego
+++ b/rules/rule-credentials-configmap/raw.rego
@@ -11,8 +11,6 @@ deny[msga] {
     map_secret != ""
 
     contains(lower(map_key), lower(key_name))
-    # check that value wasn't allowed by user
-    not is_allowed_value(map_secret)
 
     path := sprintf("data[%v]", [map_key])
 
@@ -41,8 +39,6 @@ deny[msga] {
     map_secret != ""
 
     regex.match(value , map_secret)
-    # check that value wasn't allowed by user
-    not is_allowed_value(map_secret)
 
     path := sprintf("data[%v]", [map_key])
 
@@ -72,9 +68,6 @@ deny[msga] {
 
     decoded_secret := base64.decode(map_secret)
 
-    # check that value wasn't allowed by user
-    not is_allowed_value(map_secret)
-
     regex.match(value , decoded_secret)
 
     path := sprintf("data[%v]", [map_key])
@@ -90,10 +83,4 @@ deny[msga] {
 			"k8sApiObjects": [configmap]
 		}
      }
-}
-
-
-is_allowed_value(value) {
-    allow_val := data.postureControlInputs.sensitiveValuesAllowed[_]
-    value == allow_val
 }

--- a/rules/rule-credentials-configmap/rule.metadata.json
+++ b/rules/rule-credentials-configmap/rule.metadata.json
@@ -20,8 +20,7 @@
   "ruleDependencies": [],
   "configInputs": [
     "settings.postureControlInputs.sensitiveValues",
-    "settings.postureControlInputs.sensitiveKeyNames",
-    "settings.postureControlInputs.sensitiveValuesAllowed"
+    "settings.postureControlInputs.sensitiveKeyNames"
   ],
   "controlConfigInputs": [
     {
@@ -33,11 +32,6 @@
       "path": "settings.postureControlInputs.sensitiveKeyNames",
       "name": "Keys",
       "description": "Key names that identify a potential value that should be stored in a Secret, and not in a ConfigMap or an environment variable."
-    },
-    {
-      "path":  "settings.postureControlInputs.sensitiveValuesAllowed",
-      "name": "AllowedValues",
-      "description": "Explicitly allowed values, which will override sensitiveValues."
     }
   ],
   "description": "fails if ConfigMaps have sensitive information in configuration",

--- a/rules/rule-credentials-in-env-var/raw.rego
+++ b/rules/rule-credentials-in-env-var/raw.rego
@@ -14,14 +14,15 @@
 
 		is_not_reference(env)
 
-		path := sprintf("spec.containers[%v].env[%v].name", [format_int(i, 10), format_int(j, 10)])
+		paths := [sprintf("spec.containers[%v].env[%v].name", [i, j]),
+				  sprintf("spec.containers[%v].env[%v].value", [i, j])]
 
 		msga := {
 			"alertMessage": sprintf("Pod: %v has sensitive information in environment variables", [pod.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
-			"deletePaths": [path],
-			"failedPaths": [path],
+			"deletePaths": paths,
+			"failedPaths": paths,
 			"packagename": "armo_builtins",
 			"alertObject": {
 				"k8sApiObjects": [pod]
@@ -45,14 +46,15 @@
 
 		is_not_reference(env)
 
-		path := sprintf("spec.template.spec.containers[%v].env[%v].name", [format_int(i, 10), format_int(j, 10)])
+		paths := [sprintf("spec.template.spec.containers[%v].env[%v].name", [i, j]),
+				sprintf("spec.template.spec.containers[%v].env[%v].value", [i, j])]
 
 		msga := {
 			"alertMessage": sprintf("%v: %v has sensitive information in environment variables", [wl.kind, wl.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
-			"deletePaths": [path],
-			"failedPaths": [path],
+			"deletePaths": paths,
+			"failedPaths": paths,
 			"packagename": "armo_builtins",
 			"alertObject": {
 				"k8sApiObjects": [wl]
@@ -75,14 +77,15 @@
 
 		is_not_reference(env)
 
-		path := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].name", [format_int(i, 10), format_int(j, 10)])
+		paths := [sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].name", [i, j]),
+				  sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].value", [i, j])]
 
 		msga := {
 			"alertMessage": sprintf("Cronjob: %v has sensitive information in environment variables", [wl.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
-			"deletePaths": [path],
-			"failedPaths": [path],
+			"deletePaths": paths,
+			"failedPaths": paths,
 			"packagename": "armo_builtins",
 			"alertObject": {
 				"k8sApiObjects": [wl]
@@ -104,14 +107,15 @@ deny[msga] {
 
 		is_not_reference(env)
 
-		path := sprintf("spec.containers[%v].env[%v].name", [format_int(i, 10), format_int(j, 10)])
+		paths := [sprintf("spec.containers[%v].env[%v].name", [i, j]),
+				  sprintf("spec.containers[%v].env[%v].value", [i, j])]
 
 		msga := {
 			"alertMessage": sprintf("Pod: %v has sensitive information in environment variables", [pod.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
-			"deletePaths": [path],
-			"failedPaths": [path],
+			"deletePaths": paths,
+			"failedPaths": paths,
 			"packagename": "armo_builtins",
 			"alertObject": {
 				"k8sApiObjects": [pod]
@@ -134,14 +138,15 @@ deny[msga] {
 
 		is_not_reference(env)
 
-		path := sprintf("spec.template.spec.containers[%v].env[%v].name", [format_int(i, 10), format_int(j, 10)])
+		paths := [sprintf("spec.template.spec.containers[%v].env[%v].name", [i, j]),
+				sprintf("spec.template.spec.containers[%v].env[%v].value", [i, j])]
 
 		msga := {
 			"alertMessage": sprintf("%v: %v has sensitive information in environment variables", [wl.kind, wl.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
-			"deletePaths": [path],
-			"failedPaths": [path],
+			"deletePaths": paths,
+			"failedPaths": paths,
 			"packagename": "armo_builtins",
 			"alertObject": {
 				"k8sApiObjects": [wl]
@@ -162,14 +167,15 @@ deny[msga] {
 
 		is_not_reference(env)
 
-		path := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].name", [format_int(i, 10), format_int(j, 10)])
+		paths := [sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].name", [i, j]),
+				  sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].value", [i, j])]
 
 		msga := {
 			"alertMessage": sprintf("Cronjob: %v has sensitive information in environment variables", [wl.metadata.name]),
 			"alertScore": 9,
 			"fixPaths": [],
-			"deletePaths": [path],
-			"failedPaths": [path],
+			"deletePaths": paths,
+			"failedPaths": paths,
 			"packagename": "armo_builtins",
 			"alertObject": {
 				"k8sApiObjects": [wl]

--- a/rules/rule-credentials-in-env-var/raw.rego
+++ b/rules/rule-credentials-in-env-var/raw.rego
@@ -11,8 +11,6 @@
 
 		contains(lower(env.name), lower(key_name))
 		env.value != ""
-		# check that value wasn't allowed by user
-		not is_allowed_value(env.value)
 
 		is_not_reference(env)
 
@@ -44,8 +42,6 @@
 
 		contains(lower(env.name), lower(key_name))
 		env.value != ""
-		# check that value wasn't allowed by user
-		not is_allowed_value(env.value)
 
 		is_not_reference(env)
 
@@ -76,8 +72,6 @@
 		contains(lower(env.name), lower(key_name))
 
 		env.value != ""
-		# check that value wasn't allowed by user
-		not is_allowed_value(env.value)
 
 		is_not_reference(env)
 
@@ -106,8 +100,6 @@ deny[msga] {
 		container := pod.spec.containers[i]
 		env := container.env[j]
 
-		# check that value wasn't allowed by user
-		not is_allowed_value(env.value)
 		contains(lower(env.value), lower(value))
 
 		is_not_reference(env)
@@ -138,9 +130,7 @@ deny[msga] {
 		container := wl.spec.template.spec.containers[i]
 		env := container.env[j]
 
-		not is_allowed_value(env.value)
 		contains(lower(env.value), lower(value))
-		# check that value wasn't allowed by user
 
 		is_not_reference(env)
 
@@ -168,8 +158,6 @@ deny[msga] {
 		container := wl.spec.jobTemplate.spec.template.spec.containers[i]
 		env := container.env[j]
 
-		# check that value wasn't allowed by user
-		not is_allowed_value(env.value)
 		contains(lower(env.value), lower(value))
 
 		is_not_reference(env)
@@ -194,9 +182,4 @@ is_not_reference(env)
 {
 	not env.valueFrom.secretKeyRef
 	not env.valueFrom.configMapKeyRef
-}
-
-is_allowed_value(value) {
-    allow_val := data.postureControlInputs.sensitiveValuesAllowed[_]
-    value == allow_val
 }

--- a/rules/rule-credentials-in-env-var/rule.metadata.json
+++ b/rules/rule-credentials-in-env-var/rule.metadata.json
@@ -46,8 +46,7 @@
   "ruleDependencies": [],
   "configInputs": [
     "settings.postureControlInputs.sensitiveValues",
-    "settings.postureControlInputs.sensitiveKeyNames",
-    "settings.postureControlInputs.sensitiveValuesAllowed"
+    "settings.postureControlInputs.sensitiveKeyNames"
   ],
   "controlConfigInputs": [
     {
@@ -59,11 +58,6 @@
       "path": "settings.postureControlInputs.sensitiveKeyNames",
       "name": "Keys",
       "description": "Key names that identify a potential value that should be stored in a Secret, and not in a ConfigMap or an environment variable."
-    },
-    {
-      "path":  "settings.postureControlInputs.sensitiveValuesAllowed",
-      "name": "AllowedValues",
-      "description": "Explicitly allowed values, which will override sensitiveValues."
     }
   ],
   "description": "fails if Pods have sensitive information in configuration",

--- a/rules/rule-credentials-in-env-var/test/cronjob/expected.json
+++ b/rules/rule-credentials-in-env-var/test/cronjob/expected.json
@@ -2,10 +2,12 @@
     {
         "alertMessage": "Cronjob: hello has sensitive information in environment variables",
         "deletePaths": [
-            "spec.jobTemplate.spec.template.spec.containers[0].env[0].name"
+            "spec.jobTemplate.spec.template.spec.containers[0].env[0].name",
+            "spec.jobTemplate.spec.template.spec.containers[0].env[0].value"
         ],
         "failedPaths": [
-            "spec.jobTemplate.spec.template.spec.containers[0].env[0].name"
+            "spec.jobTemplate.spec.template.spec.containers[0].env[0].name",
+            "spec.jobTemplate.spec.template.spec.containers[0].env[0].value"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/rule-credentials-in-env-var/test/deployment/expected.json
+++ b/rules/rule-credentials-in-env-var/test/deployment/expected.json
@@ -2,10 +2,12 @@
     {
         "alertMessage": "Deployment: test2 has sensitive information in environment variables",
         "deletePaths": [
-            "spec.template.spec.containers[1].env[1].name"
+            "spec.template.spec.containers[1].env[1].name",
+            "spec.template.spec.containers[1].env[1].value"
         ],
         "failedPaths": [
-            "spec.template.spec.containers[1].env[1].name"
+            "spec.template.spec.containers[1].env[1].name",
+            "spec.template.spec.containers[1].env[1].value"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/rule-credentials-in-env-var/test/pod/expected.json
+++ b/rules/rule-credentials-in-env-var/test/pod/expected.json
@@ -2,10 +2,12 @@
     {
         "alertMessage": "Pod: audit-pod has sensitive information in environment variables",
         "deletePaths": [
-            "spec.containers[0].env[1].name"
+            "spec.containers[0].env[1].name",
+            "spec.containers[0].env[1].value"
         ],
         "failedPaths": [
-            "spec.containers[0].env[1].name"
+            "spec.containers[0].env[1].name",
+            "spec.containers[0].env[1].value"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/rule-credentials-in-env-var/test/workloads/expected.json
+++ b/rules/rule-credentials-in-env-var/test/workloads/expected.json
@@ -2,10 +2,12 @@
     {
         "alertMessage": "Deployment: test2 has sensitive information in environment variables",
         "deletePaths": [
-            "spec.template.spec.containers[1].env[0].name"
+            "spec.template.spec.containers[1].env[0].name",
+            "spec.template.spec.containers[1].env[0].value"
         ],
         "failedPaths": [
-            "spec.template.spec.containers[1].env[0].name"
+            "spec.template.spec.containers[1].env[0].name",
+            "spec.template.spec.containers[1].env[0].value"
         ],
         "fixPaths": [],
         "ruleStatus": "",


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
* add path to env value in deletePaths in addition to path to env name to ensure valid yaml
* deprecate use of allowedValues list
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
Enhancement


___

## **Description**
This PR includes several enhancements and configuration changes:
- The "sensitiveValuesAllowed" key was removed from the `default-config-inputs.json` file.
- The function "is_allowed_value" and its usage were removed from the `rules/rule-credentials-configmap/raw.rego` and `rules/rule-credentials-in-env-var/raw.rego` files. This function was checking if a value was allowed by the user.
- The "settings.postureControlInputs.sensitiveValuesAllowed" was removed from the configInputs and controlConfigInputs arrays in the `rules/rule-credentials-configmap/rule.metadata.json` and `rules/rule-credentials-in-env-var/rule.metadata.json` files.
- The path to the value was added in the deletePaths and failedPaths arrays in the `rules/rule-credentials-in-env-var/raw.rego` file and in the expected test results files (`rules/rule-credentials-in-env-var/test/cronjob/expected.json`, `rules/rule-credentials-in-env-var/test/deployment/expected.json`, `rules/rule-credentials-in-env-var/test/pod/expected.json`, `rules/rule-credentials-in-env-var/test/workloads/expected.json`).


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>default-config-inputs.json&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        default-config-inputs.json<br><br>

**Removed the "sensitiveValuesAllowed" key from the JSON file.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/560/files#diff-01c7cee651bbe5f7335130d6a0e2934f121267204e54d0446da96c606d52aef9"> +0/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rule.metadata.json&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        rules/rule-credentials-configmap/rule.metadata.json<br><br>

**Removed the <br>"settings.postureControlInputs.sensitiveValuesAllowed" from <br>the configInputs and controlConfigInputs arrays.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/560/files#diff-aa06c0f418b1fb944900969faab74ebe73ca8fd83941a4789b760e1536be07fd"> +1/-7</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rule.metadata.json&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        rules/rule-credentials-in-env-var/rule.metadata.json<br><br>

**Removed the <br>"settings.postureControlInputs.sensitiveValuesAllowed" from <br>the configInputs array.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/560/files#diff-3c91e014732c8817572eb566ebd827c3bddc8e1ea523d77ed4d2e4aded668e36"> +1/-7</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>raw.rego&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        rules/rule-credentials-configmap/raw.rego<br><br>

**Removed the function "is_allowed_value" and its usage in the <br>code. This function was checking if a value was allowed by <br>the user.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/560/files#diff-1781a094769587a2c644773ca7e494d7e865b9a07edde09e601d40ac6ad00d08"> +0/-13</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>raw.rego&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        rules/rule-credentials-in-env-var/raw.rego<br><br>

**Removed the function "is_allowed_value" and its usage in the <br>code. This function was checking if a value was allowed by <br>the user. Also, added the path to the value in the <br>deletePaths and failedPaths arrays.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/560/files#diff-7c604ff0409ca6377338b9cf8d80ec376b70a1b7db37254cb75a116c4e96f877"> +24/-35</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>expected.json&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        rules/rule-credentials-in-env-var/test/cronjob/expected.json<br><br>

**Added the path to the value in the deletePaths and <br>failedPaths arrays in the expected test results.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/560/files#diff-52c14a8a9b9ab3099b9caf0b1f10bd5603d38e68749a23fa03f4cf07cbee46f0"> +4/-2</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        rules/rule-credentials-in-env-var/test/deployment/expected.json<br><br>

**Added the path to the value in the deletePaths and <br>failedPaths arrays in the expected test results.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/560/files#diff-da89cb4372adf1b355a933361bb6898a4ed5f57f7d4aa867e3eb75c0d7a72799"> +4/-2</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        rules/rule-credentials-in-env-var/test/pod/expected.json<br><br>

**Added the path to the value in the deletePaths and <br>failedPaths arrays in the expected test results.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/560/files#diff-bc9caa09385ba1c65cb5df11b78f8797d678db9d187eb2322896fe4abd139477"> +4/-2</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        rules/rule-credentials-in-env-var/test/workloads/expected.json<br><br>

**Added the path to the value in the deletePaths and <br>failedPaths arrays in the expected test results.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/560/files#diff-6046ce746617c655de591822013282420f624a34342aa2843145f9f74366f221"> +4/-2</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
