### PR TITLE
Remove GH_ACCESS_TOKEN from repository secrets on pr-tests

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -12,7 +12,6 @@ concurrency:
 env:
   REGO_ARTIFACT_KEY_NAME: rego_artifact
   REGO_ARTIFACT_PATH: releaseDev
-  GH_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
 jobs:
   # main job of testing and building the env.
@@ -35,8 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         name: checkout repo content
-        with:
-          token: ${{ env.GH_ACCESS_TOKEN }}
 
       # Test using Golang OPA hot rule compilation
       - name: Set up Go
@@ -130,7 +127,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         name: checkout repo content
-        with:
-          token: ${{ env.GH_ACCESS_TOKEN }}
       - name: Remove pre-release folder
         run: rm -r -f pre-release

--- a/rules/outdated-k8s-version/raw.rego
+++ b/rules/outdated-k8s-version/raw.rego
@@ -18,7 +18,7 @@ deny[msga] {
 
 has_outdated_version(version)  {
 	# the `supported_k8s_versions` is validated in the validations script against "https://api.github.com/repos/kubernetes/kubernetes/releases"
-    supported_k8s_versions := ["v1.35", "v1.34", "v1.33"]
+    supported_k8s_versions := ["v1.36", "v1.35", "v1.34"]
 	every v in supported_k8s_versions{
 		not startswith(version, v)
 	}


### PR DESCRIPTION

## Overview
In https://cloud-native.slack.com/archives/C04EY3ZF9GE/p1776939980157879, we talked that a PR from forked repository can't run pr-tests in CI.
It is because the workflow currently uses a Github access token (`secrets.GH_PERSONAL_ACCESS_TOKEN`) from repository secrets. By default, forked PR can't access to repository secrets.

This PR remove the line which reads the private secret, and lines which uses it.

EDIT: After passing checkout step, the workflow failed because the supported k8s version is outdated (`./scripts/validations.py`). The second commit updates the versions.

## Additional Information
According to [actions/checkout's document](https://github.com/actions/checkout#usage), it uses `github.token` as a token by default. This github.token is equal to `GITHUB_TOKEN` which Github automatically generated for each workflow run, and the lifetime of the token is scoped in the run. So it is much safer than user stored access token ([ref](https://docs.github.com/en/actions/concepts/security/github_token))

## How to Test
`Build and test rego artifacts` in pr-tests works for this forked PR

## Related issues/PRs:
Nothing

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined CI checkout process by removing use of an explicit access token in build and cleanup jobs.
* **Bug Fixes**
  * Adjusted Kubernetes version support so versions beginning with v1.34–v1.36 are treated as supported, which changes which kubelet versions are flagged as outdated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->