### PR TITLE
Fix empty alert objects in workload-with-administrative-roles rule

### DIFF
--- a/rules/workload-with-administrative-roles/raw.rego
+++ b/rules/workload-with-administrative-roles/raw.rego
@@ -2,37 +2,26 @@ package armo_builtins
 
 import future.keywords.in
 
-# Memoize by type for better performance
-serviceaccounts := [sa |
-    sa := input[_]
-    sa.kind == "ServiceAccount"
-]
-roles := [r |
-    r := input[_]
-    r.kind in ["Role", "ClusterRole"]
-]
-rolebindings := [rb |
-    rb := input[_]
-    rb.kind in ["RoleBinding", "ClusterRoleBinding"]
-]
-
 deny[msga] {
     wl := input[_]
     start_of_path := get_start_of_path(wl)
     wl_spec := object.get(wl, start_of_path, [])
 
     # get service account wl is using
-    sa := serviceaccounts[_]
+    sa := input[_]
+    sa.kind == "ServiceAccount"
     is_same_sa(wl_spec, sa.metadata, wl.metadata)
 
     # check service account token is mounted
     is_sa_auto_mounted(wl_spec, sa)
 
     # check if sa has administrative roles
-    role := roles[_]
+    role := input[_]
+    role.kind in ["Role", "ClusterRole"]
     is_administrative_role(role)
 
-    rolebinding := rolebindings[_]
+    rolebinding := input[_]
+    rolebinding.kind in ["RoleBinding", "ClusterRoleBinding"]
     rolebinding.roleRef.name == role.metadata.name
     rolebinding.subjects[j].kind == "ServiceAccount"
     rolebinding.subjects[j].name == sa.metadata.name


### PR DESCRIPTION
## Summary

Fixes spurious empty alert objects generated by the `workload-with-administrative-roles` rule that were introduced in commit c8fbe5ed.

## Problem

The performance optimization added module-level memoization using array comprehensions that caused Rego's partial evaluation to generate 3 empty alert objects when intermediate conditions failed.

## Solution

Reverted the module-level memoization and moved kind filtering back into the `deny` rule body to ensure alerts are only generated when all conditions are met.

## Test Results

All 4 test cases now pass with zero empty alerts:
- ✅ pass-wl-not-mount-sa-token 
- ✅ pass-wl-limited-permissions (previously had 3 empty alerts)
- ✅ fail-wl-creates-pod (previously had 3 extra empty alerts)
- ✅ pass-wl-rolebinding (previously had 3 empty alerts)

## Performance Impact

While this reverts the ~23% performance optimization, correctness is prioritized over marginal performance gains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the workload administrative roles validation logic by simplifying input processing mechanisms. The core validation behavior remains unchanged, with internal adjustments to how resource selections are handled during rule evaluation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->