### PR TITLE
re-add attack track external-workload-with-cluster-takeover-roles

### DIFF
--- a/attack-tracks/external-workload-with-cluster-takeover-roles.json
+++ b/attack-tracks/external-workload-with-cluster-takeover-roles.json
@@ -1,0 +1,20 @@
+{
+    "apiVersion": "regolibrary.kubescape/v1alpha1",
+    "kind": "AttackTrack",
+    "metadata": {
+        "name": "external-workload-with-cluster-takeover-roles"
+    },
+    "spec": {
+        "version": "1.0",
+        "data": {
+            "name": "Initial Access",
+            "description": "An attacker can access the Kubernetes environment.",
+            "subSteps": [
+                {
+                    "name": "Cluster Access",
+                    "description": "An attacker has access to sensitive information and can leverage them by creating pods in the cluster."
+                }
+            ]
+        }
+    }
+}

--- a/controls/C-0256-exposuretointernet.json
+++ b/controls/C-0256-exposuretointernet.json
@@ -18,6 +18,12 @@
                 ]
             },
             {
+                "attackTrack": "external-workload-with-cluster-takeover-roles",
+                "categories": [
+                    "Initial Access"
+                ]
+            },
+            {
                 "attackTrack": "external-database-without-authentication",
                 "categories": [
                     "Initial Access"

--- a/controls/C-0266-exposuretointernet-gateway.json
+++ b/controls/C-0266-exposuretointernet-gateway.json
@@ -16,6 +16,12 @@
                 "categories": [
                     "Initial Access"
                 ]
+            },
+            {
+                "attackTrack": "external-workload-with-cluster-takeover-roles",
+                "categories": [
+                    "Initial Access"
+                ]
             }
         ]
     },

--- a/controls/C-0267-workloadwithclustertakeoverroles.json
+++ b/controls/C-0267-workloadwithclustertakeoverroles.json
@@ -4,7 +4,16 @@
         "controlTypeTags": [
             "security"
         ],
-        "attackTracks": []
+        "attackTracks": [
+            {
+                "attackTrack": "external-workload-with-cluster-takeover-roles",
+                "categories": [
+                    "Cluster Access"
+                ],
+                "displayRelatedResources": true,
+                "clickableResourceKind": "ServiceAccount"
+            }
+        ]
     },
     "description": "Cluster takeover roles include workload creation or update and secret access. They can easily lead to super privileges in the cluster. If an attacker can exploit this workload then the attacker can take over the cluster using the RBAC privileges this workload is assigned to.",
     "remediation": "You should apply least privilege principle. Make sure each service account has only the permissions that are absolutely necessary.",
@@ -16,8 +25,8 @@
     "controlID": "C-0267",
     "baseScore": 6.0,
     "category": {
-        "name" : "Workload"
-   },
+        "name": "Workload"
+    },
     "scanningScope": {
         "matches": [
             "cluster",

--- a/rules/outdated-k8s-version/raw.rego
+++ b/rules/outdated-k8s-version/raw.rego
@@ -18,7 +18,7 @@ deny[msga] {
 
 has_outdated_version(version)  {
 	# the `supported_k8s_versions` is validated in the validations script against "https://api.github.com/repos/kubernetes/kubernetes/releases"
-    supported_k8s_versions := ["v1.29", "v1.28", "v1.27"] 
+    supported_k8s_versions := ["v1.30", "v1.29", "v1.28"] 
 	every v in supported_k8s_versions{
 		not startswith(version, v)
 	}


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

-->


___

## **Type**
enhancement


___

## **Description**
- Introduced a new AttackTrack for handling external workload with cluster takeover roles, enhancing security definitions.
- Updated multiple controls to integrate the new AttackTrack, improving the linkage and functionality of security controls.
- Enhanced the attributes and descriptions of controls to align with the new AttackTrack, ensuring consistency across the system.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>external-workload-with-cluster-takeover-roles.json</strong><dd><code>Add New AttackTrack Definition for Cluster Takeover Roles</code></dd></summary>
<hr>

attack-tracks/external-workload-with-cluster-takeover-roles.json
<li>Added a new AttackTrack definition for <br>'external-workload-with-cluster-takeover-roles'.<br> <li> Includes metadata and specifications such as version, name, and <br>detailed steps.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/619/files#diff-c846cebbf41f3d36366baba65563dc8bf91ce83b246ef56ae3b32a784db72fec">+20/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>C-0256-exposuretointernet.json</strong><dd><code>Update Control to Include New AttackTrack</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

controls/C-0256-exposuretointernet.json
<li>Linked the new AttackTrack <br>'external-workload-with-cluster-takeover-roles' to the control.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/619/files#diff-bb4119d6c9aa609d437b062f4112e23a93c1a333009fe971f46d2ed4d9ffbd34">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>C-0266-exposuretointernet-gateway.json</strong><dd><code>Integrate New AttackTrack into Gateway Exposure Control</code>&nbsp; &nbsp; </dd></summary>
<hr>

controls/C-0266-exposuretointernet-gateway.json
- Added reference to the new AttackTrack in the control's attributes.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/619/files#diff-7002b816a36202abcbdbb50a8b0e9ece47b63cf401adcb0cbe8b7cc49df5219e">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>C-0267-workloadwithclustertakeoverroles.json</strong><dd><code>Enhance Cluster Takeover Roles Control with New AttackTrack</code></dd></summary>
<hr>

controls/C-0267-workloadwithclustertakeoverroles.json
<li>Integrated the new AttackTrack into the control, enhancing its <br>attributes.<br> <li> Updated control details to include clickable resources and display <br>settings.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/regolibrary/pull/619/files#diff-7d83a784e1bf8b7e0e44825fd2baa508dd2ded8124b0f35f16b93c272758c278">+13/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

