### PR TITLE
Fix c0074

### DIFF
--- a/rules/containers-mounting-docker-socket/test/cronjob-containerd/expected.json
+++ b/rules/containers-mounting-docker-socket/test/cronjob-containerd/expected.json
@@ -2,10 +2,13 @@
     {
         "alertMessage": "volume: test-volume in CronJob: hello has mounting to Docker internals.",
         "deletePaths": [
-            "spec.jobTemplate.spec.template.spec.volumes[0].hostPath.path"
+            "spec.jobTemplate.spec.template.spec.volumes[0]",
+            "spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[0]"
+
         ],
         "failedPaths": [
-            "spec.jobTemplate.spec.template.spec.volumes[0].hostPath.path"
+            "spec.jobTemplate.spec.template.spec.volumes[0]",
+            "spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[0]"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/containers-mounting-docker-socket/test/cronjob-crio/expected.json
+++ b/rules/containers-mounting-docker-socket/test/cronjob-crio/expected.json
@@ -2,10 +2,12 @@
     {
         "alertMessage": "volume: test-volume in CronJob: hello has mounting to Docker internals.",
         "deletePaths": [
-            "spec.jobTemplate.spec.template.spec.volumes[0].hostPath.path"
+            "spec.jobTemplate.spec.template.spec.volumes[0]",
+            "spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[0]"
         ],
         "failedPaths": [
-            "spec.jobTemplate.spec.template.spec.volumes[0].hostPath.path"
+            "spec.jobTemplate.spec.template.spec.volumes[0]",
+            "spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[0]"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/containers-mounting-docker-socket/test/cronjob/expected.json
+++ b/rules/containers-mounting-docker-socket/test/cronjob/expected.json
@@ -2,10 +2,13 @@
     {
         "alertMessage": "volume: test-volume in CronJob: hello has mounting to Docker internals.",
         "deletePaths": [
-            "spec.jobTemplate.spec.template.spec.volumes[0].hostPath.path"
+            "spec.jobTemplate.spec.template.spec.volumes[0]",
+            "spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[0]"
+
         ],
         "failedPaths": [
-            "spec.jobTemplate.spec.template.spec.volumes[0].hostPath.path"
+            "spec.jobTemplate.spec.template.spec.volumes[0]",
+            "spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[0]"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/containers-mounting-docker-socket/test/pod-containerd/expected.json
+++ b/rules/containers-mounting-docker-socket/test/pod-containerd/expected.json
@@ -2,10 +2,12 @@
     {
         "alertMessage": "volume: test-volume in pod: test-pd has mounting to Docker internals.",
         "deletePaths": [
-            "spec.volumes[0].hostPath.path"
+            "spec.volumes[0]",
+            "spec.containers[0].volumeMounts[0]"
         ],
         "failedPaths": [
-            "spec.volumes[0].hostPath.path"
+            "spec.volumes[0]",
+            "spec.containers[0].volumeMounts[0]"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/containers-mounting-docker-socket/test/pod-crio/expected.json
+++ b/rules/containers-mounting-docker-socket/test/pod-crio/expected.json
@@ -2,10 +2,12 @@
     {
         "alertMessage": "volume: test-volume in pod: test-pd has mounting to Docker internals.",
         "deletePaths": [
-            "spec.volumes[0].hostPath.path"
+            "spec.volumes[0]",
+            "spec.containers[0].volumeMounts[0]"
         ],
         "failedPaths": [
-            "spec.volumes[0].hostPath.path"
+            "spec.volumes[0]",
+            "spec.containers[0].volumeMounts[0]"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/containers-mounting-docker-socket/test/pod/expected.json
+++ b/rules/containers-mounting-docker-socket/test/pod/expected.json
@@ -2,10 +2,12 @@
     {
         "alertMessage": "volume: test-volume in pod: test-pd has mounting to Docker internals.",
         "deletePaths": [
-            "spec.volumes[0].hostPath.path"
+            "spec.volumes[0]",
+            "spec.containers[0].volumeMounts[0]"
         ],
         "failedPaths": [
-            "spec.volumes[0].hostPath.path"
+            "spec.volumes[0]",
+            "spec.containers[0].volumeMounts[0]"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/containers-mounting-docker-socket/test/workloads-containerd/expected.json
+++ b/rules/containers-mounting-docker-socket/test/workloads-containerd/expected.json
@@ -2,10 +2,10 @@
     {
         "alertMessage": "volume: test-volume2 in Deployment: my-deployment has mounting to Docker internals.",
         "deletePaths": [
-            "spec.template.spec.volumes[1].hostPath.path"
+            "spec.template.spec.volumes[1]"
         ],
         "failedPaths": [
-            "spec.template.spec.volumes[1].hostPath.path"
+            "spec.template.spec.volumes[1]"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/containers-mounting-docker-socket/test/workloads-crio/expected.json
+++ b/rules/containers-mounting-docker-socket/test/workloads-crio/expected.json
@@ -2,10 +2,10 @@
     {
         "alertMessage": "volume: test-volume2 in Deployment: my-deployment has mounting to Docker internals.",
         "deletePaths": [
-            "spec.template.spec.volumes[1].hostPath.path"
+            "spec.template.spec.volumes[1]"
         ],
         "failedPaths": [
-            "spec.template.spec.volumes[1].hostPath.path"
+            "spec.template.spec.volumes[1]"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/containers-mounting-docker-socket/test/workloads/expected.json
+++ b/rules/containers-mounting-docker-socket/test/workloads/expected.json
@@ -2,10 +2,10 @@
     {
         "alertMessage": "volume: test-volume2 in Deployment: my-deployment has mounting to Docker internals.",
         "deletePaths": [
-            "spec.template.spec.volumes[1].hostPath.path"
+            "spec.template.spec.volumes[1]"
         ],
         "failedPaths": [
-            "spec.template.spec.volumes[1].hostPath.path"
+            "spec.template.spec.volumes[1]"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/rule-allow-privilege-escalation/raw.rego
+++ b/rules/rule-allow-privilege-escalation/raw.rego
@@ -81,7 +81,9 @@ is_allow_privilege_escalation_container(container, i, start_of_path) = [failed_p
 	psps := [psp |  psp= input[_]; psp.kind == "PodSecurityPolicy"]
 	count(psps) == 0
 	failed_path = ""
-	fixPath = {"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)]), "value":"false"} 
+	fixPath = [{"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)]), "value":"false"},
+	{"path": sprintf("%vcontainers[%v].securityContext.privileged", [start_of_path, format_int(i, 10)]), "value":"false"}
+	]
 }
 
 is_allow_privilege_escalation_container(container, i, start_of_path) = [failed_path, fixPath] {
@@ -92,7 +94,10 @@ is_allow_privilege_escalation_container(container, i, start_of_path) = [failed_p
 	psp := psps[_]
 	not psp.spec.allowPrivilegeEscalation == false
 	failed_path = ""
-	fixPath = {"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)]), "value":"false"} 
+	fixPath = [{"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)]), "value":"false"},
+	{"path": sprintf("%vcontainers[%v].securityContext.privileged", [start_of_path, format_int(i, 10)]), "value":"false"}
+
+	]
 }
 
 
@@ -101,7 +106,7 @@ is_allow_privilege_escalation_container(container, i, start_of_path) = [failed_p
 	psps := [psp |  psp= input[_]; psp.kind == "PodSecurityPolicy"]
 	count(psps) == 0
 	fixPath = ""
-	failed_path = sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)])
+	failed_path = [sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)])]
 }
 
 is_allow_privilege_escalation_container(container, i, start_of_path)= [failed_path, fixPath] {
@@ -111,15 +116,15 @@ is_allow_privilege_escalation_container(container, i, start_of_path)= [failed_pa
 	psp := psps[_]
 	not psp.spec.allowPrivilegeEscalation == false
 	fixPath = ""
-	failed_path = sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)])
+	failed_path = [sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)])]
 }
 
- get_failed_path(paths) = [paths[0]] {
+ get_failed_path(paths) = paths[0] {
 	paths[0] != ""
 } else = []
 
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) = paths[1] {
 	paths[1] != ""
 } else = []
 

--- a/rules/rule-allow-privilege-escalation/test/cronjob/expected.json
+++ b/rules/rule-allow-privilege-escalation/test/cronjob/expected.json
@@ -5,7 +5,12 @@
     "fixPaths": [{
         "path": "spec.jobTemplate.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation",
         "value": "false"
-    }],
+    },
+    {
+        "path": "spec.jobTemplate.spec.template.spec.containers[0].securityContext.privileged",
+        "value": "false"
+    }
+],
     "ruleStatus": "",
     "packagename": "armo_builtins",
     "alertScore": 7,
@@ -25,7 +30,13 @@
     "fixPaths": [{
         "path": "spec.jobTemplate.spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation",
         "value": "false"
-    }],
+    },
+    {
+        "path": "spec.jobTemplate.spec.template.spec.containers[1].securityContext.privileged",
+        "value": "false"
+    }
+
+],
     "ruleStatus": "",
     "packagename": "armo_builtins",
     "alertScore": 7,

--- a/rules/rule-allow-privilege-escalation/test/workloads/expected.json
+++ b/rules/rule-allow-privilege-escalation/test/workloads/expected.json
@@ -25,7 +25,12 @@
     "fixPaths": [{
         "path": "spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation",
         "value": "false"
-    }],
+    
+        },
+        {
+            "path": "spec.template.spec.containers[1].securityContext.privileged",
+            "value": "false"
+        }],
     "ruleStatus": "",
     "packagename": "armo_builtins",
     "alertScore": 7,


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Enhanced detection and alerting for Docker socket mounts across various Kubernetes objects.
- Improved remediation paths in alerts to include specific container volume mounts.
- Added handling for privileged containers to prevent privilege escalation.
- Updated test cases to reflect new alert formats and remediation paths.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>raw.rego</strong><dd><code>Enhance Docker Socket Mount Detection and Alerting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/containers-mounting-docker-socket/raw.rego
<li>Enhanced volume mount path identification for Docker socket mounting <br>alerts.<br> <li> Added container volume mount paths to alert messages for more precise <br>remediation.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/613/files#diff-7a89f91197e3cc19eb01b37689902d770f3dba7d41a4fa9d63a508af25915bff">+22/-9</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>raw.rego</strong><dd><code>Enhance Privilege Escalation Prevention and Handle Privileged </code><br><code>Containers</code></dd></summary>
<hr>

rules/rule-allow-privilege-escalation/raw.rego
<li>Added checks and fixes for preventing privileged container creation.<br> <li> Enhanced the rule to include fixes for both privilege escalation and <br>privileged container issues.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/613/files#diff-13e6d2d500bd736926a934b7bc48bc076e22fac2adf9f80147047fbee89b5cdc">+11/-6</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Test Output for CronJob Containerd</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/containers-mounting-docker-socket/test/cronjob-containerd/expected.json
<li>Updated expected test output to include container volume mount paths.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/613/files#diff-6e341db9d41798c39fc805925bd9695b1964add2bd487557563a7504b724d86d">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Test Output for CronJob Crio</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/containers-mounting-docker-socket/test/cronjob-crio/expected.json
- Updated expected test output to reflect new alert paths.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/613/files#diff-e526e9704537106c8d5a66b4cdd264c7a84a1fa49aea990576c25000e621a186">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Test Output for Generic CronJob</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/containers-mounting-docker-socket/test/cronjob/expected.json
<li>Adjusted expected.json to match new alert format with volume mount <br>paths.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/613/files#diff-e1775310aadd5c3f4d91e5133a03c6465be5b457f5ac6bf843d459c33ff48dd0">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Test Output for Pod Containerd</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/containers-mounting-docker-socket/test/pod-containerd/expected.json
- Updated test expectations for pod-containerd with new path format.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/613/files#diff-1496ff1bf0ce6f03416ba3cc5c118d99d28e7a87e72ed53f96c5cd0bb81c1339">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Test Output for Pod Crio</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/containers-mounting-docker-socket/test/pod-crio/expected.json
- Modified expected test results to include new alert path details.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/613/files#diff-7d97b951889666d63cf75a00351b71751724144a9c9d5b35cc03c3078e39578a">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Test Output for Generic Pod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/containers-mounting-docker-socket/test/pod/expected.json
<li>Updated test output to align with enhanced Docker socket mount <br>detection.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/613/files#diff-33dfae5351fbd78b11a779881053e2534520abcfe56918dfbe708e3c7abc0824">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Test Output for Workloads Containerd</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/containers-mounting-docker-socket/test/workloads-containerd/expected.json
- Adjusted expected test output for workloads-containerd.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/613/files#diff-8458f082f1e3a481479b92ccc380252426ed0960cfdad045b11fb3a5672a8bf2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Test Output for Workloads Crio</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/containers-mounting-docker-socket/test/workloads-crio/expected.json
- Updated test expectations for workloads-crio.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/613/files#diff-93c74ff4068337590d50f24ecb4026e9ddf96b6c4bccf424b2fb6185d01e6822">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Test Output for Generic Workloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/containers-mounting-docker-socket/test/workloads/expected.json
- Updated expected.json for workloads to reflect new alert format.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/613/files#diff-f52721d2df864f219c0cb52da7daebe7462c86fce002d943bb4265c5fe42a175">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Test Output for CronJob with Privilege Escalation Checks</code></dd></summary>
<hr>

rules/rule-allow-privilege-escalation/test/cronjob/expected.json
- Updated test output to include fixes for privileged containers.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/613/files#diff-a6e292fd42d4b3a32173742f56521b988b39a86d6d032ab616228073090d6259">+13/-2</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Test Output for Workloads with Enhanced Security Checks</code></dd></summary>
<hr>

rules/rule-allow-privilege-escalation/test/workloads/expected.json
<li>Updated expected test results to include privileged container fixes.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/613/files#diff-9e68697a2e0753e11e100662c0548b907335593049651e58b6863e507de38c4a">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

