### PR TITLE
Revert "removed control C-0264 from soc2 FW"

### DIFF
--- a/frameworks/soc2.json
+++ b/frameworks/soc2.json
@@ -60,6 +60,16 @@
                 "description": "Transport Layer Security (TLS) is used to protect the transmission of data sent over the internet to and from the organization's application server.",
                 "long_description": "Transport Layer Security (TLS) is used to protect the transmission of data sent over the internet to and from the organization's application server."
             }
+        },
+        {
+            "controlID": "C-0264",
+            "patch": {
+                "name": "Data in rest encryption - Persistent Volumes are encrypted (CC1.1,CC6.7)",
+                "description": "Transport Layer Security (TLS) is used to protect the transmission of data sent over the internet to and from the organization's application server.",
+                "long_description": "Transport Layer Security (TLS) is used to protect the transmission of data sent over the internet to and from the organization's application server."
+            }
         }
+
+
     ]
 }


### PR DESCRIPTION
## **User description**
Reverts kubescape/regolibrary#557
Re-add control C-0264 now that we have v2 release


___

## **Type**
enhancement


___

## **Description**
- Re-added control `C-0264` to the SOC2 framework, focusing on encryption of persistent volumes (data in rest).
- This control emphasizes the use of Transport Layer Security (TLS) for protecting data transmission, aligning with compliance requirements.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>soc2.json</strong><dd><code>Re-addition of Control C-0264 to SOC2 Framework</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frameworks/soc2.json
<li>Re-added control <code>C-0264</code> for SOC2 framework with details on data in <br>rest encryption.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/609/files#diff-3ad101b815b442a28e5e43128ec57ab2170b09fa5b7d79780f2e0f2e14181ac8">+10/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

