### PR TITLE
Supporting gateways from different namespaces

### DIFF
--- a/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/expected.json
+++ b/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/expected.json
@@ -1,0 +1,193 @@
+[
+   {
+      "alertMessage": "workload 'nginx' is exposed through virtualservice 'int-0721'",
+      "failedPaths": [],
+      "reviewPaths": null,
+      "deletePaths": null,
+      "fixPaths": [],
+      "ruleStatus": "",
+      "packagename": "armo_builtins",
+      "alertScore": 7,
+      "alertObject": {
+         "k8sApiObjects": [
+            {
+               "apiVersion": "apps/v1",
+               "kind": "Deployment",
+               "metadata": {
+                  "labels": {
+                     "app": "int-0721",
+                     "context": "default",
+                     "name": "int-0721",
+                     "role": "app"
+                  },
+                  "name": "nginx"
+               }
+            }
+         ]
+      },
+      "relatedObjects": [
+         {
+            "object": {
+               "apiVersion": "networking.istio.io/v1beta1",
+               "kind": "VirtualService",
+               "metadata": {
+                  "creationTimestamp": "2024-04-15T08:56:16Z",
+                  "generation": 2,
+                  "labels": {
+                     "app": "int-0721",
+                     "context": "default",
+                     "name": "int-0721",
+                     "owner": "int-0721",
+                     "owner-namespace": "kt-itinternal",
+                     "role": "app"
+                  },
+                  "name": "int-0721",
+                  "namespace": "kt-itinternal"
+               },
+               "spec": {
+                  "gateways": [
+                     "kt-connections/prod-lan-gateway",
+                     "kt-connections/sdfsdfs-gateway",
+                     "kt-connections/api-public",
+                     "kt-connections/aaaaa-public",
+                     "kt-connections/mydddd-public"
+                  ],
+                  "hosts": [
+                     "api.stg.prod.lan"
+                  ],
+                  "http": [
+                     {
+                        "corsPolicy": {
+                           "allowHeaders": [
+                              "authorization",
+                              "Origin",
+                              "Content-Type",
+                              "Accept"
+                           ],
+                           "allowMethods": [
+                              "POST",
+                              "GET",
+                              "OPTIONS",
+                              "PUT",
+                              "PATCH",
+                              "DELETE"
+                           ],
+                           "allowOrigins": [
+                              {
+                                 "regex": ".*"
+                              }
+                           ]
+                        },
+                        "match": [
+                           {
+                              "authority": {
+                                 "exact": "api.stg.prod.lan"
+                              },
+                              "uri": {
+                                 "prefix": "/int/0698/"
+                              }
+                           }
+                        ],
+                        "name": "api-http-stgprodlan",
+                        "rewrite": {
+                           "uri": "/"
+                        },
+                        "route": [
+                           {
+                              "destination": {
+                                 "host": "int-0721.kt-itinternal.svc.cluster.local",
+                                 "port": {
+                                    "number": 8080
+                                 }
+                              },
+                              "headers": {
+                                 "request": {
+                                    "set": {
+                                       "X-Forwarded-Prefix": "/int/0698",
+                                       "X-Forwarded-Proto": "https"
+                                    }
+                                 }
+                              }
+                           }
+                        ]
+                     }
+                  ]
+               }
+            },
+            "failedPaths": [
+               "spec.http[0].routes[0].destination.host"
+            ],
+            "reviewPaths": [
+               "spec.http[0].routes[0].destination.host"
+            ],
+            "deletePaths": null,
+            "fixPaths": null
+         },
+         {
+            "object": {
+               "apiVersion": "v1",
+               "kind": "Service",
+               "metadata": {
+                  "creationTimestamp": "2024-04-15T09:00:11Z",
+                  "labels": {
+                     "app": "int-0721",
+                     "context": "default",
+                     "name": "int-0721",
+                     "owner": "int-0721",
+                     "owner-namespace": "kt-itinternal",
+                     "role": "app"
+                  },
+                  "name": "int-0721",
+                  "namespace": "kt-itinternal",
+                  "ownerReferences": [
+                     {
+                        "apiVersion": "msss/v1alpha1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "Microservice",
+                        "name": "int-0721",
+                        "uid": "14a69d5b-249c-487d-9500-645bda6a4c56"
+                     }
+                  ],
+                  "resourceVersion": "3779885629",
+                  "uid": "0428cb70-5d8f-4345-8ef2-5b0a249e0793"
+               },
+               "spec": {
+                  "clusterIP": "10.81.208.49",
+                  "clusterIPs": [
+                     "10.81.208.49"
+                  ],
+                  "internalTrafficPolicy": "Cluster",
+                  "ipFamilies": [
+                     "IPv4"
+                  ],
+                  "ipFamilyPolicy": "SingleStack",
+                  "ports": [
+                     {
+                        "name": "http",
+                        "port": 8080,
+                        "protocol": "TCP",
+                        "targetPort": 8080
+                     }
+                  ],
+                  "selector": {
+                     "app": "int-0721",
+                     "context": "default",
+                     "name": "int-0721",
+                     "role": "app"
+                  },
+                  "sessionAffinity": "None",
+                  "type": "ClusterIP"
+               },
+               "status": {
+                  "loadBalancer": {}
+               }
+            },
+            "failedPaths": null,
+            "reviewPaths": null,
+            "deletePaths": null,
+            "fixPaths": null
+         }
+      ]
+   }
+]

