### PR TITLE
perf: improve workload-with-administrative-roles rule

### DIFF
--- a/rules/workload-with-administrative-roles/raw.rego
+++ b/rules/workload-with-administrative-roles/raw.rego
@@ -5,15 +5,15 @@ import future.keywords.in
 # Memoize by type for better performance
 serviceaccounts := [sa |
     sa := input[_]
-	sa.kind == "ServiceAccount"
+    sa.kind == "ServiceAccount"
 ]
 roles := [r |
-	r := input[_]
-	r.kind in ["Role", "ClusterRole"]
+    r := input[_]
+    r.kind in ["Role", "ClusterRole"]
 ]
 rolebindings := [rb |
-	rb := input[_]
-	rb.kind in ["RoleBinding", "ClusterRoleBinding"]
+    rb := input[_]
+    rb.kind in ["RoleBinding", "ClusterRoleBinding"]
 ]
 
 deny[msga] {
@@ -29,7 +29,7 @@ deny[msga] {
     is_sa_auto_mounted(wl_spec, sa)
 
     # check if sa has administrative roles
-	role := roles[_]
+    role := roles[_]
     is_administrative_role(role)
 
     rolebinding := rolebindings[_]
@@ -53,7 +53,7 @@ deny[msga] {
         },
         {
             "object": rolebinding,
-		    "reviewPaths": [reviewPath],
+            "reviewPaths": [reviewPath],
             "deletePaths": [deletePath],
         },
         {


### PR DESCRIPTION
This seems to be the slowest rule on my set-up, so I have taken a look on how to improve its performance.

It seems that it has complexity O(n) = n^5 as it iterates over all the data 5 times.

Limiting the inner loops by object kind yields 23.3% improvement on my set-up.

I would be interested to hear what the maintainers think. It feels worth it, code is not considerably worse in any way and 23.3% sounds great and the benefits will grow with a cluster size.


### Metodology

Nothing scientific, just:

		start := time.Now()
		responses, err = opaProcessor.regoEval(ctx, inputObj, compiled, *data)
		elapsed := time.Since(start)
		fmt.Printf("Execution took %s\n", elapsed)

Readings before this patch (avg: 677.1890104ms)
 - 681.387391ms
 - 652.945844ms
 - 694.478191ms
 - 646.288995ms
 - 710.844631ms

Readings after this patch (avg: 519.11271779999ms)
 - 496.79941ms
 - 521.634789ms
 - 507.044831ms
 - 536.090881ms
 - 533.993678ms


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the workload administrative roles policy evaluation through memoization of resource types for improved query performance.
  * Added namespace validation to role binding checks for stricter enforcement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->