### PR TITLE
Fix privilege escalation and privileged container issues

### DIFF
--- a/rules/rule-allow-privilege-escalation/raw.rego
+++ b/rules/rule-allow-privilege-escalation/raw.rego
@@ -81,7 +81,9 @@ is_allow_privilege_escalation_container(container, i, start_of_path) = [failed_p
 	psps := [psp |  psp= input[_]; psp.kind == "PodSecurityPolicy"]
 	count(psps) == 0
 	failed_path = ""
-	fixPath = {"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)]), "value":"false"} 
+	fixPath = [{"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)]), "value":"false"},
+	{"path": sprintf("%vcontainers[%v].securityContext.privileged", [start_of_path, format_int(i, 10)]), "value":"false"}
+	]
 }
 
 is_allow_privilege_escalation_container(container, i, start_of_path) = [failed_path, fixPath] {
@@ -92,7 +94,10 @@ is_allow_privilege_escalation_container(container, i, start_of_path) = [failed_p
 	psp := psps[_]
 	not psp.spec.allowPrivilegeEscalation == false
 	failed_path = ""
-	fixPath = {"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)]), "value":"false"} 
+	fixPath = [{"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)]), "value":"false"},
+	{"path": sprintf("%vcontainers[%v].securityContext.privileged", [start_of_path, format_int(i, 10)]), "value":"false"}
+
+	]
 }
 
 
@@ -101,7 +106,7 @@ is_allow_privilege_escalation_container(container, i, start_of_path) = [failed_p
 	psps := [psp |  psp= input[_]; psp.kind == "PodSecurityPolicy"]
 	count(psps) == 0
 	fixPath = ""
-	failed_path = sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)])
+	failed_path = [sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)])]
 }
 
 is_allow_privilege_escalation_container(container, i, start_of_path)= [failed_path, fixPath] {
@@ -111,15 +116,15 @@ is_allow_privilege_escalation_container(container, i, start_of_path)= [failed_pa
 	psp := psps[_]
 	not psp.spec.allowPrivilegeEscalation == false
 	fixPath = ""
-	failed_path = sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)])
+	failed_path = [sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)])]
 }
 
- get_failed_path(paths) = [paths[0]] {
+ get_failed_path(paths) = paths[0] {
 	paths[0] != ""
 } else = []
 
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) = paths[1] {
 	paths[1] != ""
 } else = []
 

--- a/rules/rule-allow-privilege-escalation/test/cronjob/expected.json
+++ b/rules/rule-allow-privilege-escalation/test/cronjob/expected.json
@@ -5,7 +5,12 @@
     "fixPaths": [{
         "path": "spec.jobTemplate.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation",
         "value": "false"
-    }],
+    },
+    {
+        "path": "spec.jobTemplate.spec.template.spec.containers[0].securityContext.privileged",
+        "value": "false"
+    }
+],
     "ruleStatus": "",
     "packagename": "armo_builtins",
     "alertScore": 7,
@@ -25,7 +30,13 @@
     "fixPaths": [{
         "path": "spec.jobTemplate.spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation",
         "value": "false"
-    }],
+    },
+    {
+        "path": "spec.jobTemplate.spec.template.spec.containers[1].securityContext.privileged",
+        "value": "false"
+    }
+
+],
     "ruleStatus": "",
     "packagename": "armo_builtins",
     "alertScore": 7,

--- a/rules/rule-allow-privilege-escalation/test/workloads/expected.json
+++ b/rules/rule-allow-privilege-escalation/test/workloads/expected.json
@@ -25,7 +25,12 @@
     "fixPaths": [{
         "path": "spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation",
         "value": "false"
-    }],
+    
+        },
+        {
+            "path": "spec.template.spec.containers[1].securityContext.privileged",
+            "value": "false"
+        }],
     "ruleStatus": "",
     "packagename": "armo_builtins",
     "alertScore": 7,


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Enhanced security by adding a fix to disable `privileged` mode in containers, in addition to preventing privilege escalation.
- Modified the `fixPath` structure in the Rego policy to support multiple fixes (disabling both `allowPrivilegeEscalation` and `privileged` mode).
- Updated test expectations in JSON files to align with the new security context fixes.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>raw.rego</strong><dd><code>Enhance Security by Disabling Privileged Containers and Privilege </code><br><code>Escalation</code></dd></summary>
<hr>

rules/rule-allow-privilege-escalation/raw.rego
<li>Added a fix to also set <code>privileged</code> to <code>false</code> in the security context of <br>containers alongside <code>allowPrivilegeEscalation</code>.<br> <li> Modified the structure of <code>fixPath</code> from a single object to an array of <br>objects to include the new fix.<br> <li> Adjusted the <code>failed_path</code> and <code>get_fixed_path</code> functions to support the <br>updated <code>fixPath</code> structure.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/612/files#diff-13e6d2d500bd736926a934b7bc48bc076e22fac2adf9f80147047fbee89b5cdc">+11/-6</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Test Expectations for Privileged Containers Fix</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/rule-allow-privilege-escalation/test/cronjob/expected.json
<li>Updated test expectations to include fixes for disabling <code>privileged</code> <br>mode in containers.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/612/files#diff-a6e292fd42d4b3a32173742f56521b988b39a86d6d032ab616228073090d6259">+13/-2</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Workloads Test Expectations with Security Context Fixes</code></dd></summary>
<hr>

rules/rule-allow-privilege-escalation/test/workloads/expected.json
<li>Updated test expectations to reflect the new security context fixes <br>for workloads.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/612/files#diff-9e68697a2e0753e11e100662c0548b907335593049651e58b6863e507de38c4a">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

