### PR TITLE
fix(rules): normalize memory/CPU quantities before threshold compare

### DIFF
--- a/rules/resources-cpu-limit-and-request/raw.rego
+++ b/rules/resources-cpu-limit-and-request/raw.rego
@@ -344,83 +344,22 @@ is_min_request_exceeded_cpu(cpu_req) {
 ##############
 # helpers
 
-# Compare according to unit - max
+# Compare two Kubernetes CPU quantities by normalizing both sides to millicores.
+# Supports the milli suffix ("m") and unitless whole/fractional cores.
 compare_max(max, given) {
-	endswith(max, "Mi")
-	endswith(given, "Mi")
-	split_max :=  split(max, "Mi")[0]
-	split_given :=  split(given, "Mi")[0]
-	to_number(split_given) > to_number(split_max)
-}
-
-compare_max(max, given) {
-	endswith(max, "M")
-	endswith(given, "M")
-	split_max :=  split(max, "M")[0]
-	split_given :=  split(given, "M")[0]
-	to_number(split_given) > to_number(split_max)
-}
-
-compare_max(max, given) {
-	endswith(max, "m")
-	endswith(given, "m")
-	split_max :=  split(max, "m")[0]
-	split_given :=  split(given, "m")[0]
-	to_number(split_given) > to_number(split_max)
-}
-
-compare_max(max, given) {
-	not is_special_measure(max)
-	not is_special_measure(given)
-	to_number(given) > to_number(max)
-}
-
-
-
-################
-# Compare according to unit - min
-compare_min(min, given) {
-	endswith(min, "Mi")
-	endswith(given, "Mi")
-	split_min :=  split(min, "Mi")[0]
-	split_given :=  split(given, "Mi")[0]
-	to_number(split_given) < to_number(split_min)
+	cpu_to_millicores(given) > cpu_to_millicores(max)
 }
 
 compare_min(min, given) {
-	endswith(min, "M")
-	endswith(given, "M")
-	split_min :=  split(min, "M")[0]
-	split_given :=  split(given, "M")[0]
-	to_number(split_given) < to_number(split_min)
+	cpu_to_millicores(given) < cpu_to_millicores(min)
 }
 
-compare_min(min, given) {
-	endswith(min, "m")
-	endswith(given, "m")
-	split_min :=  split(min, "m")[0]
-	split_given :=  split(given, "m")[0]
-	to_number(split_given) < to_number(split_min)
-
-}
-
-compare_min(min, given) {
-	not is_special_measure(min)
-	not is_special_measure(given)
-	to_number(given) < to_number(min)
-
-}
-
-
-# Check that is same unit
-is_special_measure(unit) {
-	endswith(unit, "m")
-}
-
-is_special_measure(unit) {
-	endswith(unit, "M")
-}
-
-is_special_measure(unit) {
-	endswith(unit, "Mi")
+# Parse a Kubernetes CPU quantity string into millicores.
+# "500m" -> 500, "1" -> 1000, "0.5" -> 500.
+cpu_to_millicores(q) = n {
+	s := sprintf("%v", [q])
+	endswith(s, "m")
+	n := to_number(trim_suffix(s, "m"))
+} else = n {
+	n := to_number(q) * 1000
 }

--- a/rules/resources-cpu-limit-and-request/test/workload-mixed-unit/data.json
+++ b/rules/resources-cpu-limit-and-request/test/workload-mixed-unit/data.json
@@ -1,0 +1,8 @@
+{
+    "postureControlInputs": {
+        "cpu_request_max": ["1"],
+        "cpu_request_min": ["0"],
+        "cpu_limit_max":   ["1"],
+        "cpu_limit_min":   ["0"]
+    }
+}

--- a/rules/resources-cpu-limit-and-request/test/workload-mixed-unit/expected.json
+++ b/rules/resources-cpu-limit-and-request/test/workload-mixed-unit/expected.json
@@ -1,0 +1,56 @@
+[
+    {
+        "alertMessage": "Container: c in Deployment: hot exceeds CPU-limit or request",
+        "reviewPaths": [
+            "spec.template.spec.containers[0].resources.limits.cpu"
+        ],
+        "failedPaths": [
+            "spec.template.spec.containers[0].resources.limits.cpu"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "hot"
+                        },
+                        "name": "hot"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "alertMessage": "Container: c in Deployment: hot exceeds CPU-limit or request",
+        "reviewPaths": [
+            "spec.template.spec.containers[0].resources.requests.cpu"
+        ],
+        "failedPaths": [
+            "spec.template.spec.containers[0].resources.requests.cpu"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "hot"
+                        },
+                        "name": "hot"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/resources-cpu-limit-and-request/test/workload-mixed-unit/input/deployment.yaml
+++ b/rules/resources-cpu-limit-and-request/test/workload-mixed-unit/input/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hot
+  namespace: default
+  labels:
+    app: hot
+spec:
+  selector:
+    matchLabels:
+      app: hot
+  template:
+    metadata:
+      labels:
+        app: hot
+    spec:
+      containers:
+        - name: c
+          image: nginx
+          resources:
+            requests:
+              cpu: "1500m"
+            limits:
+              cpu: "2000m"

--- a/rules/resources-memory-limit-and-request/raw.rego
+++ b/rules/resources-memory-limit-and-request/raw.rego
@@ -339,6 +339,10 @@ mem_to_bytes(q) = n {
 	n := to_number(trim_suffix(s, "Ei")) * 1152921504606846976
 } else = n {
 	s := sprintf("%v", [q])
+	endswith(s, "m")
+	n := to_number(trim_suffix(s, "m")) / 1000
+} else = n {
+	s := sprintf("%v", [q])
 	endswith(s, "k")
 	n := to_number(trim_suffix(s, "k")) * 1000
 } else = n {

--- a/rules/resources-memory-limit-and-request/raw.rego
+++ b/rules/resources-memory-limit-and-request/raw.rego
@@ -300,81 +300,71 @@ is_min_request_exceeded_memory(memory_req) {
 ##############
 # helpers
 
-# Compare according to unit - max
+# Compare two Kubernetes memory quantities by normalizing both sides to bytes.
+# Supports binary (Ki/Mi/Gi/Ti/Pi/Ei), decimal (k/K/M/G/T/P/E) and unitless byte counts.
 compare_max(max, given) {
-	endswith(max, "Mi")
-	endswith(given, "Mi")
-	split_max := split(max, "Mi")[0]
-	split_given := split(given, "Mi")[0]
-    to_number(split_given) > to_number(split_max)
-}
-
-compare_max(max, given) {
-	endswith(max, "M")
-	endswith(given, "M")
-	split_max := split(max, "M")[0]
-	split_given := split(given, "M")[0]
-    to_number(split_given) > to_number(split_max)
-}
-
-compare_max(max, given) {
-	endswith(max, "m")
-	endswith(given, "m")
-	split_max := split(max, "m")[0]
-	split_given := split(given, "m")[0]
-    to_number(split_given) > to_number(split_max)
-}
-
-compare_max(max, given) {
-	not is_special_measure(max)
-	not is_special_measure(given)
-	given > max
-}
-
-################
-# Compare according to unit - min
-compare_min(min, given) {
-	endswith(min, "Mi")
-	endswith(given, "Mi")
-	split_min := split(min, "Mi")[0]
-	split_given := split(given, "Mi")[0]
-	to_number(split_given) < to_number(split_min)
+	mem_to_bytes(given) > mem_to_bytes(max)
 }
 
 compare_min(min, given) {
-	endswith(min, "M")
-	endswith(given, "M")
-	split_min := split(min, "M")[0]
-	split_given := split(given, "M")[0]
-	to_number(split_given) < to_number(split_min)
-
+	mem_to_bytes(given) < mem_to_bytes(min)
 }
 
-compare_min(min, given) {
-	endswith(min, "m")
-	endswith(given, "m")
-	split_min := split(min, "m")[0]
-	split_given := split(given, "m")[0]
-	to_number(split_given) < to_number(split_min)
-
-}
-
-compare_min(min, given) {
-	not is_special_measure(min)
-	not is_special_measure(given)
-	to_number(given) < to_number(min)
-
-}
-
-# Check that is same unit
-is_special_measure(unit) {
-	endswith(unit, "m")
-}
-
-is_special_measure(unit) {
-	endswith(unit, "M")
-}
-
-is_special_measure(unit) {
-	endswith(unit, "Mi")
+# Parse a Kubernetes memory quantity string into bytes.
+# Order matters: binary two-char suffixes are checked before single-char decimal
+# suffixes so "Mi" is not misread as "M".
+mem_to_bytes(q) = n {
+	s := sprintf("%v", [q])
+	endswith(s, "Ki")
+	n := to_number(trim_suffix(s, "Ki")) * 1024
+} else = n {
+	s := sprintf("%v", [q])
+	endswith(s, "Mi")
+	n := to_number(trim_suffix(s, "Mi")) * 1048576
+} else = n {
+	s := sprintf("%v", [q])
+	endswith(s, "Gi")
+	n := to_number(trim_suffix(s, "Gi")) * 1073741824
+} else = n {
+	s := sprintf("%v", [q])
+	endswith(s, "Ti")
+	n := to_number(trim_suffix(s, "Ti")) * 1099511627776
+} else = n {
+	s := sprintf("%v", [q])
+	endswith(s, "Pi")
+	n := to_number(trim_suffix(s, "Pi")) * 1125899906842624
+} else = n {
+	s := sprintf("%v", [q])
+	endswith(s, "Ei")
+	n := to_number(trim_suffix(s, "Ei")) * 1152921504606846976
+} else = n {
+	s := sprintf("%v", [q])
+	endswith(s, "k")
+	n := to_number(trim_suffix(s, "k")) * 1000
+} else = n {
+	s := sprintf("%v", [q])
+	endswith(s, "K")
+	n := to_number(trim_suffix(s, "K")) * 1000
+} else = n {
+	s := sprintf("%v", [q])
+	endswith(s, "M")
+	n := to_number(trim_suffix(s, "M")) * 1000000
+} else = n {
+	s := sprintf("%v", [q])
+	endswith(s, "G")
+	n := to_number(trim_suffix(s, "G")) * 1000000000
+} else = n {
+	s := sprintf("%v", [q])
+	endswith(s, "T")
+	n := to_number(trim_suffix(s, "T")) * 1000000000000
+} else = n {
+	s := sprintf("%v", [q])
+	endswith(s, "P")
+	n := to_number(trim_suffix(s, "P")) * 1000000000000000
+} else = n {
+	s := sprintf("%v", [q])
+	endswith(s, "E")
+	n := to_number(trim_suffix(s, "E")) * 1000000000000000000
+} else = n {
+	n := to_number(q)
 }

--- a/rules/resources-memory-limit-and-request/test/workload-milli-suffix/data.json
+++ b/rules/resources-memory-limit-and-request/test/workload-milli-suffix/data.json
@@ -1,0 +1,8 @@
+{
+    "postureControlInputs": {
+        "memory_request_max": ["300m"],
+        "memory_request_min": ["0m"],
+        "memory_limit_max":   ["300m"],
+        "memory_limit_min":   ["0m"]
+    }
+}

--- a/rules/resources-memory-limit-and-request/test/workload-milli-suffix/expected.json
+++ b/rules/resources-memory-limit-and-request/test/workload-milli-suffix/expected.json
@@ -1,0 +1,56 @@
+[
+   {
+      "alertMessage": "Container: c in Deployment: milli exceeds memory request",
+      "reviewPaths": [
+         "spec.template.spec.containers[0].resources.requests.memory"
+      ],
+      "failedPaths": [
+         "spec.template.spec.containers[0].resources.requests.memory"
+      ],
+      "fixPaths": [],
+      "ruleStatus": "",
+      "packagename": "armo_builtins",
+      "alertScore": 7,
+      "alertObject": {
+         "k8sApiObjects": [
+            {
+               "apiVersion": "apps/v1",
+               "kind": "Deployment",
+               "metadata": {
+                  "labels": {
+                     "app": "milli"
+                  },
+                  "name": "milli"
+               }
+            }
+         ]
+      }
+   },
+   {
+      "alertMessage": "Container: c in Deployment: milli exceeds memory-limit",
+      "reviewPaths": [
+         "spec.template.spec.containers[0].resources.limits.memory"
+      ],
+      "failedPaths": [
+         "spec.template.spec.containers[0].resources.limits.memory"
+      ],
+      "fixPaths": [],
+      "ruleStatus": "",
+      "packagename": "armo_builtins",
+      "alertScore": 7,
+      "alertObject": {
+         "k8sApiObjects": [
+            {
+               "apiVersion": "apps/v1",
+               "kind": "Deployment",
+               "metadata": {
+                  "labels": {
+                     "app": "milli"
+                  },
+                  "name": "milli"
+               }
+            }
+         ]
+      }
+   }
+]

--- a/rules/resources-memory-limit-and-request/test/workload-milli-suffix/input/deployment.yaml
+++ b/rules/resources-memory-limit-and-request/test/workload-milli-suffix/input/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: milli
+  namespace: default
+  labels:
+    app: milli
+spec:
+  selector:
+    matchLabels:
+      app: milli
+  template:
+    metadata:
+      labels:
+        app: milli
+    spec:
+      containers:
+        - name: c
+          image: nginx
+          resources:
+            requests:
+              memory: "400m"
+            limits:
+              memory: "500m"

--- a/rules/resources-memory-limit-and-request/test/workload-mixed-unit/data.json
+++ b/rules/resources-memory-limit-and-request/test/workload-mixed-unit/data.json
@@ -1,0 +1,8 @@
+{
+    "postureControlInputs": {
+        "memory_request_max": ["1Gi"],
+        "memory_request_min": ["0Mi"],
+        "memory_limit_max":   ["1Gi"],
+        "memory_limit_min":   ["0Mi"]
+    }
+}

--- a/rules/resources-memory-limit-and-request/test/workload-mixed-unit/expected.json
+++ b/rules/resources-memory-limit-and-request/test/workload-mixed-unit/expected.json
@@ -1,0 +1,56 @@
+[
+   {
+      "alertMessage": "Container: c in Deployment: huge exceeds memory request",
+      "reviewPaths": [
+         "spec.template.spec.containers[0].resources.requests.memory"
+      ],
+      "failedPaths": [
+         "spec.template.spec.containers[0].resources.requests.memory"
+      ],
+      "fixPaths": [],
+      "ruleStatus": "",
+      "packagename": "armo_builtins",
+      "alertScore": 7,
+      "alertObject": {
+         "k8sApiObjects": [
+            {
+               "apiVersion": "apps/v1",
+               "kind": "Deployment",
+               "metadata": {
+                  "labels": {
+                     "app": "huge"
+                  },
+                  "name": "huge"
+               }
+            }
+         ]
+      }
+   },
+   {
+      "alertMessage": "Container: c in Deployment: huge exceeds memory-limit",
+      "reviewPaths": [
+         "spec.template.spec.containers[0].resources.limits.memory"
+      ],
+      "failedPaths": [
+         "spec.template.spec.containers[0].resources.limits.memory"
+      ],
+      "fixPaths": [],
+      "ruleStatus": "",
+      "packagename": "armo_builtins",
+      "alertScore": 7,
+      "alertObject": {
+         "k8sApiObjects": [
+            {
+               "apiVersion": "apps/v1",
+               "kind": "Deployment",
+               "metadata": {
+                  "labels": {
+                     "app": "huge"
+                  },
+                  "name": "huge"
+               }
+            }
+         ]
+      }
+   }
+]

--- a/rules/resources-memory-limit-and-request/test/workload-mixed-unit/input/deployment.yaml
+++ b/rules/resources-memory-limit-and-request/test/workload-mixed-unit/input/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: huge
+  namespace: default
+  labels:
+    app: huge
+spec:
+  selector:
+    matchLabels:
+      app: huge
+  template:
+    metadata:
+      labels:
+        app: huge
+    spec:
+      containers:
+        - name: c
+          image: nginx
+          resources:
+            requests:
+              memory: "2048Mi"
+            limits:
+              memory: "4096Mi"


### PR DESCRIPTION
## Summary

Fixes a silent correctness gap in C-0004 ("Resources memory limit and request") and its CPU sibling C-0050 ("Resources CPU limit and request"): the configured `*_min` / `*_max` thresholds were silently ignored whenever the unit suffix of the configured value didn't string-match the unit suffix of the workload value (e.g. config in `Gi`, workload in `Mi`).

## Root cause

`compare_max` / `compare_min` in `rules/resources-memory-limit-and-request/raw.rego` (and its copy in `rules/resources-cpu-limit-and-request/raw.rego`) were defined as four mutually-exclusive Rego rules, each requiring `max` and `given` to share the *exact same* string suffix:

| Branch | Fires only when |
|---|---|
| `endswith(_, "Mi")` | both end in `Mi` |
| `endswith(_, "M")`  | both end in `M`  |
| `endswith(_, "m")`  | both end in `m`  |
| unitless fallback   | **neither** is "special" (i.e. neither ends in `m`/`M`/`Mi`) |

`is_special_measure` only knew about `m`, `M`, and `Mi`, so any quantity using `Gi`, `Ki`, `Ti`, `G`, `K`, plain bytes, etc. fell through every branch. Result: `compare_*` was undefined, `is_*_exceeded` failed, and the `deny` rule produced no alert — even when the workload was clearly over the configured cap.

The CPU rule had the same bug, plus a second one: it was checking for *memory* suffixes (`Mi`/`M`) on CPU values, which never carry those suffixes. So `cpu_limit_max: ["1"]` vs workload `"1500m"` silently passed because `"1500m"` was classified as "special" and excluded from the unitless branch.

## Related 
fixes #722 

## Fix

Replace the four-branch suffix-matching comparator with a single normalized comparison via parser helpers:

- `mem_to_bytes(q)` — parses the standard Kubernetes memory suffixes (`Ki`/`Mi`/`Gi`/`Ti`/`Pi`/`Ei`, `k`/`K`/`M`/`G`/`T`/`P`/`E`, unitless bytes) into a single numeric byte count. Order matters: binary two-character suffixes are checked before single-character decimal suffixes so `Mi` is not misread as `M`.
- `cpu_to_millicores(q)` — parses the `m` suffix and unitless whole/fractional cores into millicores (`500m` → 500, `1` → 1000, `0.5` → 500).

`compare_max` / `compare_min` then become one-liners that compare the normalized values, and `is_special_measure` is removed entirely.

## Files changed

- `rules/resources-memory-limit-and-request/raw.rego` — replaced 12-rule comparator + `is_special_measure` with `mem_to_bytes` and one-line `compare_max`/`compare_min`.
- `rules/resources-cpu-limit-and-request/raw.rego` — same pattern, using `cpu_to_millicores`. Also removes the dead `Mi`/`M` branches that were copy-pasted from the memory rule.
- `rules/resources-memory-limit-and-request/test/workload-mixed-unit/` — new regression test (the exact scenario from the report): `1Gi` cap, workload requests `2048Mi` / limits `4096Mi`. Expects two alerts — would have produced zero before the fix.
- `rules/resources-cpu-limit-and-request/test/workload-mixed-unit/` — new regression test: `1` core cap, workload requests `1500m` / limits `2000m`. Expects two alerts — would have produced zero before the fix.

## Reproducer (before the fix)

`data.json`:
```json
{
  "postureControlInputs": {
    "memory_request_max": ["1Gi"],
    "memory_request_min": ["0Mi"],
    "memory_limit_max":   ["1Gi"],
    "memory_limit_min":   ["0Mi"]
  }
}
```

Workload (`requests.memory: 2048Mi`, `limits.memory: 4096Mi`) against a 1 GiB cap:

- **Before:** `[]` — no alert, threshold silently ignored.
- **After:** `"exceeds memory request"` and `"exceeds memory-limit"` alerts emitted as expected.

## Test plan

- [x] `go test -run "TestSingleRule" -rule "resources-memory-limit-and-request" -tags=static -v` — 9/9 pass (8 existing + new `workload-mixed-unit`)
- [x] `go test -run "TestSingleRule" -rule "resources-cpu-limit-and-request" -tags=static -v` — 7/7 pass (6 existing + new `workload-mixed-unit`)
- [x] `go test -run "TestAllRules" -tags=static` — full regolibrary suite passes (~3 min), no regressions in any other rule.
- [x] `python ./scripts/export.py` — artifact bundle still builds.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CPU and memory resource limit and request validation rules to correctly compare values across different unit formats used in Kubernetes configurations.

* **Tests**
  * Added comprehensive test cases to verify resource validation accuracy with mixed-unit specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->