### PR TITLE
remove armoBuiltin attribute

### DIFF
--- a/frameworks/__YAMLscan.json
+++ b/frameworks/__YAMLscan.json
@@ -1,9 +1,7 @@
 {
     "name": "YAML-scanning",
     "description": "Controls relevant to yamls",
-    "attributes": {
-        "armoBuiltin": true
-    },
+    "attributes": {},
     "scanningScope": {
         "matches": [
             "file"

--- a/frameworks/allcontrols.json
+++ b/frameworks/allcontrols.json
@@ -1,9 +1,7 @@
 {
     "name": "AllControls",
     "description": "Contains all the controls from all the frameworks",
-    "attributes": {
-        "armoBuiltin": true
-    },
+    "attributes": {},
     "scanningScope": {
         "matches": [
             "cluster",

--- a/frameworks/armobest.json
+++ b/frameworks/armobest.json
@@ -1,9 +1,7 @@
 {
     "name": "ArmoBest",
     "description": "",
-    "attributes": {
-        "armoBuiltin": true
-    },
+    "attributes": {},
     "scanningScope": {
         "matches": [
             "cluster",

--- a/frameworks/cis-aks-t1.2.0.json
+++ b/frameworks/cis-aks-t1.2.0.json
@@ -2,7 +2,6 @@
     "name": "cis-aks-t1.2.0",
     "description": "Testing CIS for Azure Kubernetes Service (AKS) as suggested by CIS benchmark: https://workbench.cisecurity.org/benchmarks/9058",
     "attributes": {
-        "armoBuiltin": true,
         "version": "v1.2.0"
     },
     "scanningScope": {

--- a/frameworks/cis-eks-t1.2.0.json
+++ b/frameworks/cis-eks-t1.2.0.json
@@ -2,7 +2,6 @@
     "name": "cis-eks-t1.2.0",
     "description": "Testing CIS for Amazon Elastic Kubernetes Service (EKS) as suggested by CIS benchmark: https://workbench.cisecurity.org/benchmarks/9681",
     "attributes": {
-        "armoBuiltin": true,
         "version": "v1.2.0"
     },
     "scanningScope": {

--- a/frameworks/cis-v1.23-t1.0.1.json
+++ b/frameworks/cis-v1.23-t1.0.1.json
@@ -2,7 +2,6 @@
     "name": "cis-v1.23-t1.0.1",
     "description": "Testing CIS for Kubernetes as suggested by CIS in https://workbench.cisecurity.org/benchmarks/8973",
     "attributes": {
-        "armoBuiltin": true,
         "version": "v1.0.1"
     },
     "scanningScope": {

--- a/frameworks/clusterscan.json
+++ b/frameworks/clusterscan.json
@@ -1,9 +1,7 @@
 {
     "name": "ClusterScan",
     "description": "Framework for scanning a cluster",
-    "attributes": {
-        "armoBuiltin": true
-    },
+    "attributes": {},
     "typeTags": [
         "security"
     ],

--- a/frameworks/devopsbest.json
+++ b/frameworks/devopsbest.json
@@ -1,9 +1,7 @@
 {
     "name": "DevOpsBest",
     "description": "",
-    "attributes": {
-        "armoBuiltin": true
-    },
+    "attributes": {},
     "scanningScope": {
         "matches": [
             "cluster",

--- a/frameworks/mitre.json
+++ b/frameworks/mitre.json
@@ -1,9 +1,7 @@
 {
     "name": "MITRE",
     "description": "Testing MITRE for Kubernetes as suggested by microsoft in https://www.microsoft.com/security/blog/wp-content/uploads/2020/04/k8s-matrix.png",
-    "attributes": {
-        "armoBuiltin": true
-    },
+    "attributes": {},
     "scanningScope": {
         "matches": [
             "cluster",

--- a/frameworks/nsaframework.json
+++ b/frameworks/nsaframework.json
@@ -1,9 +1,7 @@
 {
     "name": "NSA",
     "description": "Implement NSA security advices for K8s ",
-    "attributes": {
-        "armoBuiltin": true
-    },
+    "attributes": {},
     "scanningScope": {
         "matches": [
             "cluster",

--- a/frameworks/security.json
+++ b/frameworks/security.json
@@ -1,9 +1,7 @@
 {
     "name": "security",
     "description": "Controls that are used to assess security threats.",
-    "attributes": {
-        "armoBuiltin": true
-    },
+    "attributes": {},
     "typeTags": [
         "security"
     ],

--- a/frameworks/soc2.json
+++ b/frameworks/soc2.json
@@ -1,9 +1,7 @@
 {
     "name": "SOC2",
     "description": "SOC2 compliance related controls",
-    "attributes": {
-        "armoBuiltin": true
-    },
+    "attributes": {},
     "scanningScope": {
         "matches": [
             "cluster",

--- a/frameworks/workloadscan.json
+++ b/frameworks/workloadscan.json
@@ -1,9 +1,7 @@
 {
     "name": "WorkloadScan",
     "description": "Framework for scanning a workload",
-    "attributes": {
-        "armoBuiltin": true
-    },
+    "attributes": {},
     "typeTags": [
         "security"
     ],


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
enhancement


___

## **Description**
- Removed `armoBuiltin` attribute from multiple framework configurations to streamline attributes.
- This change affects frameworks such as YAML Scanning, All Controls, ArmoBest, various CIS benchmarks, ClusterScan, DevOpsBest, MITRE, NSA, Security, SOC2, and WorkloadScan.
- The removal of `armoBuiltin` attribute simplifies the framework attributes without altering their core functionalities.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>__YAMLscan.json</strong><dd><code>Remove `armoBuiltin` Attribute from YAML Scanning Framework</code></dd></summary>
<hr>

frameworks/__YAMLscan.json
- Removed `armoBuiltin` attribute from the framework's attributes.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/618/files#diff-5354bc1b9d127ae8d98ab2307a4912e1ea1dde2bde52a4d7e9b28badd10652ed">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>allcontrols.json</strong><dd><code>Remove `armoBuiltin` Attribute from All Controls Framework</code></dd></summary>
<hr>

frameworks/allcontrols.json
- Removed `armoBuiltin` attribute from the framework's attributes.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/618/files#diff-1b255853be0e9786fe0eb09dc9ac5c64053bf176a897d3b8a853d77fd0c33f10">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>armobest.json</strong><dd><code>Remove `armoBuiltin` Attribute from ArmoBest Framework</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frameworks/armobest.json
- Removed `armoBuiltin` attribute from the framework's attributes.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/618/files#diff-980c28f624bd7990247dc4b3b98f52913c36dbe3cb07e0c9d90189148b26a812">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cis-aks-t1.2.0.json</strong><dd><code>Remove `armoBuiltin` Attribute from CIS AKS Framework</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frameworks/cis-aks-t1.2.0.json
- Removed `armoBuiltin` attribute, retaining `version` attribute.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/618/files#diff-a95be918aa20a0f2ae88d16f5832bed103ce361b8d0084bea394d5d7dbacbbda">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cis-eks-t1.2.0.json</strong><dd><code>Remove `armoBuiltin` Attribute from CIS EKS Framework</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frameworks/cis-eks-t1.2.0.json
- Removed `armoBuiltin` attribute, retaining `version` attribute.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/618/files#diff-e58ff4a8a0547b6332a52feb83c67705f0128ed916e3f099b6b9479a218d963e">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cis-v1.23-t1.0.1.json</strong><dd><code>Remove `armoBuiltin` Attribute from CIS v1.23 Framework</code>&nbsp; &nbsp; </dd></summary>
<hr>

frameworks/cis-v1.23-t1.0.1.json
- Removed `armoBuiltin` attribute, retaining `version` attribute.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/618/files#diff-94504e71905ad452decc3e8329a3df6afc6183934a16c69b4444e9413d9e6b7e">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>clusterscan.json</strong><dd><code>Remove `armoBuiltin` Attribute from ClusterScan Framework</code></dd></summary>
<hr>

frameworks/clusterscan.json
- Removed `armoBuiltin` attribute from the framework's attributes.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/618/files#diff-3b5ef8e78f7fd4e5f539e8670a98d029a305fc8d8f646fedcf78732a6a00b4e8">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>devopsbest.json</strong><dd><code>Remove `armoBuiltin` Attribute from DevOpsBest Framework</code>&nbsp; </dd></summary>
<hr>

frameworks/devopsbest.json
- Removed `armoBuiltin` attribute from the framework's attributes.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/618/files#diff-bc6c553fcca3afdd549839ccb297c3270d83107b94441fc3c14301b9eeeeb8f1">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mitre.json</strong><dd><code>Remove `armoBuiltin` Attribute from MITRE Framework</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frameworks/mitre.json
- Removed `armoBuiltin` attribute from the framework's attributes.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/618/files#diff-c7aeece8f29dc74d9c91fc5423a4ca120855b0f3c6c6788b89233ba5285eb009">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>nsaframework.json</strong><dd><code>Remove `armoBuiltin` Attribute from NSA Framework</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frameworks/nsaframework.json
- Removed `armoBuiltin` attribute from the framework's attributes.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/618/files#diff-e9029de0e895bc035e6eccb8c295e60a9cd2a047e4bf6f545e3fa94eb5c0ebd0">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>security.json</strong><dd><code>Remove `armoBuiltin` Attribute from Security Framework</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frameworks/security.json
- Removed `armoBuiltin` attribute from the framework's attributes.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/618/files#diff-c88e59bbd8f153d854b49e17546ea6b8864bf2532f9be44e5d339f36f2658a9f">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>soc2.json</strong><dd><code>Remove `armoBuiltin` Attribute from SOC2 Framework</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frameworks/soc2.json
- Removed `armoBuiltin` attribute from the framework's attributes.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/618/files#diff-3ad101b815b442a28e5e43128ec57ab2170b09fa5b7d79780f2e0f2e14181ac8">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workloadscan.json</strong><dd><code>Remove `armoBuiltin` Attribute from WorkloadScan Framework</code></dd></summary>
<hr>

frameworks/workloadscan.json
- Removed `armoBuiltin` attribute from the framework's attributes.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/618/files#diff-231d3bcb540848c1c0e1cd1b5c868a2f13c7703d7b79b4311791e151b8212334">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

