### PR TITLE
C-0048 - fix to valid remediation

### DIFF
--- a/rules/alert-any-hostpath/raw.rego
+++ b/rules/alert-any-hostpath/raw.rego
@@ -9,14 +9,17 @@ deny[msga] {
 	start_of_path := "spec."
 	result  := is_dangerous_volume(volume, start_of_path, i)
     podname := pod.metadata.name
+	volumeMounts := pod.spec.containers[j].volumeMounts
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.containers[%v]", [j]))
+	finalPath := array.concat([result], pathMounts)
 
 
 	msga := {
 		"alertMessage": sprintf("pod: %v has: %v as hostPath volume", [podname, volume.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
-		"deletePaths": [result],
-		"failedPaths": [result],
+		"deletePaths": finalPath,
+		"failedPaths": finalPath,
 		"fixPaths":[],
 		"alertObject": {
 			"k8sApiObjects": [pod]
@@ -33,14 +36,17 @@ deny[msga] {
     volume := volumes[i]
 	start_of_path := "spec.template.spec."
     result  := is_dangerous_volume(volume, start_of_path, i)
+	volumeMounts := wl.spec.template.spec.containers[j].volumeMounts
+	pathMounts = volume_mounts(volume.name,volumeMounts, sprintf("spec.template.spec.containers[%v]", [j]))
+	finalPath := array.concat([result], pathMounts)
 
 
 	msga := {
 		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
-		"deletePaths": [result],
-		"failedPaths": [result],
+		"deletePaths": finalPath,
+		"failedPaths": finalPath,
 		"fixPaths":[],
 		"alertObject": {
 			"k8sApiObjects": [wl]
@@ -56,12 +62,16 @@ deny[msga] {
     volume := volumes[i]
 	start_of_path := "spec.jobTemplate.spec.template.spec."
     result  := is_dangerous_volume(volume, start_of_path, i)
+	volumeMounts := wl.spec.jobTemplate.spec.template.spec.containers[j].volumeMounts
+	pathMounts = volume_mounts(volume.name,volumeMounts, sprintf("spec.jobTemplate.spec.template.spec.containers[%v]", [j]))
+	finalPath := array.concat([result], pathMounts)
+
 	msga := {
 		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
-		"deletePaths": [result],
-		"failedPaths": [result],
+		"deletePaths": finalPath,
+		"failedPaths": finalPath,
 		"fixPaths":[],
 		"alertObject": {
 			"k8sApiObjects": [wl]
@@ -71,5 +81,10 @@ deny[msga] {
 
 is_dangerous_volume(volume, start_of_path, i) = path {
     volume.hostPath.path
-    path = sprintf("%vvolumes[%v].hostPath.path", [start_of_path, format_int(i, 10)])
+    path = sprintf("%vvolumes[%v]", [start_of_path, format_int(i, 10)])
 }
+
+volume_mounts(name, volume_mounts, str) = [path] {
+	name == volume_mounts[j].name
+	path := sprintf("%s.volumeMounts[%v]", [str, j])
+} else = []

--- a/rules/alert-any-hostpath/test/deployment/expected.json
+++ b/rules/alert-any-hostpath/test/deployment/expected.json
@@ -1,11 +1,13 @@
 [
     {
         "alertMessage": "Deployment: my-deployment has: test-volume as hostPath volume",
-        "deletePaths": [
-            "spec.template.spec.volumes[0].hostPath.path"
-        ],
         "failedPaths": [
-            "spec.template.spec.volumes[0].hostPath.path"
+            "spec.template.spec.volumes[0]",
+            "spec.template.spec.containers[0].volumeMounts[0]"
+        ],
+        "deletePaths": [
+            "spec.template.spec.volumes[0]",
+            "spec.template.spec.containers[0].volumeMounts[0]"
         ],
         "fixPaths": [],
         "ruleStatus": "",
@@ -28,11 +30,13 @@
     },
     {
         "alertMessage": "Deployment: my-deployment has: test-volume2 as hostPath volume",
-        "deletePaths": [
-            "spec.template.spec.volumes[1].hostPath.path"
-        ],
         "failedPaths": [
-            "spec.template.spec.volumes[1].hostPath.path"
+            "spec.template.spec.volumes[1]",
+            "spec.template.spec.containers[0].volumeMounts[1]"
+        ],
+        "deletePaths": [
+            "spec.template.spec.volumes[1]",
+            "spec.template.spec.containers[0].volumeMounts[1]"
         ],
         "fixPaths": [],
         "ruleStatus": "",

--- a/rules/alert-any-hostpath/test/deployment/input/deployment.yaml
+++ b/rules/alert-any-hostpath/test/deployment/input/deployment.yaml
@@ -23,7 +23,7 @@ spec:
               name : test-volume
 
             - mountPath : /test-pd2
-              name : test-volume
+              name : test-volume2
       volumes :
         - name : test-volume
           hostPath :

--- a/rules/alert-any-hostpath/test/pod/expected.json
+++ b/rules/alert-any-hostpath/test/pod/expected.json
@@ -1,24 +1,28 @@
-{
-	"alertMessage": "pod: test-pd has: test-volume as hostPath volume",
-	"deletePaths": [
-		"spec.volumes[0].hostPath.path"
-	],
-	"failedPaths": [
-		"spec.volumes[0].hostPath.path"
-	],
-	"fixPaths": [],
-	"ruleStatus": "",
-	"packagename": "armo_builtins",
-	"alertScore": 7,
-	"alertObject": {
-		"k8sApiObjects": [
-			{
-				"apiVersion": "v1",
-				"kind": "Pod",
-				"metadata": {
-					"name": "test-pd"
+[
+	{
+		"alertMessage": "pod: test-pd has: test-volume as hostPath volume",
+		"failedPaths": [
+			"spec.volumes[0]",
+			"spec.containers[0].volumeMounts[0]"
+		],
+		"deletePaths": [
+			"spec.volumes[0]",
+			"spec.containers[0].volumeMounts[0]"
+		],
+		"fixPaths": [],
+		"ruleStatus": "",
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"alertObject": {
+			"k8sApiObjects": [
+				{
+					"apiVersion": "v1",
+					"kind": "Pod",
+					"metadata": {
+						"name": "test-pd"
+					}
 				}
-			}
-        ]
+			]
+		}
 	}
-}
+]


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Enhanced hostPath volume detection logic to include volumeMounts paths in the alert details, providing a more comprehensive view of the security issue.
- Added a new helper function `volume_mounts` to efficiently find and include the matching volume mounts in the alert paths.
- Updated expected test results to reflect the new alert structure, ensuring test accuracy.
- Fixed a mismatch in the test deployment volume name to align with the expected volumeMounts.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>raw.rego</strong><dd><code>Enhance HostPath Volume Detection with VolumeMounts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/alert-any-hostpath/raw.rego
<li>Enhanced hostPath volume detection by including volumeMounts in the <br>alert paths.<br> <li> Concatenated the original dangerous volume path with the new <br>volumeMounts paths for a comprehensive alert detail.<br> <li> Introduced a new helper function <code>volume_mounts</code> to find the matching <br>volume mounts.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/616/files#diff-3faeb179a066cd2809d096ec6f296de7fb673f65fa27cf9e02476bf04cc1421e">+23/-8</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Expected Test Results for Deployment with VolumeMounts</code></dd></summary>
<hr>

rules/alert-any-hostpath/test/deployment/expected.json
<li>Updated expected test results to include both volume and volumeMounts <br>paths in <code>deletePaths</code> and <code>failedPaths</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/616/files#diff-776c3c32858ebc0bed656bcc54bd2e7d0d50dbcdad5b3ef8e4dcb0f846619fac">+12/-8</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expected.json</strong><dd><code>Update Expected Test Results for Pod with VolumeMounts</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/alert-any-hostpath/test/pod/expected.json
<li>Updated expected test results for pod to reflect the new alert <br>structure with volume and volumeMounts paths.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/616/files#diff-f90af8ded92856bb76ca42a5edb22cabe19adf3e646903ec893d141ee52b2aa1">+26/-22</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug_fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deployment.yaml</strong><dd><code>Fix Test Deployment Volume Name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rules/alert-any-hostpath/test/deployment/input/deployment.yaml
<li>Corrected the volume name in the test deployment to match the expected <br>volumeMounts.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/616/files#diff-62578883d0c0d2b54eea23dc869f1ed25231797d9888bbde0ad36405d26edaed">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

