### PR TITLE
Feat/Add manual controls for completeness of cis-1.10 framework

### DIFF
--- a/controls/C-0246-avoiduseofsystemmastersgroup.json
+++ b/controls/C-0246-avoiduseofsystemmastersgroup.json
@@ -9,6 +9,7 @@
         "https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/rbac/escalation_check.go#L38"
     ],
     "attributes": {
+        "actionRequired": "manual review"
     },
     "rulesNames": [
         "rule-manual"

--- a/controls/C-0254-enableauditlogs.json
+++ b/controls/C-0254-enableauditlogs.json
@@ -9,6 +9,7 @@
         "<https://kubernetes.io/docs/tasks/debug-application-cluster/audit/>\n\n  <https://docs.microsoft.com/en-us/azure/aks/view-master-logs>\n\n  <https://docs.microsoft.com/security/benchmark/azure/security-controls-v2-logging-threat-detection#lt-4-enable-logging-for-azure-resources>"
     ],
     "attributes": {
+        "actionRequired": "manual review"
     },
     "rulesNames": [
         "rule-manual"

--- a/controls/C-0286-clientcertificateauthenticationshouldnotbeusedforusers.json
+++ b/controls/C-0286-clientcertificateauthenticationshouldnotbeusedforusers.json
@@ -1,0 +1,21 @@
+{
+    "id": "CIS-3.1.1",
+    "controlID": "C-0286",
+    "name": "Client certificate authentication should not be used for users",
+    "description": "Kubernetes provides the option to use client certificates for user authentication. However as there is no way to revoke these certificates when a user leaves an organization or loses their credential, they are not suitable for this purpose.\n\n It is not possible to fully disable client certificate use within a cluster as it is used for component to component authentication.",
+    "long_description": "With any authentication mechanism the ability to revoke credentials if they are compromised or no longer required, is a key control. Kubernetes client certificate authentication does not allow for this due to a lack of support for certificate revocation.",
+    "remediation": "Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented in place of client certificates.",
+    "manual_test": "Review user access to the cluster and ensure that users are not making use of Kubernetes client certificate authentication.",
+    "references": [
+        "https://workbench.cisecurity.org/sections/2633383/recommendations/4261934"
+    ],
+    "attributes": {
+        "actionRequired": "manual review"
+    },
+    "rulesNames": [
+        "rule-manual"
+    ],
+    "baseScore": 0,
+    "impact_statement": "External mechanisms for authentication generally require additional software to be deployed.",
+    "default_value": "Client certificate authentication is enabled by default."
+}

--- a/controls/C-0287-serviceaccounttokenauthenticationshouldnotbeusedforusers.json
+++ b/controls/C-0287-serviceaccounttokenauthenticationshouldnotbeusedforusers.json
@@ -1,0 +1,21 @@
+{
+    "id": "CIS-3.1.2",
+    "controlID": "C-0287",
+    "name": "Service account token authentication should not be used for users",
+    "description": "Kubernetes provides service account tokens which are intended for use by workloads running in the Kubernetes cluster, for authentication to the API server.\n\n These tokens are not designed for use by end-users and do not provide for features such as revocation or expiry, making them insecure. A newer version of the feature (Bound service account token volumes) does introduce expiry but still does not allow for specific revocation.",
+    "long_description": "With any authentication mechanism the ability to revoke credentials if they are compromised or no longer required, is a key control. Service account token authentication does not allow for this due to the use of JWT tokens as an underlying technology.",
+    "remediation": "Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented in place of service account tokens.",
+    "manual_test": "Review user access to the cluster and ensure that users are not making use of service account token authentication.",
+    "references": [
+        "https://workbench.cisecurity.org/sections/2633383/recommendations/4261935"
+    ],
+    "attributes": {
+        "actionRequired": "manual review"
+    },
+    "rulesNames": [
+        "rule-manual"
+    ],
+    "baseScore": 0,
+    "impact_statement": "External mechanisms for authentication generally require additional software to be deployed.",
+    "default_value": "Service account token authentication is enabled by default."
+}

--- a/controls/C-0288-bootstraptokenauthenticationshouldnotbeusedforusers.json
+++ b/controls/C-0288-bootstraptokenauthenticationshouldnotbeusedforusers.json
@@ -1,0 +1,21 @@
+{
+    "id": "CIS-3.1.3",
+    "controlID": "C-0288",
+    "name": "Bootstrap token authentication should not be used for users",
+    "description": "Kubernetes provides bootstrap tokens which are intended for use by new nodes joining the cluster\n\n These tokens are not designed for use by end-users they are specifically designed for the purpose of bootstrapping new nodes and not for general authentication",
+    "long_description": "Bootstrap tokens are not intended for use as a general authentication mechanism and impose constraints on user and group naming that do not facilitate good RBAC design. They also cannot be used with MFA resulting in a weak authentication mechanism being available.",
+    "remediation": "Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented in place of bootstrap tokens.",
+    "manual_test": "Review user access to the cluster and ensure that users are not making use of bootstrap token authentication.",
+    "references": [
+        "https://workbench.cisecurity.org/sections/2633383/recommendations/4261936"
+    ],
+    "attributes": {
+        "actionRequired": "manual review"
+    },
+    "rulesNames": [
+        "rule-manual"
+    ],
+    "baseScore": 0,
+    "impact_statement": "External mechanisms for authentication generally require additional software to be deployed.",
+    "default_value": "Bootstrap token authentication is not enabled by default and requires an API server parameter to be set."
+}

--- a/controls/C-0289-configureimageprovenanceusingimagepolicywebhookadmissioncontroller.json
+++ b/controls/C-0289-configureimageprovenanceusingimagepolicywebhookadmissioncontroller.json
@@ -1,0 +1,21 @@
+{
+    "id": "CIS-5.5.1",
+    "controlID": "C-0289",
+    "name": "Configure Image Provenance using ImagePolicyWebhook admission controller",
+    "description": "Configure Image Provenance for your deployment.",
+    "long_description": "Kubernetes supports plugging in provenance rules to accept or reject the images in your deployments. You could configure such rules to ensure that only approved images are deployed in the cluster.",
+    "remediation": "Follow the Kubernetes documentation and setup image provenance.",
+    "manual_test": "Review the pod definitions in your cluster and verify that image provenance is configured as appropriate.",
+    "references": [
+        "https://workbench.cisecurity.org/sections/2633394/recommendations/4261995"
+    ],
+    "attributes": {
+        "actionRequired": "manual review"
+    },
+    "rulesNames": [
+        "rule-manual"
+    ],
+    "baseScore": 0,
+    "impact_statement": "You need to regularly maintain your provenance configuration based on container image updates.",
+    "default_value": "By default, image provenance is not set."
+}

--- a/frameworks/cis-v1.10.0.json
+++ b/frameworks/cis-v1.10.0.json
@@ -121,6 +121,15 @@
             "name": "Control Plane Configuration",
             "id": "3",
             "subSections": {
+                "1": {
+                    "name": "Authentication and Authorization",
+                    "id": "3.1",
+                    "controlsIDs": [
+                        "C-0286",
+                        "C-0287",
+                        "C-0288"
+                    ]
+                },
                 "2": {
                     "name": "Logging",
                     "id": "3.2",
@@ -186,6 +195,7 @@
                         "C-0188",
                         "C-0189",
                         "C-0190",
+                        "C-0246",
                         "C-0191",
                         "C-0278",
                         "C-0279",
@@ -227,6 +237,13 @@
                     "controlsIDs": [
                         "C-0207",
                         "C-0208"
+                    ]
+                },
+                "5": {
+                    "name": "Extensible Admission Control",
+                    "id": "5.5",
+                    "controlsIDs": [
+                        "C-0289"
                     ]
                 },
                 "7": {
@@ -1325,6 +1342,12 @@
             }
         },
         {
+            "controlID": "C-0246",
+            "patch": {
+                "name": "CIS-5.1.7 Avoid use of system:masters group"
+            }
+        },
+        {
             "controlID": "C-0275",
             "patch": {
                 "name": "CIS-5.2.3 Minimize the admission of containers wishing to share the host process ID namespace",
@@ -1423,6 +1446,30 @@
                 "name": "CIS-4.2.13 Ensure that a limit is set on pod PIDs",
                 "long_description": "By default pods running in a cluster can consume any number of PIDs, potentially exhausting the resources available on the node. Setting an appropriate limit reduces the risk of a denial of service attack on cluster nodes.",
                 "manual_test": "Review the Kubelet's start-up parameters for the value of `--pod-max-pids`, and check the Kubelet configuration file for the `PodPidsLimit` . If neither of these values is set, then there is no limit in place."
+            }
+        },
+        {
+            "controlID": "C-0286",
+            "patch": {
+                "name": "CIS-3.1.1 Client certificate authentication should not be used for users"
+            }
+        },
+        {
+            "controlID": "C-0287",
+            "patch": {
+                "name": "CIS-3.1.2 Service account token authentication should not be used for users"
+            }
+        },
+        {
+            "controlID": "C-0288",
+            "patch": {
+                "name": "CIS-3.1.3 Bootstrap token authentication should not be used for users"
+            }
+        },
+        {
+            "controlID": "C-0289",
+            "patch": {
+                "name": "CIS-5.5.1 Configure Image Provenance using ImagePolicyWebhook admission controller"
             }
         }
     ]


