### PR TITLE
feat: add "Initial Access" controls to "workload-unauthenticated-service" attack track

### DIFF
--- a/controls/C-0256-exposuretointernet.json
+++ b/controls/C-0256-exposuretointernet.json
@@ -28,6 +28,12 @@
                 "categories": [
                     "Initial Access"
                 ]
+            },
+            {
+                "attackTrack": "workload-unauthenticated-service",
+                "categories": [
+                    "Initial Access"
+                ]
             }
         ]
     },

--- a/controls/C-0266-exposuretointernet-gateway.json
+++ b/controls/C-0266-exposuretointernet-gateway.json
@@ -22,6 +22,12 @@
                 "categories": [
                     "Initial Access"
                 ]
+            },
+            {
+                "attackTrack": "workload-unauthenticated-service",
+                "categories": [
+                    "Initial Access"
+                ]
             }
         ]
     },


### PR DESCRIPTION
This commit adds the unauthenticated service control to the `C-0256-exposuretointernet.json` and `C-0266-exposuretointernet-gateway.json` files. The control is categorized under "Initial Access" and is part of the "workload-unauthenticated-service" attack track.

Note: This commit message follows the established convention of starting with a type prefix (feat for feature) and providing a concise and descriptive summary of the changes made.

## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