--- a/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/gateway.yaml
+++ b/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/gateway.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  annotations:
+    meta.helm.sh/release-name: legacy-compatibility
+    meta.helm.sh/release-namespace: kt-itinternal
+  creationTimestamp: "2023-03-16T10:18:13Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: prod-lan-gateway
+  namespace: kt-itinternal
+  resourceVersion: "713118464"
+  uid: 46cb8274-3569-4b4a-952a-52037a352715
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - legacy.stg.prod.lan
+    port:
+      name: http
+      number: 80
+      protocol: HTTP

--- a/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/input/deployment.yaml
+++ b/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/input/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: int-0721
+    context: default
+    name: int-0721
+    role: app
+  name: nginx
+  namespace: kt-itinternal
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        imagePullPolicy: Always
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 1
+  conditions:
+  - lastTransitionTime: "2024-11-19T19:33:45Z"
+    lastUpdateTime: "2024-11-19T19:33:45Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2024-11-19T19:33:37Z"
+    lastUpdateTime: "2024-11-19T19:33:45Z"
+    message: ReplicaSet "nginx-7854ff8877" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1

--- a/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/input/gateway.yaml
+++ b/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/input/gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: prod-lan-gateway
+  namespace: kt-connections
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - legacy.stg.prod.lan
+    port:
+      name: http
+      number: 80
+      protocol: HTTP

