### PR TITLE
fix C-0211 sysctls fixpath

### DIFF
--- a/rules/set-sysctls-params/raw.rego
+++ b/rules/set-sysctls-params/raw.rego
@@ -12,12 +12,14 @@ deny[msga] {
     not pod.spec.securityContext.sysctls
 
     path := "spec.securityContext.sysctls"
+	fixPaths := [{"path": sprintf("%s.name", [path]), "value": "YOUR_VALUE"},
+				{"path": sprintf("%s.value", [path]), "value": "YOUR_VALUE"}]
     msga := {
 		"alertMessage": sprintf("Pod: %v does not set 'securityContext.sysctls'", [pod.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [],
-		"fixPaths": [{"path": path, "name": "net.ipv4.tcp_syncookie", "value": "1"}],
+		"fixPaths": fixPaths,
 		"alertObject": {
 			"k8sApiObjects": [pod]
 		}
@@ -37,12 +39,14 @@ deny[msga] {
     not wl.spec.template.spec.securityContext.sysctls
 
     path := "spec.template.spec.securityContext.sysctls"
+	fixPaths := [{"path": sprintf("%s.name", [path]), "value": "YOUR_VALUE"},
+				{"path": sprintf("%s.value", [path]), "value": "YOUR_VALUE"}]
     msga := {
 		"alertMessage": sprintf("Workload: %v does not set 'securityContext.sysctls'", [wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [],
-		"fixPaths": [{"path": path, "name": "net.ipv4.tcp_syncookie", "value": "1"}],
+		"fixPaths": fixPaths,
 		"alertObject": {
 			"k8sApiObjects": [wl]
 		}
@@ -61,12 +65,14 @@ deny[msga] {
     not cj.spec.jobTemplate.spec.template.spec.securityContext.sysctls
 
     path := "spec.jobTemplate.spec.template.spec.securityContext.sysctls"
+	fixPaths := [{"path": sprintf("%s.name", [path]), "value": "YOUR_VALUE"},
+				{"path": sprintf("%s.value", [path]), "value": "YOUR_VALUE"}]
     msga := {
 		"alertMessage": sprintf("CronJob: %v does not set 'securityContext.sysctls'", [cj.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [],
-		"fixPaths": [{"path": path, "name": "net.ipv4.tcp_syncookie", "value": "1"}],
+		"fixPaths": fixPaths,
 		"alertObject": {
 			"k8sApiObjects": [cj]
 		}

--- a/rules/set-sysctls-params/test/cronjob/expected.json
+++ b/rules/set-sysctls-params/test/cronjob/expected.json
@@ -1,21 +1,30 @@
 [
-    {
-        "alertMessage": "CronJob: hello does not set 'securityContext.sysctls'",
-        "packagename": "armo_builtins",
-        "alertScore": 7,
-        "failedPaths": [],
-        "fixPaths": [{"path": "spec.jobTemplate.spec.template.spec.securityContext.sysctls", "name": "net.ipv4.tcp_syncookie", "value": "1"}],
-        "ruleStatus": "",
-        "alertObject": {
-            "k8sApiObjects": [
-                {
-                  "apiVersion": "batch/v1beta1",
-                  "kind": "CronJob",
-                  "metadata": {
-                    "name": "hello"
-                  }
-                }
-            ]
+  {
+    "alertMessage": "CronJob: hello does not set 'securityContext.sysctls'",
+    "packagename": "armo_builtins",
+    "alertScore": 7,
+    "failedPaths": [],
+    "fixPaths": [
+      {
+        "path": "spec.jobTemplate.spec.template.spec.securityContext.sysctls.name",
+        "value": "YOUR_VALUE"
+      },
+      {
+        "path": "spec.jobTemplate.spec.template.spec.securityContext.sysctls.value",
+        "value": "YOUR_VALUE"
+      }
+    ],
+    "ruleStatus": "",
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "batch/v1beta1",
+          "kind": "CronJob",
+          "metadata": {
+            "name": "hello"
+          }
         }
+      ]
     }
+  }
 ]

--- a/rules/set-sysctls-params/test/pod/expected.json
+++ b/rules/set-sysctls-params/test/pod/expected.json
@@ -1,21 +1,29 @@
 [
-    {
-        "alertMessage": "Pod: nginx does not set 'securityContext.sysctls'",
-        "packagename": "armo_builtins",
-        "alertScore": 7,
-        "failedPaths": [],
-        "fixPaths": [{"path": "spec.securityContext.sysctls", "name": "net.ipv4.tcp_syncookie", "value": "1"}],
-        "ruleStatus": "",
-        "alertObject": {
-            "k8sApiObjects": [
-                {
-                  "apiVersion": "v1",
-                  "kind": "Pod",
-                  "metadata": {
-                    "name": "nginx"
-                  }
-                }
-            ]
+  {
+    "alertMessage": "Pod: nginx does not set 'securityContext.sysctls'",
+    "packagename": "armo_builtins",
+    "alertScore": 7,
+    "failedPaths": [],
+    "fixPaths": [
+      {
+        "path": "spec.securityContext.sysctls.name",
+        "value": "YOUR_VALUE"
+      },
+      {
+        "path": "spec.securityContext.sysctls.value",
+        "value": "YOUR_VALUE"}
+    ],
+    "ruleStatus": "",
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "v1",
+          "kind": "Pod",
+          "metadata": {
+            "name": "nginx"
+          }
         }
+      ]
     }
+  }
 ]

--- a/rules/set-sysctls-params/test/workload/expected.json
+++ b/rules/set-sysctls-params/test/workload/expected.json
@@ -1,24 +1,33 @@
 [
-    {
-        "alertMessage": "Workload: my-deployment does not set 'securityContext.sysctls'",
-        "packagename": "armo_builtins",
-        "alertScore": 7,
-        "failedPaths": [],
-	"fixPaths": [{"path": "spec.template.spec.securityContext.sysctls", "name": "net.ipv4.tcp_syncookie", "value": "1"}],
-        "ruleStatus": "",
-        "alertObject": {
-            "k8sApiObjects": [
-                {
-                  "apiVersion": "apps/v1",
-                  "kind": "Deployment",
-                  "metadata": {
-                    "name": "my-deployment",
-                    "labels": {
-                      "app": "goproxy"
-                    }
-                  }
-                }
-            ]
+  {
+    "alertMessage": "Workload: my-deployment does not set 'securityContext.sysctls'",
+    "packagename": "armo_builtins",
+    "alertScore": 7,
+    "failedPaths": [],
+    "fixPaths": [
+      {
+        "path": "spec.template.spec.securityContext.sysctls.name",
+        "value": "YOUR_VALUE"
+      },
+      {
+        "path": "spec.template.spec.securityContext.sysctls.value",
+        "value": "YOUR_VALUE"
+      }
+    ],
+    "ruleStatus": "",
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "metadata": {
+            "name": "my-deployment",
+            "labels": {
+              "app": "goproxy"
+            }
+          }
         }
+      ]
     }
+  }
 ]


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
This PR fixes the suggested fix of the sysctls section in the security context.
Important note - this fix is a place holder meant to prompt users to fill this section with values that are relevant for their application. K8s will not allow applying it as is because the key name is capital letters, this is good as it will force users to fill in meaningful values. 
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->
Resolves [issue](https://github.com/kubescape/kubescape/issues/1582)
<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
enhancement


___

## **Description**
- Enhanced sysctls configuration placeholders in security context checks to prompt users with "YOUR_VALUE" for customization.
- Updated expected test outputs to align with the new placeholder approach for Pods, Workloads, and CronJobs.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>raw.rego</strong><dd><code>Enhance sysctls Configuration Placeholders</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/set-sysctls-params/raw.rego
<li>Updated fixPaths to prompt users with "YOUR_VALUE" placeholders for <br>both name and value in sysctls configurations.<br> <li> Applied changes across Pod, Workload, and CronJob securityContext <br>checks.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/580/files#diff-a37f2cd9a003a7477451e586a81f39157377ca261a756e07153876f5e18f4301">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Expected Test Output for CronJob sysctls Configuration</code></dd></summary>
<hr>

rules/set-sysctls-params/test/cronjob/expected.json
<li>Modified expected test output to match new "YOUR_VALUE" placeholders <br>in sysctls configurations for CronJobs.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/580/files#diff-f174d879b4fa50082e890c0a607558060ae7a376e6c3fee5b11b5bb80a813c65">+27/-18</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Expected Test Output for Pod sysctls Configuration</code></dd></summary>
<hr>

rules/set-sysctls-params/test/pod/expected.json
<li>Updated expected test output to include "YOUR_VALUE" placeholders for <br>sysctls configurations in Pods.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/580/files#diff-a0f7111c7c25d4e3fc21032c16bc0587033ad543a21ffc34658534d3fbe24c22">+26/-18</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Expected Test Output for Workload sysctls Configuration</code></dd></summary>
<hr>

rules/set-sysctls-params/test/workload/expected.json
<li>Adjusted expected test output to reflect "YOUR_VALUE" placeholders in <br>sysctls configurations for Workloads.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/580/files#diff-e43b6b37747de50bdc2ad73383fb261712770916d5f919fa6b4ef701512addc0">+30/-21</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
