### PR TITLE
C-0013 - clarify remediation

### DIFF
--- a/controls/C-0013-nonrootcontainers.json
+++ b/controls/C-0013-nonrootcontainers.json
@@ -7,12 +7,12 @@
         ]
     },
     "description": "Potential attackers may gain access to a container and leverage its existing privileges to conduct an attack. Therefore, it is not recommended to deploy containers with root privileges unless it is absolutely necessary. This control identifies all the pods running as root or can escalate to root.",
-    "remediation": "If your application does not need root privileges, make sure to define the runAsUser or runAsGroup under the PodSecurityContext or container securityContext and use user ID 1000 or higher, or make sure that runAsNonRoot is true.",
+    "remediation": "If your application does not need root privileges, make sure to define runAsNonRoot as true or explicitly set the runAsUser using ID 1000 or higher under the PodSecurityContext or container securityContext. In addition, set an explicit value for runAsGroup using ID 1000 or higher.",
     "rulesNames": [
         "non-root-containers"
     ],
     "long_description": "Container engines allow containers to run applications as a non-root user with non-root group membership. Typically, this non-default setting is configured when the container image is built. Alternatively, Kubernetes can load containers into a Pod with SecurityContext:runAsUser specifying a non-zero user. While the runAsUser directive effectively forces non-root execution at deployment, NSA and CISA encourage developers to build container applications to execute as a non-root user. Having non-root execution integrated at build time provides better assurance that applications will function correctly without root privileges.",
-    "test": "Verify that runAsUser and runAsGroup are set to a user id greater than 0, or that runAsNonRoot is set to true. Check all the combinations with PodSecurityContext and SecurityContext (for containers).",
+    "test": "Verify that runAsUser is set to a user id greater than 0 or that runAsNonRoot is set to true, and that runAsGroup is set to an id greater than 0. Check all the combinations with PodSecurityContext and SecurityContext (for containers).",
     "controlID": "C-0013",
     "baseScore": 6.0,
     "example": "@controls/examples/c013.yaml",


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
enhancement


___

## **Description**
- Enhanced the `remediation` section in `C-0013-nonrootcontainers.json` to clarify the use of `runAsNonRoot`, `runAsUser`, and `runAsGroup` for better security practices.
- Updated the `test` section to provide more specific instructions on verifying the security settings related to running containers as non-root.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>C-0013-nonrootcontainers.json</strong><dd><code>Enhanced Remediation and Testing Instructions for Non-Root Containers</code></dd></summary>
<hr>

controls/C-0013-nonrootcontainers.json
<li>Updated the <code>remediation</code> section to provide clearer instructions on <br>setting <code>runAsNonRoot</code>, <code>runAsUser</code>, and <code>runAsGroup</code>.<br> <li> Refined the <code>test</code> section to specify the verification of <code>runAsUser</code>, <br><code>runAsNonRoot</code>, and <code>runAsGroup</code> settings.


</details>
    

  </td>
  <td><a href="https:/kubescape/regolibrary/pull/585/files#diff-56711d09e40b4585693f8ded3d254a02bf966d104dbc0243fe37408f5f49cde3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

