### PR TITLE
rm roleref as reviewPath, return only subject to del

### DIFF
--- a/rules/workload-with-cluster-takeover-roles/raw.rego
+++ b/rules/workload-with-cluster-takeover-roles/raw.rego
@@ -27,7 +27,6 @@ deny[msga] {
     rolebinding.subjects[j].name == sa.metadata.name
     rolebinding.subjects[j].namespace == sa.metadata.namespace
 
-    reviewPath := "roleRef"
     deletePath := sprintf("subjects[%d]", [j])
 
     msga := {
@@ -42,7 +41,6 @@ deny[msga] {
         },
         {
             "object": rolebinding,
-		    "reviewPaths": [reviewPath],
             "deletePaths": [deletePath],
         },
         {

--- a/rules/workload-with-cluster-takeover-roles/test/fail-wl-creates-pod/expected.json
+++ b/rules/workload-with-cluster-takeover-roles/test/fail-wl-creates-pod/expected.json
@@ -69,9 +69,7 @@
                     ]
                 },
                 "failedPaths": null,
-                "reviewPaths": [
-                    "roleRef"
-                ],
+                "reviewPaths": null,
                 "deletePaths": [
                     "subjects[1]"
                 ],

--- a/rules/workload-with-cluster-takeover-roles/test/fail-wl-gets-secrets/expected.json
+++ b/rules/workload-with-cluster-takeover-roles/test/fail-wl-gets-secrets/expected.json
@@ -69,9 +69,7 @@
                     ]
                 },
                 "failedPaths": null,
-                "reviewPaths": [
-                    "roleRef"
-                ],
+                "reviewPaths": null,
                 "deletePaths": [
                     "subjects[0]"
                 ],


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
enhancement


___

## **Description**
- This PR simplifies the policy evaluation result structure by removing the `roleRef` as a review path. Now, the result focuses solely on the subject to be deleted, making it clearer and more straightforward.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>raw.rego</strong><dd><code>Simplify Policy Evaluation Result Structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/workload-with-cluster-takeover-roles/raw.rego
<li>Removed <code>roleRef</code> as a review path in the policy evaluation result.<br> <li> Simplified the policy evaluation result by focusing on the deletion <br>path only.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/600/files#diff-1f2a0681b0f49068da5da4e76cfacca1b14a6f01c91b3fe101340f5c8dd42c2e">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

