### PR TITLE
Adding default exceptions

### DIFF
--- a/exceptions/kubescape.json
+++ b/exceptions/kubescape.json
@@ -1,5 +1,56 @@
 [
     {
+        "name": "kubescape-ignore",
+        "policyType": "postureExceptionPolicy",
+        "actions": [
+            "alertOnly"
+        ],
+        "attributes": {
+            "systemException": true
+        },
+        "resources": [
+            {
+                "designatorType": "Attributes",
+                "attributes": {
+                    "kubescape.io/ignore": "true"
+                }
+            },
+            {
+                "designatorType": "Attributes",
+                "attributes": {
+                    "kubescape.io/ignore": "True"
+                }
+            },
+            {
+                "designatorType": "Attributes",
+                "attributes": {
+                    "kubescape.io/ignore": "yes"
+                }
+            },
+            {
+                "designatorType": "Attributes",
+                "attributes": {
+                    "kubescape.io/ignore": "1"
+                }
+            },
+            {
+                "designatorType": "Attributes",
+                "attributes": {
+                    "kubescape.io/ignore": "enable"
+                }
+            },
+            {
+                "designatorType": "Attributes",
+                "attributes": {
+                    "kubescape.io/ignore": "enabled"
+                }
+            }
+        ],
+        "posturePolicies": [
+            {}
+        ]
+    },
+    {
         "name": "exclude-kubescape-deployment-security-context",
         "policyType": "postureExceptionPolicy",
         "actions": [

--- a/exceptions/kubescape.json
+++ b/exceptions/kubescape.json
@@ -163,9 +163,6 @@
                 "controlID": "c-0211"
             },
             {
-                "controlID": "c-0076"
-            },
-            {
                 "controlID": "c-0058"
             },
             {

--- a/exceptions/kubescape.json
+++ b/exceptions/kubescape.json
@@ -76,19 +76,49 @@
         ],
         "posturePolicies": [
             {
+                "controlID": "c-0076"
+            },
+            {
+                "controlID": "c-0237"
+            },
+            {
                 "controlID": "c-0055"
+            },
+            {
+                "controlID": "c-0056"
             },
             {
                 "controlID": "c-0017"
             },
             {
+                "controlID": "c-0018"
+            },
+            {
+                "controlID": "c-0013"
+            },
+            {
+                "controlID": "c-0030"
+            },
+            {
                 "controlID": "c-0210"
+            },
+            {
+                "controlID": "c-0260"
+            },
+            {
+                "controlID": "c-0207"
             },
             {
                 "controlID": "c-0211"
             },
             {
+                "controlID": "c-0076"
+            },
+            {
                 "controlID": "c-0058"
+            },
+            {
+                "controlID": "c-0038"
             }
         ]
     },
@@ -206,6 +236,9 @@
         "posturePolicies": [
             {
                 "controlID": "c-0030"
+            },
+            {
+                "controlID": "c-0013"
             }
         ]
     },
@@ -380,7 +413,31 @@
                 "designatorType": "Attributes",
                 "attributes": {
                     "kind": "ServiceAccount",
+                    "name": "storage",
+                    "namespace": "kubescape"
+                }
+            },
+            {
+                "designatorType": "Attributes",
+                "attributes": {
+                    "kind": "ServiceAccount",
                     "name": "kubescape-sa",
+                    "namespace": "kubescape"
+                }
+            },
+            {
+                "designatorType": "Attributes",
+                "attributes": {
+                    "kind": "ServiceAccount",
+                    "name": "node-agent",
+                    "namespace": "kubescape"
+                }
+            },
+            {
+                "designatorType": "Attributes",
+                "attributes": {
+                    "kind": "ServiceAccount",
+                    "name": "kubevuln",
                     "namespace": "kubescape"
                 }
             },
@@ -406,7 +463,19 @@
                 "controlID": "c-0034"
             },
             {
+                "controlID": "c-0207"
+            },
+            {
+                "controlID": "c-0013"
+            },
+            {
+                "controlID": "c-0015"
+            },
+            {
                 "controlID": "c-0053"
+            },
+            {
+                "controlID": "c-0186"
             }
         ]
     },
@@ -530,6 +599,12 @@
                 "controlID": "c-0055"
             },
             {
+                "controlID": "c-0260"
+            },
+            {
+                "controlID": "c-0013"
+            },
+            {
                 "controlID": "c-0056"
             },
             {
@@ -577,6 +652,9 @@
             },
             {
                 "controlID": "c-0034"
+            },
+            {
+                "controlID": "c-0260"
             },
             {
                 "controlID": "c-0055"


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
enhancement


___

## **Description**
- Enhanced the security posture by adding new control IDs (`c-0076`, `c-0237`, `c-0056`, `c-0018`, `c-0013`, `c-0030`, `c-0260`, `c-0207`, `c-0038`, `c-0015`, `c-0186`) to the `posturePolicies` across various sections.
- Introduced new `Attributes` for `ServiceAccount` with specific names (`storage`, `node-agent`, `kubevuln`) and namespace `kubescape`, improving the granularity of exceptions.
- This update aims to provide a more comprehensive and fine-grained control over security exceptions, enhancing the overall security posture.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kubescape.json</strong><dd><code>Enhancement of Security Posture with Additional Exceptions</code></dd></summary>
<hr>

exceptions/kubescape.json
<li>Added new control IDs to <code>posturePolicies</code> in multiple sections.<br> <li> Introduced new <code>Attributes</code> with <code>designatorType</code> for various <br><code>ServiceAccount</code> names and namespaces.<br> <li> Enhanced the coverage of exceptions by including additional control <br>IDs and attributes for better security posture management.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/576/files#diff-abf091dad0e0f404cfe698288b41d65e11d7c58d18c543fdd21345dbcabe6e10">+78/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