### PR DESCRIPTION
This pull request adds several new security controls and updates the CIS Kubernetes v1.10.0 framework to include them. It introduces controls focused on authentication mechanisms and image provenance, ensures they are grouped correctly in the framework, and marks several controls as requiring manual review.

This pull request is a request by a customer in order to ensure full visibilty and tracking of all issues.

**New and Updated Security Controls:**

* New controls for authentication mechanisms:
  - Added `C-0286`: Client certificate authentication should not be used for users.
  - Added `C-0287`: Service account token authentication should not be used for users.
  - Added `C-0288`: Bootstrap token authentication should not be used for users.
* New control for image provenance:
  - Added `C-0289`: Configure Image Provenance using ImagePolicyWebhook admission controller.

**Framework Organization and Metadata Updates:**

* Updated `cis-v1.10.0.json` to:
  - Add a new "Authentication and Authorization" subsection (3.1) with the new authentication controls.
  - Add a new "Extensible Admission Control" subsection (5.5) for the image provenance control.
  - Include the new controls and patch their names for clarity.
  - Add `C-0246` to the list of controls and patch its name. [[1]](diffhunk://#diff-a05c2374a6622e71771b114c8dd474748f273d7236ecfcd9fa5ea31beebe3390R198) [[2]](diffhunk://#diff-a05c2374a6622e71771b114c8dd474748f273d7236ecfcd9fa5ea31beebe3390R1344-R1349)

**Manual Review Requirement:**

* Marked the following controls as requiring manual review in their respective JSON files:
  - [`C-0246`](diffhunk://#diff-d47d79bccc1dde02566696c5222c7fd15e16c656de0bd22b99d1c5bc9c506e75R12): Avoid use of system:masters group.
  - [`C-0254`](diffhunk://#diff-3de1c7a4436aac268c601e2bff5953cc1b6203fd663b891556f579b58548f4e1R12): Enable audit logs.
  - The four new controls above. [[1]](diffhunk://#diff-db1d371bf8d598e5ff62336b647b0d654a42de048439cf4197f914a4b07034eaR1-R21) [[2]](diffhunk://#diff-7c4f4575ca491c31c1b78c5fd44378222dd016c94dc0e92b1dde557923c89758R1-R21) [[3]](diffhunk://#diff-eed7b6949e196b22a4feb330a58de6dbb3a0f50c562e289c5d8d719333dfaefdR1-R21) [[4]](diffhunk://#diff-a665c273bda73d8eb01eb52a4bb13ef1236463f20da205960170c0a957a4d331R1-R21)