### PR TITLE
chore: tidy up use of spec_template_spec_patterns

### DIFF
--- a/rules/host-ipc-privileges/raw.rego
+++ b/rules/host-ipc-privileges/raw.rego
@@ -25,6 +25,7 @@ deny[msga] {
 deny[msga] {
     wl := input[_]
 	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns[wl.kind]
 	is_host_ipc(wl.spec.template.spec)
 	path := "spec.template.spec.hostIPC"
     msga := {

--- a/rules/host-network-access/raw.rego
+++ b/rules/host-network-access/raw.rego
@@ -24,6 +24,7 @@ deny[msga] {
 deny[msga] {
     wl := input[_]
 	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns[wl.kind]
 	is_host_network(wl.spec.template.spec)
 	path := "spec.template.spec.hostNetwork"
     msga := {

--- a/rules/host-pid-privileges/raw.rego
+++ b/rules/host-pid-privileges/raw.rego
@@ -25,6 +25,7 @@ deny[msga] {
 deny[msga] {
     wl := input[_]
 	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns[wl.kind]
 	is_host_pid(wl.spec.template.spec)
 	path := "spec.template.spec.hostPID"
     msga := {


### PR DESCRIPTION
The

    spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
    spec_template_spec_patterns[wl.kind]

is common pattern in multiple rules. This commit fixes instances, where the second line of this pattern was missing. Effectively rendering the first line of the pattern to be useless assignment.

For future reference, I found, it might be useful to complete this pattern properly, even though this commit does not have any logical effect on the scanner's RuleResults.

Found only 3 occurrences of this issue.


