### PR TITLE
add exception for built-in eks ClusterRoleBinding

### DIFF
--- a/exceptions/eks.json
+++ b/exceptions/eks.json
@@ -251,6 +251,13 @@
                     "kind": "Group",
                     "name": "system:masters"
                 }
+            },
+            {
+                "designatorType": "Attributes",
+                "attributes": {
+                    "kind": "ClusterRoleBinding",
+                    "name": "system:public-info-viewer"
+                }
             }
         ],
         "posturePolicies": [


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
Adding an exception for EKS ClusterRoleBinding `system:public-info-viewer`.
This change is according to aws best practices:
https://docs.aws.amazon.com/eks/latest/best-practices/identity-and-access-management.html
<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
