### PR TITLE
add new attack paths for security risks

### DIFF
--- a/attack-tracks/external-wl-unauthenticated.json
+++ b/attack-tracks/external-wl-unauthenticated.json
@@ -1,0 +1,20 @@
+{
+    "apiVersion": "regolibrary.kubescape/v1alpha1",
+    "kind": "AttackTrack",
+    "metadata": {
+        "name": "external-database-without-authentication"
+    },
+    "spec": {
+        "version": "1.0",
+        "data": {
+            "name": "Initial Access",
+            "description": "An attacker can access the Kubernetes environment.",
+            "subSteps": [
+                {
+                    "name": "Unauthenticated Access",
+                    "description": "An unauthenticated attacker can access resources."
+                }
+            ]
+        }
+    }
+}

--- a/attack-tracks/external-wl-with-cluster-takeover-roles.json
+++ b/attack-tracks/external-wl-with-cluster-takeover-roles.json
@@ -11,7 +11,7 @@
             "description": "An attacker can access the Kubernetes environment.",
             "subSteps": [
                 {
-                    "name": "Cluster/Resources Access",
+                    "name": "Cluster Access",
                     "description": "An attacker has access to sensitive information and can leverage them by creating pods in the cluster."
                 }
             ]

--- a/attack-tracks/external-wl-with-cluster-takeover-roles.json
+++ b/attack-tracks/external-wl-with-cluster-takeover-roles.json
@@ -1,0 +1,20 @@
+{
+    "apiVersion": "regolibrary.kubescape/v1alpha1",
+    "kind": "AttackTrack",
+    "metadata": {
+        "name": "external-workload-with-cluster-takeover-roles"
+    },
+    "spec": {
+        "version": "1.0",
+        "data": {
+            "name": "Initial Access",
+            "description": "An attacker can access the Kubernetes environment.",
+            "subSteps": [
+                {
+                    "name": "Cluster/Resources Access",
+                    "description": "An attacker has access to sensitive information and can leverage them by creating pods in the cluster."
+                }
+            ]
+        }
+    }
+}

--- a/controls/C-0256-exposuretointernet.json
+++ b/controls/C-0256-exposuretointernet.json
@@ -16,6 +16,18 @@
                 "categories": [
                     "Initial Access"
                 ]
+            },
+            {
+                "attackTrack": "external-workload-with-cluster-takeover-roles",
+                "categories": [
+                    "Initial Access"
+                ]
+            },
+            {
+                "attackTrack": "external-database-without-authentication",
+                "categories": [
+                    "Initial Access"
+                ]
             }
         ]
     },

--- a/controls/C-0267-workloadwithclustertakeoverroles.json
+++ b/controls/C-0267-workloadwithclustertakeoverroles.json
@@ -1,6 +1,18 @@
 {
     "name": "Workload with cluster takeover roles",
-    "attributes": {},
+    "attributes": {
+        "controlTypeTags": [
+            "security"
+        ],
+        "attackTracks": [
+            {
+                "attackTrack": "external-workload-with-cluster-takeover-roles",
+                "categories": [
+                    "Initial Access"
+                ]
+            }
+        ]
+    },
     "description": "Cluster takeover roles include workload creation or update and secret access. They can easily lead to super privileges in the cluster. If an attacker can exploit this workload then the attacker can take over the cluster using the RBAC privileges this workload is assigned to.",
     "remediation": "You should apply least privilege principle. Make sure each service account has only the permissions that are absolutely necessary.",
     "rulesNames": [

--- a/controls/C-0267-workloadwithclustertakeoverroles.json
+++ b/controls/C-0267-workloadwithclustertakeoverroles.json
@@ -8,7 +8,7 @@
             {
                 "attackTrack": "external-workload-with-cluster-takeover-roles",
                 "categories": [
-                    "Initial Access"
+                    "Cluster Access"
                 ]
             }
         ]

--- a/frameworks/security.json
+++ b/frameworks/security.json
@@ -183,6 +183,12 @@
             }
         },
         {
+            "controlID": "C-0267",
+            "patch": {
+                "name": "Workload with cluster takeover roles"
+            }
+        },
+        {
             "controlID": "C-0270",
             "patch": {
                 "name": "Ensure CPU limits are set"
@@ -192,6 +198,18 @@
             "controlID": "C-0271",
             "patch": {
                 "name": "Ensure memory limits are set"
+            }
+        },
+        {
+            "controlID": "C-0272",
+            "patch": {
+                "name": "Workload with administrative roles"
+            }
+        },
+        {
+            "controlID": "C-0273",
+            "patch": {
+                "name": "Outdated Kubernetes version"
             }
         }
     ]


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
enhancement


___

## **Description**
- Introduced two new AttackTracks for identifying security risks related to unauthenticated external database access and external workloads with cluster takeover roles.
- Updated controls and the security framework to include references to these new AttackTracks.
- Enhanced the detection of internet-exposed workloads by linking them with the newly added AttackTracks.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>external-wl-unauthenticated.json</strong><dd><code>Add AttackTrack for Unauthenticated External Database Access</code></dd></summary>
<hr>

attack-tracks/external-wl-unauthenticated.json
<li>Added a new AttackTrack for external databases without authentication.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/598/files#diff-3f0ebdd52387a2a1a949e852340165014f778ba834160fd455eea3ed49732301">+20/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>external-wl-with-cluster-takeover-roles.json</strong><dd><code>New AttackTrack for External Workloads with Cluster Takeover Roles</code></dd></summary>
<hr>

attack-tracks/external-wl-with-cluster-takeover-roles.json
<li>Introduced a new AttackTrack for external workloads with cluster <br>takeover roles.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/598/files#diff-dc833275e2ae28e80d7f6952ab191c558d05bfe612fa2f820776a549be7a00e5">+20/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>C-0256-exposuretointernet.json</strong><dd><code>Update Control for Internet-Exposed Workloads with New Attack Tracks</code></dd></summary>
<hr>

controls/C-0256-exposuretointernet.json
<li>Linked new attack tracks to the control for detecting internet-exposed <br>workloads.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/598/files#diff-bb4119d6c9aa609d437b062f4112e23a93c1a333009fe971f46d2ed4d9ffbd34">+12/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>C-0267-workloadwithclustertakeoverroles.json</strong><dd><code>Enhance Workload with Cluster Takeover Roles Control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

controls/C-0267-workloadwithclustertakeoverroles.json
<li>Updated attributes to include security tags and linked the new attack <br>track.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/598/files#diff-7d83a784e1bf8b7e0e44825fd2baa508dd2ded8124b0f35f16b93c272758c278">+13/-1</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>security.json</strong><dd><code>Security Framework Update with New Controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frameworks/security.json
<li>Added references to new controls and updated the security framework.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/598/files#diff-c88e59bbd8f153d854b49e17546ea6b8864bf2532f9be44e5d339f36f2658a9f">+18/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

