### PR TITLE
chore: tidy up use of spec_template_spec_patterns

### DIFF
--- a/rules/host-ipc-privileges/raw.rego
+++ b/rules/host-ipc-privileges/raw.rego
@@ -25,6 +25,7 @@ deny[msga] {
 deny[msga] {
     wl := input[_]
 	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns[wl.kind]
 	is_host_ipc(wl.spec.template.spec)
 	path := "spec.template.spec.hostIPC"
     msga := {

--- a/rules/host-network-access/raw.rego
+++ b/rules/host-network-access/raw.rego
@@ -24,6 +24,7 @@ deny[msga] {
 deny[msga] {
     wl := input[_]
 	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns[wl.kind]
 	is_host_network(wl.spec.template.spec)
 	path := "spec.template.spec.hostNetwork"
     msga := {

--- a/rules/host-pid-privileges/raw.rego
+++ b/rules/host-pid-privileges/raw.rego
@@ -25,6 +25,7 @@ deny[msga] {
 deny[msga] {
     wl := input[_]
 	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns[wl.kind]
 	is_host_pid(wl.spec.template.spec)
 	path := "spec.template.spec.hostPID"
     msga := {


### PR DESCRIPTION
The

    spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
    spec_template_spec_patterns[wl.kind]

is common pattern in multiple rules. This commit fixes instances, where the second line of this pattern was missing. Effectively rendering the first line of the pattern to be useless assignment.

For future reference, I found, it might be useful to complete this pattern properly, even though this commit does not have any logical effect on the scanner's RuleResults.

Found only 3 occurrences of this issue.

## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

--> 
