### PR TITLE
Support Istio v1beta1 objects

### DIFF
--- a/rules/exposure-to-internet-via-istio-ingress/rule.metadata.json
+++ b/rules/exposure-to-internet-via-istio-ingress/rule.metadata.json
@@ -48,7 +48,8 @@
         "networking.istio.io"
       ],
       "apiVersions": [
-        "v1"
+        "v1",
+        "v1beta1"
       ],
       "resources": [
         "VirtualService",


### PR DESCRIPTION
## Overview
Support the Istio `v1beta1` objects (they don't make a difference from our testing point of view)
