### PR TITLE
Changing release artifact names

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -133,6 +133,38 @@ jobs:
           name: ${{ env.REGO_ARTIFACT_KEY_NAME }}
           path: ${{ env.REGO_ARTIFACT_PATH }}
 
+      - name: Create v2 assets
+        run: |
+          LIST_OF_V1_ASSETS=("frameworks.json" "security_frameworks.json" "controls.json" "rules.json" "exceptions.json")
+          LIST_OF_V2_ASSETS=("frameworks-v2.json" "security_frameworks-v2.json" "controls-v2.json" "rules-v2.json" "exceptions-v2.json")
+          # Rename assets in v1 list to the name in v2 list
+          for i in "${!LIST_OF_V1_ASSETS[@]}"; do
+          mv "${REGO_ARTIFACT_PATH}/${LIST_OF_V1_ASSETS[$i]}" "${REGO_ARTIFACT_PATH}/${LIST_OF_V2_ASSETS[$i]}"
+          done
+
+          LAST_V1_URL="https://github.com/kubescape/regolibrary/releases/download/v1.0.312-rc.0/"
+          # Loop over v1 assets and download them
+          for i in "${!LIST_OF_V1_ASSETS[@]}"; do
+          # Remove .json from the asset name
+          basename=$(echo "${LIST_OF_V1_ASSETS[$i]}" | sed 's/.json//')
+          curl -s -f -L -o "${REGO_ARTIFACT_PATH}/${LIST_OF_V1_ASSETS[$i]}" "${LAST_V1_URL}${basename}"
+          done
+
+          printf "Important note!\n\nThe following assets are the real releases and have been renamed to v2: \n" > "${REGO_ARTIFACT_PATH}/IMPORTANT_v2_assets_note.txt"
+          for i in "${!LIST_OF_V1_ASSETS[@]}"; do
+          printf "  - ${LIST_OF_V1_ASSETS[$i]} -> ${LIST_OF_V2_ASSETS[$i]}\n" >> "${REGO_ARTIFACT_PATH}/IMPORTANT_v2_assets_note.txt"
+          done
+          printf "\n" >> "${REGO_ARTIFACT_PATH}/IMPORTANT_v2_assets_note.txt"
+          printf "The following assets have been downloaded from the release ${LAST_V1_URL}: \n" >> "${REGO_ARTIFACT_PATH}/IMPORTANT_v2_assets_note.txt"
+          for i in "${!LIST_OF_V1_ASSETS[@]}"; do
+          printf "  - ${LIST_OF_V1_ASSETS[$i]}\n" >> "${REGO_ARTIFACT_PATH}/IMPORTANT_v2_assets_note.txt"
+          done
+          printf "\nThis is due to the problem that were introduced in Kubescape that it failes when cannot collect scan objects. This prevents regolibrary to release new controls therefore we are doing releases under new artifact names and keeping a copy of old release artifacts here." >> "${REGO_ARTIFACT_PATH}/IMPORTANT_v2_assets_note.txt"
+
+
+
+
+
       - name: Create Release and upload assets
         id: create_release_upload_assets
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -160,6 +160,7 @@ jobs:
           printf "  - ${LIST_OF_V1_ASSETS[$i]}\n" >> "${REGO_ARTIFACT_PATH}/IMPORTANT_v2_assets_note.txt"
           done
           printf "\nThis is due to the problem that were introduced in Kubescape that it failes when cannot collect scan objects. This prevents regolibrary to release new controls therefore we are doing releases under new artifact names and keeping a copy of old release artifacts here." >> "${REGO_ARTIFACT_PATH}/IMPORTANT_v2_assets_note.txt"
+          printf "See https://github.com/kubescape/regolibrary/issues/577\n\n" >> "${REGO_ARTIFACT_PATH}/IMPORTANT_v2_assets_note.txt"
 
 
 

--- a/gitregostore/gitstoreutils.go
+++ b/gitregostore/gitstoreutils.go
@@ -23,14 +23,14 @@ type storeSetter func(*GitRegoStore, string) error
 const (
 	attackTracksJsonFileName          = "attack_tracks.json"
 	attackTracksPathPrefix            = "attack-tracks"
-	frameworksJsonFileName            = "frameworks.json"
-	securityFrameworksJsonFileName    = "security_frameworks.json"
-	controlsJsonFileName              = "controls.json"
-	rulesJsonFileName                 = "rules.json"
+	frameworksJsonFileName            = "frameworks-v2.json"
+	securityFrameworksJsonFileName    = "security_frameworks-v2.json"
+	controlsJsonFileName              = "controls-v2.json"
+	rulesJsonFileName                 = "rules-v2.json"
 	frameworkControlRelationsFileName = "FWName_CID_CName.csv"
 	ControlRuleRelationsFileName      = "ControlID_RuleName.csv"
 	defaultConfigInputsFileName       = "default_config_inputs.json"
-	systemPostureExceptionFileName    = "exceptions.json"
+	systemPostureExceptionFileName    = "exceptions-v2.json"
 
 	controlIDRegex                    = `^(?:[a-z]+|[A-Z]+)(?:[\-][v]?(?:[0-9][\.]?)+)(?:[\-]?[0-9][\.]?)+$`
 	earliestTagWithSecurityFrameworks = "v1.0.282-rc.0"


### PR DESCRIPTION
## **User description**
## Overview

This PR changes the names of release artifacts in the Regolibrary release and changes the go-module to take the new release names. It also preserves old release artifacts under the old name to enable backward compatibility in for older Kubescapes.

This is the first PR to mitigate #577


___

## **Type**
enhancement, documentation


___

## **Description**
- Renamed artifact file names in `gitregostore/gitstoreutils.go` to include a '-v2' suffix for frameworks, security frameworks, controls, rules, and exceptions to support v2 release.
- Updated the GitHub Actions workflow in `.github/workflows/create-release.yaml` to:
  - Rename v1 assets to v2 during the release process.
  - Download and preserve old v1 assets for backward compatibility.
  - Add an important note in the release artifacts about the renaming and preservation of v1 assets, addressing issue #577.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitstoreutils.go</strong><dd><code>Renaming Artifact File Names to Support v2 Release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gitregostore/gitstoreutils.go
<li>Renamed artifact file names with a '-v2' suffix for frameworks, <br>security frameworks, controls, rules, and exceptions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/578/files#diff-0038136303ab8a67bc3ddffd96c369f1b568f1a7ee406069a152f2fd984e46ab">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create-release.yaml</strong><dd><code>Enhancing Release Workflow for v2 Assets and Backward Compatibility</code></dd></summary>
<hr>

.github/workflows/create-release.yaml
<li>Added steps to rename v1 assets to v2 in the release process.<br> <li> Downloaded old v1 assets and preserved them for backward <br>compatibility.<br> <li> Added an important note in the release artifacts about the renaming <br>and preservation of v1 assets.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/578/files#diff-a318819fb0ec8889018cbef8e6dd222e317757d95ddd93b62b714ac7c49f04f6">+33/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
