### PR TITLE
add constructor for regolibrary V2

### DIFF
--- a/gitregostore/datastructures.go
+++ b/gitregostore/datastructures.go
@@ -100,6 +100,13 @@ func (gs *GitRegoStore) SetRegoObjects() error {
 
 // NewDefaultGitRegoStore - generates git store object for production regolibrary release files.
 // Release files source: "https://github.com/kubescape/regolibrary/releases/latest/download"
+func NewGitRegoStoreV2(frequency int) *GitRegoStore {
+	gs := NewGitRegoStore("https://github.com", "kubescape", "regolibrary", "releases", "download/v2", "", frequency)
+	return gs
+}
+
+// NewDefaultGitRegoStore - generates git store object for production regolibrary release files.
+// Release files source: "https://github.com/kubescape/regolibrary/releases/latest/download"
 func NewDefaultGitRegoStore(frequency int) *GitRegoStore {
 	gs := NewGitRegoStore("https://github.com", "kubescape", "regolibrary", "releases", "latest/download", "", frequency)
 	return gs

--- a/gitregostore/gitstoremethods_test.go
+++ b/gitregostore/gitstoremethods_test.go
@@ -222,6 +222,18 @@ func gs_tests(t *testing.T, gs *GitRegoStore) {
 	})
 }
 
+func TestGetPoliciesMethodsNewV2(t *testing.T) {
+	t.Parallel()
+
+	gs := NewGitRegoStoreV2(-1)
+	t.Run("shoud set objects in rego store", func(t *testing.T) {
+		require.NoError(t, gs.SetRegoObjects())
+	})
+
+	gs_tests(t, gs)
+
+}
+
 func TestGetPoliciesMethodsNew(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
enhancement, tests


___

## **Description**
- Introduced a new constructor `NewGitRegoStoreV2` in `gitregostore/datastructures.go` for initializing GitRegoStore instances for RegoLibrary V2, specifying a new URL for V2 releases.
- Added tests in `gitregostore/gitstoremethods_test.go` to validate the functionality of the `NewGitRegoStoreV2` constructor, ensuring correct setup for V2 rego store objects.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>datastructures.go</strong><dd><code>Add NewGitRegoStoreV2 Constructor for RegoLibrary V2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gitregostore/datastructures.go
<li>Introduced <code>NewGitRegoStoreV2</code> constructor for creating GitRegoStore <br>instances targeting the V2 release of the regolibrary.<br> <li> This constructor specifies a new URL path for accessing V2 releases.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/610/files#diff-98bfc2fd15777c1c7f821f99d0344c3bd99b29b33af7e6225eeafead06f42180">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitstoremethods_test.go</strong><dd><code>Implement Tests for NewGitRegoStoreV2 Constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gitregostore/gitstoremethods_test.go
<li>Added a new test <code>TestGetPoliciesMethodsNewV2</code> to verify the <br>functionality of the <code>NewGitRegoStoreV2</code> constructor.<br> <li> The test ensures that the rego store objects are correctly set for the <br>V2 version.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/610/files#diff-3d80724468e24b9071a0e1d5c19afff51e88399257b2b4188c0e346f1155b1e1">+12/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