--- a/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/input/istio-gw.yaml
+++ b/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/input/istio-gw.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: istio-ingressgateway
+    istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    operator.istio.io/managed: Reconcile
+    operator.istio.io/version: 1.18.7
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
+  externalTrafficPolicy: Local
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: status-port
+    nodePort: 30432
+    port: 15033
+    protocol: TCP
+    targetPort: 15033
+  selector:
+    app: istio-ingressgateway
+    istio: ingressgateway
+  sessionAffinity: None
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/input/service.yaml
+++ b/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/input/service.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2024-04-15T09:00:11Z"
+  labels:
+    app: int-0721
+    context: default
+    name: int-0721
+    owner: int-0721
+    owner-namespace: kt-itinternal
+    role: app
+  name: int-0721
+  namespace: kt-itinternal
+  ownerReferences:
+  - apiVersion: msss/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Microservice
+    name: int-0721
+    uid: 14a69d5b-249c-487d-9500-645bda6a4c56
+  resourceVersion: "3779885629"
+  uid: 0428cb70-5d8f-4345-8ef2-5b0a249e0793
+spec:
+  clusterIP: 10.81.208.49
+  clusterIPs:
+  - 10.81.208.49
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: int-0721
+    context: default
+    name: int-0721
+    role: app
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/input/vs.yaml
+++ b/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/input/vs.yaml
@@ -1,0 +1,57 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  creationTimestamp: "2024-04-15T08:56:16Z"
+  generation: 2
+  labels:
+    app: int-0721
+    context: default
+    name: int-0721
+    owner: int-0721
+    owner-namespace: kt-itinternal
+    role: app
+  name: int-0721
+  namespace: kt-itinternal
+spec:
+  gateways:
+  - kt-connections/prod-lan-gateway
+  - kt-connections/sdfsdfs-gateway
+  - kt-connections/api-public
+  - kt-connections/aaaaa-public
+  - kt-connections/mydddd-public
+  hosts:
+  - api.stg.prod.lan
+  http:
+  - corsPolicy:
+      allowHeaders:
+      - authorization
+      - Origin
+      - Content-Type
+      - Accept
+      allowMethods:
+      - POST
+      - GET
+      - OPTIONS
+      - PUT
+      - PATCH
+      - DELETE
+      allowOrigins:
+      - regex: .*
+    match:
+    - authority:
+        exact: api.stg.prod.lan
+      uri:
+        prefix: /int/0698/
+    name: api-http-stgprodlan
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: int-0721.kt-itinternal.svc.cluster.local
+        port:
+          number: 8080
+      headers:
+        request:
+          set:
+            X-Forwarded-Prefix: /int/0698
+            X-Forwarded-Proto: https

--- a/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/service.yaml
+++ b/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/service.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    ctx.vrs.meeseeks.sre.monaco-telecom.mc/default: "3664777130"
+    ms.vrs.meeseeks.sre.monaco-telecom.mc/int-0721: "3779862107"
+    pe.vrs.meeseeks.sre.monaco-telecom.mc/int-0721: "2387894954"
+  creationTimestamp: "2024-04-15T09:00:11Z"
+  labels:
+    app: int-0721
+    context: default
+    name: int-0721
+    owner: int-0721
+    owner-namespace: kt-itinternal
+    role: app
+  name: int-0721
+  namespace: kt-itinternal
+  ownerReferences:
+  - apiVersion: msss/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Microservice
+    name: int-0721
+    uid: 14a69d5b-249c-487d-9500-645bda6a4c56
+  resourceVersion: "3779885629"
+  uid: 0428cb70-5d8f-4345-8ef2-5b0a249e0793
+spec:
+  clusterIP: 10.81.208.49
+  clusterIPs:
+  - 10.81.208.49
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: int-0721
+    context: default
+    name: int-0721
+    role: app
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/vs.yaml
+++ b/rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/vs.yaml
@@ -1,0 +1,57 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  creationTimestamp: "2024-04-15T08:56:16Z"
+  generation: 2
+  labels:
+    app: int-0721
+    context: default
+    name: int-0721
+    owner: int-0721
+    owner-namespace: kt-itinternal
+    role: app
+  name: int-0721
+  namespace: kt-itinternal
+spec:
+  gateways:
+  - kt-connections/wildcard-stg-gateway
+  - kt-connections/sdfsdfs-gateway
+  - kt-connections/api-public
+  - kt-connections/aaaaa-public
+  - kt-connections/mydddd-public
+  hosts:
+  - api.stg.prod.lan
+  http:
+  - corsPolicy:
+      allowHeaders:
+      - authorization
+      - Origin
+      - Content-Type
+      - Accept
+      allowMethods:
+      - POST
+      - GET
+      - OPTIONS
+      - PUT
+      - PATCH
+      - DELETE
+      allowOrigins:
+      - regex: .*
+    match:
+    - authority:
+        exact: api.stg.prod.lan
+      uri:
+        prefix: /int/0698/
+    name: api-http-stgprodlan
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: int-0721.kt-itinternal.svc.cluster.local
+        port:
+          number: 8080
+      headers:
+        request:
+          set:
+            X-Forwarded-Prefix: /int/0698
+            X-Forwarded-Proto: https


