### PR TITLE
C-0012 add allowed values and keys lists to reduce false positives

### DIFF
--- a/default-config-inputs.json
+++ b/default-config-inputs.json
@@ -74,6 +74,8 @@
                 "_key_",
                 "_secret_"
             ],
+            "sensitiveKeyNamesAllowed": [],
+            "sensitiveValuesAllowed": [],
             "servicesNames": [
                 "nifi-service",
                 "argo-server",

--- a/rules/rule-credentials-configmap/raw.rego
+++ b/rules/rule-credentials-configmap/raw.rego
@@ -12,6 +12,10 @@ deny[msga] {
 
     contains(lower(map_key), lower(key_name))
 
+    # check that value or key weren't allowed by user
+    not is_allowed_value(map_secret)
+    not is_allowed_key_name(map_key)
+
     path := sprintf("data[%v]", [map_key])
 
 	msga := {
@@ -39,6 +43,10 @@ deny[msga] {
     map_secret != ""
 
     regex.match(value , map_secret)
+
+    # check that value or key weren't allowed by user
+    not is_allowed_value(map_secret)
+    not is_allowed_key_name(map_key)
 
     path := sprintf("data[%v]", [map_key])
 
@@ -70,6 +78,10 @@ deny[msga] {
 
     regex.match(value , decoded_secret)
 
+    # check that value or key weren't allowed by user
+    not is_allowed_value(map_secret)
+    not is_allowed_key_name(map_key)
+
     path := sprintf("data[%v]", [map_key])
 
 	msga := {
@@ -83,4 +95,14 @@ deny[msga] {
 			"k8sApiObjects": [configmap]
 		}
      }
+}
+
+is_allowed_value(value) {
+    allow_val := data.postureControlInputs.sensitiveValuesAllowed[_]
+    regex.match(allow_val , value)
+}
+
+is_allowed_key_name(key_name) {
+    allow_key := data.postureControlInputs.sensitiveKeyNamesAllowed[_]
+    contains(lower(key_name), lower(allow_key))
 }

--- a/rules/rule-credentials-configmap/rule.metadata.json
+++ b/rules/rule-credentials-configmap/rule.metadata.json
@@ -20,18 +20,30 @@
   "ruleDependencies": [],
   "configInputs": [
     "settings.postureControlInputs.sensitiveValues",
-    "settings.postureControlInputs.sensitiveKeyNames"
+    "settings.postureControlInputs.sensitiveKeyNames",
+    "settings.postureControlInputs.sensitiveValuesAllowed",
+    "settings.postureControlInputs.sensitiveKeyNamesAllowed"
   ],
   "controlConfigInputs": [
     {
       "path": "settings.postureControlInputs.sensitiveValues",
-      "name": "Values",
+      "name": "Sensitive Values",
       "description": "Strings that identify a value that Kubescape believes should be stored in a Secret, and not in a ConfigMap or an environment variable."
     },
     {
+      "path": "settings.postureControlInputs.sensitiveValuesAllowed",
+      "name": "Allowed Values",
+      "description": "Reduce false positives with known values."
+    },
+    {
       "path": "settings.postureControlInputs.sensitiveKeyNames",
-      "name": "Keys",
+      "name": "Sensitive Keys",
       "description": "Key names that identify a potential value that should be stored in a Secret, and not in a ConfigMap or an environment variable."
+    },
+    {
+      "path": "settings.postureControlInputs.sensitiveKeyNamesAllowed",
+      "name": "Allowed Keys",
+      "description": "Reduce false positives with known key names."
     }
   ],
   "description": "fails if ConfigMaps have sensitive information in configuration",

--- a/rules/rule-credentials-configmap/test/test-allowed-values-keys/data.json
+++ b/rules/rule-credentials-configmap/test/test-allowed-values-keys/data.json
@@ -1,0 +1,31 @@
+{
+    "postureControlInputs": {
+        "sensitiveKeyNames": [
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "azure_batchai_storage_account",
+            "azure_batchai_storage_key",
+            "azure_batch_account",
+            "azure_batch_key",
+            "secret",
+            "key",
+            "password",
+            "pwd",
+            "token",
+            "jwt",
+            "bearer",
+            "credential"
+        ],
+        "sensitiveValues": [
+            "BEGIN \\w+ PRIVATE KEY",
+            "PRIVATE KEY",
+            "eyJhbGciO",
+            "JWT",
+            "Bearer",
+            "_key_",
+            "_secret_"
+        ],
+        "sensitiveKeyNamesAllowed": ["_FILE"],
+        "sensitiveValuesAllowed": ["my/secret/file/path"]
+    }
+}

--- a/rules/rule-credentials-configmap/test/test-allowed-values-keys/expected.json
+++ b/rules/rule-credentials-configmap/test/test-allowed-values-keys/expected.json
@@ -1,0 +1,35 @@
+[{
+    "alertMessage": "this configmap has sensitive information: game-demo",
+    "deletePaths": ["data[aws_access_key_id]"],
+    "failedPaths": ["data[aws_access_key_id]"],
+    "fixPaths": [],
+    "ruleStatus": "",
+    "packagename": "armo_builtins",
+    "alertScore": 9,
+    "alertObject": {
+        "k8sApiObjects": [{
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": "game-demo"
+            }
+        }]
+    }
+}, {
+    "alertMessage": "this configmap has sensitive information: game-demo",
+    "deletePaths": ["data[pwd]"],
+    "failedPaths": ["data[pwd]"],
+    "fixPaths": [],
+    "ruleStatus": "",
+    "packagename": "armo_builtins",
+    "alertScore": 9,
+    "alertObject": {
+        "k8sApiObjects": [{
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": "game-demo"
+            }
+        }]
+    }
+}]

--- a/rules/rule-credentials-configmap/test/test-allowed-values-keys/input/configmap.yaml
+++ b/rules/rule-credentials-configmap/test/test-allowed-values-keys/input/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: game-demo
+data:
+  # property-like keys; each key maps to a simple value
+  player_initial_lives: "3"
+  ui_properties_file_name: "user-interface.properties"
+  aws_access_key_id: "XXXX"
+  pwd: "hi"
+  aws_access_key_id_file: "/etc/secret-volume/aws"
+  aws_secret: "my/secret/file/path"
+  # file-like keys
+  game.properties: |
+    enemy.types=aliens,monsters
+    player.maximum-lives=5
+  user-interface.properties: |
+    color.good=purple
+    color.bad=yellow
+    allow.textmode=true

--- a/rules/rule-credentials-in-env-var/raw.rego
+++ b/rules/rule-credentials-in-env-var/raw.rego
@@ -11,6 +11,9 @@
 
 		contains(lower(env.name), lower(key_name))
 		env.value != ""
+		# check that value or key weren't allowed by user
+    	not is_allowed_value(env.value)
+    	not is_allowed_key_name(env.name)
 
 		is_not_reference(env)
 
@@ -43,6 +46,9 @@
 
 		contains(lower(env.name), lower(key_name))
 		env.value != ""
+		# check that value or key weren't allowed by user
+    	not is_allowed_value(env.value)
+    	not is_allowed_key_name(env.name)
 
 		is_not_reference(env)
 
@@ -72,8 +78,10 @@
 		env := container.env[j]
 
 		contains(lower(env.name), lower(key_name))
-
 		env.value != ""
+		# check that value or key weren't allowed by user
+    	not is_allowed_value(env.value)
+    	not is_allowed_key_name(env.name)
 
 		is_not_reference(env)
 
@@ -104,6 +112,9 @@ deny[msga] {
 		env := container.env[j]
 
 		contains(lower(env.value), lower(value))
+		# check that value or key weren't allowed by user
+    	not is_allowed_value(env.value)
+    	not is_allowed_key_name(env.name)
 
 		is_not_reference(env)
 
@@ -135,6 +146,9 @@ deny[msga] {
 		env := container.env[j]
 
 		contains(lower(env.value), lower(value))
+		# check that value or key weren't allowed by user
+    	not is_allowed_value(env.value)
+    	not is_allowed_key_name(env.name)
 
 		is_not_reference(env)
 
@@ -164,6 +178,9 @@ deny[msga] {
 		env := container.env[j]
 
 		contains(lower(env.value), lower(value))
+		# check that value or key weren't allowed by user
+    	not is_allowed_value(env.value)
+    	not is_allowed_key_name(env.name)
 
 		is_not_reference(env)
 
@@ -188,4 +205,14 @@ is_not_reference(env)
 {
 	not env.valueFrom.secretKeyRef
 	not env.valueFrom.configMapKeyRef
+}
+
+is_allowed_value(value) {
+    allow_val := data.postureControlInputs.sensitiveValuesAllowed[_]
+    regex.match(allow_val , value)
+}
+
+is_allowed_key_name(key_name) {
+    allow_key := data.postureControlInputs.sensitiveKeyNamesAllowed[_]
+    contains(lower(key_name), lower(allow_key))
 }

--- a/rules/rule-credentials-in-env-var/rule.metadata.json
+++ b/rules/rule-credentials-in-env-var/rule.metadata.json
@@ -46,18 +46,30 @@
   "ruleDependencies": [],
   "configInputs": [
     "settings.postureControlInputs.sensitiveValues",
-    "settings.postureControlInputs.sensitiveKeyNames"
+    "settings.postureControlInputs.sensitiveKeyNames",
+    "settings.postureControlInputs.sensitiveValuesAllowed",
+    "settings.postureControlInputs.sensitiveKeyNamesAllowed"
   ],
   "controlConfigInputs": [
     {
       "path": "settings.postureControlInputs.sensitiveValues",
-      "name": "Values",
+      "name": "Sensitive Values",
       "description": "Strings that identify a value that Kubescape believes should be stored in a Secret, and not in a ConfigMap or an environment variable."
     },
     {
+      "path": "settings.postureControlInputs.sensitiveValuesAllowed",
+      "name": "Allowed Values",
+      "description": "Reduce false positives with known values."
+    },
+    {
       "path": "settings.postureControlInputs.sensitiveKeyNames",
-      "name": "Keys",
+      "name": "Sensitive Keys",
       "description": "Key names that identify a potential value that should be stored in a Secret, and not in a ConfigMap or an environment variable."
+    },
+    {
+      "path": "settings.postureControlInputs.sensitiveKeyNamesAllowed",
+      "name": "Allowed Keys",
+      "description": "Reduce false positives with known key names."
     }
   ],
   "description": "fails if Pods have sensitive information in configuration",

--- a/rules/rule-credentials-in-env-var/test/pod-allowed-values-keys/data.json
+++ b/rules/rule-credentials-in-env-var/test/pod-allowed-values-keys/data.json
@@ -1,0 +1,31 @@
+{
+    "postureControlInputs": {
+        "sensitiveKeyNames": [
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "azure_batchai_storage_account",
+            "azure_batchai_storage_key",
+            "azure_batch_account",
+            "azure_batch_key",
+            "secret",
+            "key",
+            "password",
+            "pwd",
+            "token",
+            "jwt",
+            "bearer",
+            "credential"
+        ],
+        "sensitiveValues": [
+            "BEGIN \\w+ PRIVATE KEY",
+            "PRIVATE KEY",
+            "eyJhbGciO",
+            "JWT",
+            "Bearer",
+            "_key_",
+            "_secret_"
+        ],
+        "sensitiveKeyNamesAllowed": ["_FILE"],
+        "sensitiveValuesAllowed": ["my/secret/file/path"]
+    }
+}

--- a/rules/rule-credentials-in-env-var/test/pod-allowed-values-keys/expected.json
+++ b/rules/rule-credentials-in-env-var/test/pod-allowed-values-keys/expected.json
@@ -1,0 +1,31 @@
+[
+    {
+        "alertMessage": "Pod: audit-pod has sensitive information in environment variables",
+        "deletePaths": [
+            "spec.containers[0].env[1].name",
+            "spec.containers[0].env[1].value"
+        ],
+        "failedPaths": [
+            "spec.containers[0].env[1].name",
+            "spec.containers[0].env[1].value"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 9,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "labels": {
+                            "app": "audit-pod"
+                        },
+                        "name": "audit-pod"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/rule-credentials-in-env-var/test/pod-allowed-values-keys/input/pod.yaml
+++ b/rules/rule-credentials-in-env-var/test/pod-allowed-values-keys/input/pod.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: audit-pod
+  labels:
+    app: audit-pod
+spec:
+  containers:
+  - name: test-container
+    env :
+      - name : random
+        value : "Hello from the environment"
+      - name: some-name
+        value: my_key_value
+    image: hashicorp/http-echo:0.2.3
+    securityContext:
+      allowPrivilegeEscalation: true
+  - name : test-container2
+    env :
+      - name : random
+        value : "Hello from the environment"
+      - name: AWS_TOKEN_FILE
+        value: /etc/secret-volume/aws
+      - name: my_password
+        value: my/secret/file/path
+    image : hashicorp/http-echo:0.2.3


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
This adds the ability to exclude keys and values that would regularly be considered as sensitive (re-adding sensitiveValuesAllowed and adding sensitiveKeyNamesAllowed).
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Added the ability to specify allowed keys and values to reduce false positives in ConfigMap and environment variable rules.
- Implemented checks in Rego policies to skip alerts for user-specified allowed keys and values.
- Updated rule metadata to include new configuration inputs for allowed keys and values.
- Added tests and test data to verify the functionality of allowed keys and values in reducing false positives.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>default-config-inputs.json</strong><dd><code>Add Allowed Keys and Values to Configuration Inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

default-config-inputs.json
<li>Added <code>sensitiveKeyNamesAllowed</code> and <code>sensitiveValuesAllowed</code> to the <br>configuration inputs.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/581/files#diff-01c7cee651bbe5f7335130d6a0e2934f121267204e54d0446da96c606d52aef9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rule.metadata.json</strong><dd><code>Update ConfigMap Rule Metadata for Allowed Keys and Values</code></dd></summary>
<hr>

rules/rule-credentials-configmap/rule.metadata.json
<li>Updated <code>configInputs</code> and <code>controlConfigInputs</code> to include allowed keys <br>and values.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/581/files#diff-aa06c0f418b1fb944900969faab74ebe73ca8fd83941a4789b760e1536be07fd">+15/-3</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rule.metadata.json</strong><dd><code>Update Env Var Rule Metadata for Allowed Keys and Values</code>&nbsp; </dd></summary>
<hr>

rules/rule-credentials-in-env-var/rule.metadata.json
<li>Updated <code>configInputs</code> and <code>controlConfigInputs</code> to include allowed keys <br>and values for environment variables.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/581/files#diff-3c91e014732c8817572eb566ebd827c3bddc8e1ea523d77ed4d2e4aded668e36">+15/-3</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>raw.rego</strong><dd><code>Implement Allowed Keys and Values Checks for ConfigMaps</code>&nbsp; &nbsp; </dd></summary>
<hr>

rules/rule-credentials-configmap/raw.rego
<li>Implemented checks to skip alerts for allowed keys and values <br>specified by the user.<br> <li> Added helper functions <code>is_allowed_value</code> and <code>is_allowed_key_name</code> to <br>facilitate these checks.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/581/files#diff-1781a094769587a2c644773ca7e494d7e865b9a07edde09e601d40ac6ad00d08">+22/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>raw.rego</strong><dd><code>Implement Allowed Keys and Values Checks for Env Vars</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/rule-credentials-in-env-var/raw.rego
<li>Added checks to skip alerts for allowed keys and values in environment <br>variables.<br> <li> Added helper functions <code>is_allowed_value</code> and <code>is_allowed_key_name</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/581/files#diff-7c604ff0409ca6377338b9cf8d80ec376b70a1b7db37254cb75a116c4e96f877">+28/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>data.json</strong><dd><code>Add Test Data for Allowed Keys and Values in ConfigMap Rule</code></dd></summary>
<hr>

rules/rule-credentials-configmap/test/test-allowed-values-keys/data.json
- Added test data for allowed keys and values in ConfigMap rule.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/581/files#diff-7692753d43005006df1b1aab17085642a8943f9afd412bd2beb2e09c7b7f0b8a">+31/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Add Expected Test Results for Allowed Keys and Values</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/rule-credentials-configmap/test/test-allowed-values-keys/expected.json
<li>Added expected test results for allowed keys and values in ConfigMap <br>rule.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/581/files#diff-ef44f08f65230db34207637b5e417897e75e57dd2ccd57a8acfacf2ab2def7c5">+35/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>configmap.yaml</strong><dd><code>Add ConfigMap YAML for Testing Allowed Keys and Values</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/rule-credentials-configmap/test/test-allowed-values-keys/input/configmap.yaml
- Added a ConfigMap YAML for testing allowed keys and values.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/581/files#diff-087c12b704e87277675f08f2b2da4dbf0983ea2c0cc073e62a0474b63a092698">+20/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>data.json</strong><dd><code>Add Test Data for Allowed Keys and Values in Env Var Rule</code></dd></summary>
<hr>

rules/rule-credentials-in-env-var/test/pod-allowed-values-keys/data.json
<li>Added test data for allowed keys and values in environment variables <br>rule.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/581/files#diff-8ed08e21e3b717ece52222eef493cc3400ca5a9b0f36ea20ed681a8b9cba9f65">+31/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Add Expected Test Results for Allowed Keys and Values in Env Var Rule</code></dd></summary>
<hr>

rules/rule-credentials-in-env-var/test/pod-allowed-values-keys/expected.json
<li>Added expected test results for allowed keys and values in environment <br>variables rule.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/581/files#diff-9ba70d7ab6b0bc9da6bf9650f7e2d914eff936f1080f156e871ada860340a2c8">+31/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pod.yaml</strong><dd><code>Add Pod YAML for Testing Allowed Keys and Values in Env Vars</code></dd></summary>
<hr>

rules/rule-credentials-in-env-var/test/pod-allowed-values-keys/input/pod.yaml
<li>Added a Pod YAML for testing allowed keys and values in environment <br>variables.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/581/files#diff-e7de0928679bcc1a9dcfd1081c0162aef20c615e84d7150c9440e5ebdec170b5">+26/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

