### PR TITLE
improve remediation - return fix path in every case

### DIFF
--- a/rules/rule-allow-privilege-escalation/raw.rego
+++ b/rules/rule-allow-privilege-escalation/raw.rego
@@ -7,17 +7,14 @@ deny[msga] {
     pod.kind == "Pod"
 	container := pod.spec.containers[i]
 	start_of_path := "spec."
-    result := is_allow_privilege_escalation_container(container, i, start_of_path)
-	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+    is_allow_privilege_escalation_container(container)
+	fixPath := get_fix_path(i, start_of_path)
 
 	msga := {
 		"alertMessage": sprintf("container: %v in pod: %v  allow privilege escalation", [container.name, pod.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
-		"reviewPaths": failed_path,
-		"failedPaths": failed_path,
-		"fixPaths": fixed_path,
+		"fixPaths": fixPath,
 		"alertObject": {
 			"k8sApiObjects": [pod]
 		}
@@ -32,17 +29,14 @@ deny[msga] {
 	spec_template_spec_patterns[wl.kind]
     container := wl.spec.template.spec.containers[i]
 	start_of_path := "spec.template.spec."
-    result := is_allow_privilege_escalation_container(container, i, start_of_path)
-	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+    is_allow_privilege_escalation_container(container)
+	fixPath := get_fix_path(i, start_of_path)
 
     msga := {
 		"alertMessage": sprintf("container :%v in %v: %v  allow privilege escalation", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
-		"reviewPaths": failed_path,
-		"failedPaths": failed_path,
-		"fixPaths": fixed_path,
+		"fixPaths": fixPath,
 		"alertObject": {
 			"k8sApiObjects": [wl]
 		}
@@ -56,17 +50,14 @@ deny[msga] {
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 	start_of_path := "spec.jobTemplate.spec.template.spec."
-	result := is_allow_privilege_escalation_container(container, i, start_of_path)
-	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	is_allow_privilege_escalation_container(container)
+	fixPath := get_fix_path(i, start_of_path)
 
     msga := {
 		"alertMessage": sprintf("container :%v in %v: %v allow privilege escalation", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
-		"reviewPaths": failed_path,
-		"failedPaths": failed_path,
-		"fixPaths": fixed_path,
+		"fixPaths": fixPath,
 		"alertObject": {
 			"k8sApiObjects": [wl]
 		}
@@ -75,56 +66,38 @@ deny[msga] {
 
 
 
-is_allow_privilege_escalation_container(container, i, start_of_path) = [failed_path, fixPath] {
+is_allow_privilege_escalation_container(container) {
     not container.securityContext.allowPrivilegeEscalation == false
 	not container.securityContext.allowPrivilegeEscalation == true
 	psps := [psp |  psp= input[_]; psp.kind == "PodSecurityPolicy"]
 	count(psps) == 0
-	failed_path = ""
-	fixPath = [{"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)]), "value":"false"},
-	{"path": sprintf("%vcontainers[%v].securityContext.privileged", [start_of_path, format_int(i, 10)]), "value":"false"}
-	]
 }
 
-is_allow_privilege_escalation_container(container, i, start_of_path) = [failed_path, fixPath] {
+is_allow_privilege_escalation_container(container) {
     not container.securityContext.allowPrivilegeEscalation == false
 	not container.securityContext.allowPrivilegeEscalation == true
 	psps := [psp |  psp= input[_]; psp.kind == "PodSecurityPolicy"]
 	count(psps) > 0
 	psp := psps[_]
 	not psp.spec.allowPrivilegeEscalation == false
-	failed_path = ""
-	fixPath = [{"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)]), "value":"false"},
-	{"path": sprintf("%vcontainers[%v].securityContext.privileged", [start_of_path, format_int(i, 10)]), "value":"false"}
-
-	]
 }
 
 
-is_allow_privilege_escalation_container(container, i, start_of_path) = [failed_path, fixPath]  {
+is_allow_privilege_escalation_container(container) {
     container.securityContext.allowPrivilegeEscalation == true
 	psps := [psp |  psp= input[_]; psp.kind == "PodSecurityPolicy"]
 	count(psps) == 0
-	fixPath = ""
-	failed_path = [sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)])]
 }
 
-is_allow_privilege_escalation_container(container, i, start_of_path)= [failed_path, fixPath] {
+is_allow_privilege_escalation_container(container) {
     container.securityContext.allowPrivilegeEscalation == true
 	psps := [psp |  psp= input[_]; psp.kind == "PodSecurityPolicy"]
 	count(psps) > 0
 	psp := psps[_]
 	not psp.spec.allowPrivilegeEscalation == false
-	fixPath = ""
-	failed_path = [sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, format_int(i, 10)])]
 }
 
- get_failed_path(paths) = paths[0] {
-	paths[0] != ""
-} else = []
-
-
-get_fixed_path(paths) = paths[1] {
-	paths[1] != ""
-} else = []
-
+get_fix_path(i, start_of_path) = fixPath {
+	fixPath = [{"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, i]), "value":"false"},
+	{"path": sprintf("%vcontainers[%v].securityContext.privileged", [start_of_path, i]), "value":"false"}]
+}

--- a/rules/rule-allow-privilege-escalation/raw.rego
+++ b/rules/rule-allow-privilege-escalation/raw.rego
@@ -97,7 +97,5 @@ is_allow_privilege_escalation_container(container) {
 	not psp.spec.allowPrivilegeEscalation == false
 }
 
-get_fix_path(i, start_of_path) = fixPath {
-	fixPath = [{"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, i]), "value":"false"},
+get_fix_path(i, start_of_path) = [{"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, i]), "value":"false"},
 	{"path": sprintf("%vcontainers[%v].securityContext.privileged", [start_of_path, i]), "value":"false"}]
-}

--- a/rules/rule-allow-privilege-escalation/test/cronjob/expected.json
+++ b/rules/rule-allow-privilege-escalation/test/cronjob/expected.json
@@ -1,52 +1,56 @@
-[{
-    "alertMessage": "container :mysql in CronJob: hello allow privilege escalation",
-    "reviewPaths": [],
-    "failedPaths": [],
-    "fixPaths": [{
-        "path": "spec.jobTemplate.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation",
-        "value": "false"
+[
+    {
+        "alertMessage": "container :mysql in CronJob: hello allow privilege escalation",
+        "fixPaths": [
+            {
+                "path": "spec.jobTemplate.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation",
+                "value": "false"
+            },
+            {
+                "path": "spec.jobTemplate.spec.template.spec.containers[0].securityContext.privileged",
+                "value": "false"
+            }
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "batch/v1beta1",
+                    "kind": "CronJob",
+                    "metadata": {
+                        "name": "hello"
+                    }
+                }
+            ]
+        }
     },
     {
-        "path": "spec.jobTemplate.spec.template.spec.containers[0].securityContext.privileged",
-        "value": "false"
-    }
-],
-    "ruleStatus": "",
-    "packagename": "armo_builtins",
-    "alertScore": 7,
-    "alertObject": {
-        "k8sApiObjects": [{
-            "apiVersion": "batch/v1beta1",
-            "kind": "CronJob",
-            "metadata": {
-                "name": "hello"
+        "alertMessage": "container :php in CronJob: hello allow privilege escalation",
+        "fixPaths": [
+            {
+                "path": "spec.jobTemplate.spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation",
+                "value": "false"
+            },
+            {
+                "path": "spec.jobTemplate.spec.template.spec.containers[1].securityContext.privileged",
+                "value": "false"
             }
-        }]
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "batch/v1beta1",
+                    "kind": "CronJob",
+                    "metadata": {
+                        "name": "hello"
+                    }
+                }
+            ]
+        }
     }
-}, {
-    "alertMessage": "container :php in CronJob: hello allow privilege escalation",
-    "reviewPaths": [],
-    "failedPaths": [],
-    "fixPaths": [{
-        "path": "spec.jobTemplate.spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation",
-        "value": "false"
-    },
-    {
-        "path": "spec.jobTemplate.spec.template.spec.containers[1].securityContext.privileged",
-        "value": "false"
-    }
-
-],
-    "ruleStatus": "",
-    "packagename": "armo_builtins",
-    "alertScore": 7,
-    "alertObject": {
-        "k8sApiObjects": [{
-            "apiVersion": "batch/v1beta1",
-            "kind": "CronJob",
-            "metadata": {
-                "name": "hello"
-            }
-        }]
-    }
-}]
+]

--- a/rules/rule-allow-privilege-escalation/test/pod/expected.json
+++ b/rules/rule-allow-privilege-escalation/test/pod/expected.json
@@ -1,21 +1,32 @@
-[{
-    "alertMessage": "container: test-container in pod: audit-pod  allow privilege escalation",
-    "reviewPaths": ["spec.containers[0].securityContext.allowPrivilegeEscalation"],
-    "failedPaths": ["spec.containers[0].securityContext.allowPrivilegeEscalation"],
-    "fixPaths": [],
-    "ruleStatus": "",
-    "packagename": "armo_builtins",
-    "alertScore": 7,
-    "alertObject": {
-        "k8sApiObjects": [{
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {
-                "labels": {
-                    "app": "audit-pod"
-                },
-                "name": "audit-pod"
+[
+    {
+        "alertMessage": "container: test-container in pod: audit-pod  allow privilege escalation",
+        "fixPaths": [
+            {
+                "path": "spec.containers[0].securityContext.allowPrivilegeEscalation",
+                "value": "false"
+            },
+            {
+                "path": "spec.containers[0].securityContext.privileged",
+                "value": "false"
             }
-        }]
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "labels": {
+                            "app": "audit-pod"
+                        },
+                        "name": "audit-pod"
+                    }
+                }
+            ]
+        }
     }
-}]
+]

--- a/rules/rule-allow-privilege-escalation/test/workloads/expected.json
+++ b/rules/rule-allow-privilege-escalation/test/workloads/expected.json
@@ -1,49 +1,62 @@
-[{
-    "alertMessage": "container :mysql in Deployment: my-deployment  allow privilege escalation",
-    "reviewPaths": ["spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation"],
-    "failedPaths": ["spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation"],
-    "fixPaths": [],
-    "ruleStatus": "",
-    "packagename": "armo_builtins",
-    "alertScore": 7,
-    "alertObject": {
-        "k8sApiObjects": [{
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "metadata": {
-                "labels": {
-                    "app": "goproxy"
-                },
-                "name": "my-deployment"
+[
+    {
+        "alertMessage": "container :mysql in Deployment: my-deployment  allow privilege escalation",
+        "fixPaths": [
+            {
+                "path": "spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation",
+                "value": "false"
+            },
+            {
+                "path": "spec.template.spec.containers[0].securityContext.privileged",
+                "value": "false"
             }
-        }]
-    }
-}, {
-    "alertMessage": "container :php in Deployment: my-deployment  allow privilege escalation",
-    "reviewPaths": [],
-    "failedPaths": [],
-    "fixPaths": [{
-        "path": "spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation",
-        "value": "false"
-    
-        },
-        {
-            "path": "spec.template.spec.containers[1].securityContext.privileged",
-            "value": "false"
-        }],
-    "ruleStatus": "",
-    "packagename": "armo_builtins",
-    "alertScore": 7,
-    "alertObject": {
-        "k8sApiObjects": [{
-            "apiVersion": "apps/v1",
-            "kind": "Deployment",
-            "metadata": {
-                "labels": {
-                    "app": "goproxy"
-                },
-                "name": "my-deployment"
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "goproxy"
+                        },
+                        "name": "my-deployment"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "alertMessage": "container :php in Deployment: my-deployment  allow privilege escalation",
+        "fixPaths": [
+            {
+                "path": "spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation",
+                "value": "false"
+            },
+            {
+                "path": "spec.template.spec.containers[1].securityContext.privileged",
+                "value": "false"
             }
-        }]
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "goproxy"
+                        },
+                        "name": "my-deployment"
+                    }
+                }
+            ]
+        }
     }
-}]
+]


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
enhancement


___

## **Description**
- Simplified the logic for checking privilege escalation in containers by removing the return of paths from `is_allow_privilege_escalation_container`.
- Introduced a new function `get_fix_path` to generate fix paths for adjusting container security contexts.
- Updated expected test outputs for CronJob, Pod, and Workloads to align with the new fix path generation approach.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>raw.rego</strong><dd><code>Simplify Privilege Escalation Check and Introduce Fix Path Generation</code></dd></summary>
<hr>

rules/rule-allow-privilege-escalation/raw.rego
<li>Simplified the <code>is_allow_privilege_escalation_container</code> function to no <br>longer return paths.<br> <li> Introduced <code>get_fix_path</code> function to generate fix paths for security <br>context adjustments.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/614/files#diff-13e6d2d500bd736926a934b7bc48bc076e22fac2adf9f80147047fbee89b5cdc">+17/-44</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Expected Test Output for CronJob</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/rule-allow-privilege-escalation/test/cronjob/expected.json
<li>Updated expected test output to reflect changes in fix path <br>generation.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/614/files#diff-a6e292fd42d4b3a32173742f56521b988b39a86d6d032ab616228073090d6259">+50/-46</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Expected Test Output for Pod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/rule-allow-privilege-escalation/test/pod/expected.json
<li>Updated expected test output for Pod to include new fix path <br>structure.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/614/files#diff-18ee2abf39f4cc0af5f86953ca104d18a54c7fa97cc9da3420208cc177d5534e">+30/-19</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Expected Test Output for Workloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/rule-allow-privilege-escalation/test/workloads/expected.json
<li>Adjusted expected test output for workloads to match new fix path <br>logic.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/614/files#diff-9e68697a2e0753e11e100662c0548b907335593049651e58b6863e507de38c4a">+59/-46</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