### PR DESCRIPTION
This pull request includes significant changes to the `rules/exposure-to-internet-via-istio-ingress/raw.rego` file and related test files to improve the handling of VirtualService and Gateway connections and their exposure to the internet. The most important changes include adding new functions to parse gateway namespaces, modifying the logic for checking namespace consistency, and updating test cases to reflect these changes.

Improvements to VirtualService and Gateway handling:

* [`rules/exposure-to-internet-via-istio-ingress/raw.rego`](diffhunk://#diff-b294c2175df84f32392c6d2dc7ad31a8f7878982515b72a8279095e61df6a35cR9-R35): Added `get_vs_gw_ns` function to parse the namespace and name of gateways from VirtualService specifications, and updated the logic to check if the gateway and VirtualService are in the same namespace. [[1]](diffhunk://#diff-b294c2175df84f32392c6d2dc7ad31a8f7878982515b72a8279095e61df6a35cR9-R35) [[2]](diffhunk://#diff-b294c2175df84f32392c6d2dc7ad31a8f7878982515b72a8279095e61df6a35cR87-R100)

* [`rules/exposure-to-internet-via-istio-ingress/raw.rego`](diffhunk://#diff-b294c2175df84f32392c6d2dc7ad31a8f7878982515b72a8279095e61df6a35cL45-R50): Modified the `deny[msga]` rule to use the new `get_vs_gw_ns` function and adjusted the logic to correctly identify failed paths for VirtualService routes. [[1]](diffhunk://#diff-b294c2175df84f32392c6d2dc7ad31a8f7878982515b72a8279095e61df6a35cL45-R50) [[2]](diffhunk://#diff-b294c2175df84f32392c6d2dc7ad31a8f7878982515b72a8279095e61df6a35cL59-R65)

Updates to test cases:

* [`rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/expected.json`](diffhunk://#diff-35b7da3cf8a3fb25fe5637f16ee78e72b858774fe2cef52b7cbed89792a38956R1-R193): Updated expected output to reflect the changes in the `deny[msga]` rule, including the new failed paths format.

* [`rules/exposure-to-internet-via-istio-ingress/test/failed_with_beta/gateway.yaml`](diffhunk://#diff-c85af2cf8ab8484f7622d87cd32f65a7e4139e0b9f44c1a4b27670816379ff00R1-R24): Added a new test case for a Gateway resource to validate the updated logic.

* Various test input files (`deployment.yaml`, `gateway.yaml`, `istio-gw.yaml`, `service.yaml`, `vs.yaml`): Added new resources and updated existing ones to ensure comprehensive coverage of the new logic. [[1]](diffhunk://#diff-878eccdd4046b53ae6ab90eb314b0e062b962bff710816a842ff00b02e8b949dR1-R58) [[2]](diffhunk://#diff-3b931f389f288a7ae4bdbd83849643eac4b1128728a0c8189f804597142ef68cR1-R15) [[3]](diffhunk://#diff-358682b135588c7deae9d567dc86f238e367af12894e0c3605ebaac5183dfbf9R1-R32) [[4]](diffhunk://#diff-3cfcf005edb5b5519e8f491c6e7f9b689d66b68b49b12340950536c227663369R1-R44) [[5]](diffhunk://#diff-b890b5526fc26d210fba8d3b73a7eca658550a613c3d659753f5fdfa4a1df0bbR1-R57) [[6]](diffhunk://#diff-c4b3c0723898bbf2e962aaeed18dea2d9382b4b65b5bcb133e1d979a7a251a61R1-R48) [[7]](diffhunk://#diff-fb40c289d8bc5234d97232dbb0c9f81119ebaa523d0cbae1b16d87c46d9c8ca0R1-R57)