### PR TITLE
feat: new C-0295 for duplicate env variables in containers

### DIFF
--- a/ControlID_RuleName.csv
+++ b/ControlID_RuleName.csv
@@ -228,3 +228,4 @@ CIS-5.7.4,resources-notpods-in-default-namespace
 C-0292,detect-nginx-ingress-controller-eol
 C-0293,service-with-no-workload
 C-0294,deprecated-service-account-field
+C-0295,duplicate-env-var

--- a/FWName_CID_CName.csv
+++ b/FWName_CID_CName.csv
@@ -288,3 +288,5 @@ DevOpsBest,C-0293,Service with no workload
 AllControls,C-0293,Service with no workload
 DevOpsBest,C-0294,Deprecated serviceAccount field
 AllControls,C-0294,Deprecated serviceAccount field
+DevOpsBest,C-0295,Duplicate environment variable
+AllControls,C-0295,Duplicate environment variable

--- a/controls/C-0295-duplicateenvvar.json
+++ b/controls/C-0295-duplicateenvvar.json
@@ -1,0 +1,25 @@
+{
+    "name": "Duplicate environment variable",
+    "attributes": {
+        "controlTypeTags": [
+            "devops"
+        ]
+    },
+    "description": "A container with duplicate environment variable names can behave unexpectedly because later values override earlier values. Duplicate entries usually indicate configuration drift or copy-paste mistakes.",
+    "remediation": "Remove or rename duplicate environment variable entries so each container defines each environment variable name only once.",
+    "rulesNames": [
+        "duplicate-env-var"
+    ],
+    "test": "Check every container in Pods, pod-template workloads, and CronJobs for repeated env[].name values within the same container.",
+    "controlID": "C-0295",
+    "baseScore": 3.0,
+    "category": {
+        "name": "Workload"
+    },
+    "scanningScope": {
+        "matches": [
+            "cluster",
+            "file"
+        ]
+    }
+}

--- a/frameworks/allcontrols.json
+++ b/frameworks/allcontrols.json
@@ -383,6 +383,12 @@
             "patch": {
                 "name": "Deprecated serviceAccount field"
             }
+        },
+        {
+            "controlID": "C-0295",
+            "patch": {
+                "name": "Duplicate environment variable"
+            }
         }
     ]
 }

--- a/frameworks/devopsbest.json
+++ b/frameworks/devopsbest.json
@@ -113,6 +113,12 @@
             "patch": {
                 "name": "Deprecated serviceAccount field"
             }
+        },
+        {
+            "controlID": "C-0295",
+            "patch": {
+                "name": "Duplicate environment variable"
+            }
         }
     ]
 }

--- a/rules/duplicate-env-var/raw.rego
+++ b/rules/duplicate-env-var/raw.rego
@@ -18,37 +18,67 @@ deny contains msga if {
 
 	path := sprintf("spec.containers[%v].env[%v].name", [i, j])
 
-	msga := {
-		"alertMessage": sprintf("Pod: %v container %v has duplicate environment variable name %v at this entry", [pod.metadata.name, container.name, env.name]),
-		"packagename": "armo_builtins",
-		"failedPaths": [path],
-		"fixPaths": [],
-		"alertScore": 3,
-		"alertObject": {
-			"k8sApiObjects": [pod],
-		},
-	}
+	msga := make_alert(pod, "Pod", pod.metadata.name, container, env.name, path)
+}
+
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.initContainers[i]
+	env := container.env[j]
+	same_name_at_other_index(container.env, j, env.name)
+
+	path := sprintf("spec.initContainers[%v].env[%v].name", [i, j])
+
+	msga := make_alert(pod, "Pod", pod.metadata.name, container, env.name, path)
+}
+
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.ephemeralContainers[i]
+	env := container.env[j]
+	same_name_at_other_index(container.env, j, env.name)
+
+	path := sprintf("spec.ephemeralContainers[%v].env[%v].name", [i, j])
+
+	msga := make_alert(pod, "Pod", pod.metadata.name, container, env.name, path)
 }
 
 deny contains msga if {
 	wl := input[_]
-	wl.kind in {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl.kind in {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "ReplicationController"}
 	container := wl.spec.template.spec.containers[i]
 	env := container.env[j]
 	same_name_at_other_index(container.env, j, env.name)
 
 	path := sprintf("spec.template.spec.containers[%v].env[%v].name", [i, j])
 
-	msga := {
-		"alertMessage": sprintf("%v: %v container %v has duplicate environment variable name %v at this entry", [wl.kind, wl.metadata.name, container.name, env.name]),
-		"packagename": "armo_builtins",
-		"failedPaths": [path],
-		"fixPaths": [],
-		"alertScore": 3,
-		"alertObject": {
-			"k8sApiObjects": [wl],
-		},
-	}
+	msga := make_alert(wl, wl.kind, wl.metadata.name, container, env.name, path)
+}
+
+deny contains msga if {
+	wl := input[_]
+	wl.kind in {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "ReplicationController"}
+	container := wl.spec.template.spec.initContainers[i]
+	env := container.env[j]
+	same_name_at_other_index(container.env, j, env.name)
+
+	path := sprintf("spec.template.spec.initContainers[%v].env[%v].name", [i, j])
+
+	msga := make_alert(wl, wl.kind, wl.metadata.name, container, env.name, path)
+}
+
+deny contains msga if {
+	wl := input[_]
+	wl.kind in {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "ReplicationController"}
+	container := wl.spec.template.spec.ephemeralContainers[i]
+	env := container.env[j]
+	same_name_at_other_index(container.env, j, env.name)
+
+	path := sprintf("spec.template.spec.ephemeralContainers[%v].env[%v].name", [i, j])
+
+	msga := make_alert(wl, wl.kind, wl.metadata.name, container, env.name, path)
 }
 
 deny contains msga if {
@@ -60,14 +90,40 @@ deny contains msga if {
 
 	path := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].name", [i, j])
 
-	msga := {
-		"alertMessage": sprintf("CronJob: %v container %v has duplicate environment variable name %v at this entry", [wl.metadata.name, container.name, env.name]),
-		"packagename": "armo_builtins",
-		"failedPaths": [path],
-		"fixPaths": [],
-		"alertScore": 3,
-		"alertObject": {
-			"k8sApiObjects": [wl],
-		},
-	}
+	msga := make_alert(wl, "CronJob", wl.metadata.name, container, env.name, path)
+}
+
+deny contains msga if {
+	wl := input[_]
+	wl.kind == "CronJob"
+	container := wl.spec.jobTemplate.spec.template.spec.initContainers[i]
+	env := container.env[j]
+	same_name_at_other_index(container.env, j, env.name)
+
+	path := sprintf("spec.jobTemplate.spec.template.spec.initContainers[%v].env[%v].name", [i, j])
+
+	msga := make_alert(wl, "CronJob", wl.metadata.name, container, env.name, path)
+}
+
+deny contains msga if {
+	wl := input[_]
+	wl.kind == "CronJob"
+	container := wl.spec.jobTemplate.spec.template.spec.ephemeralContainers[i]
+	env := container.env[j]
+	same_name_at_other_index(container.env, j, env.name)
+
+	path := sprintf("spec.jobTemplate.spec.template.spec.ephemeralContainers[%v].env[%v].name", [i, j])
+
+	msga := make_alert(wl, "CronJob", wl.metadata.name, container, env.name, path)
+}
+
+make_alert(obj, kind, name, container, env_name, path) := {
+	"alertMessage": sprintf("%v: %v container %v has duplicate environment variable name %v at this entry", [kind, name, container.name, env_name]),
+	"packagename": "armo_builtins",
+	"failedPaths": [path],
+	"fixPaths": [],
+	"alertScore": 3,
+	"alertObject": {
+		"k8sApiObjects": [obj],
+	},
 }

--- a/rules/duplicate-env-var/raw.rego
+++ b/rules/duplicate-env-var/raw.rego
@@ -1,0 +1,71 @@
+package armo_builtins
+
+deny[msga] {
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.containers[i]
+	env := container.env[j]
+	previous := container.env[k]
+	k < j
+	env.name == previous.name
+
+	path := sprintf("spec.containers[%v].env[%v].name", [i, j])
+
+	msga := {
+		"alertMessage": sprintf("Pod: %v container %v has duplicate environment variable %v", [pod.metadata.name, container.name, env.name]),
+		"packagename": "armo_builtins",
+		"failedPaths": [path],
+		"fixPaths": [],
+		"alertScore": 3,
+		"alertObject": {
+			"k8sApiObjects": [pod],
+		},
+	}
+}
+
+deny[msga] {
+	wl := input[_]
+	workload_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	workload_kinds[wl.kind]
+	container := wl.spec.template.spec.containers[i]
+	env := container.env[j]
+	previous := container.env[k]
+	k < j
+	env.name == previous.name
+
+	path := sprintf("spec.template.spec.containers[%v].env[%v].name", [i, j])
+
+	msga := {
+		"alertMessage": sprintf("%v: %v container %v has duplicate environment variable %v", [wl.kind, wl.metadata.name, container.name, env.name]),
+		"packagename": "armo_builtins",
+		"failedPaths": [path],
+		"fixPaths": [],
+		"alertScore": 3,
+		"alertObject": {
+			"k8sApiObjects": [wl],
+		},
+	}
+}
+
+deny[msga] {
+	wl := input[_]
+	wl.kind == "CronJob"
+	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
+	env := container.env[j]
+	previous := container.env[k]
+	k < j
+	env.name == previous.name
+
+	path := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].name", [i, j])
+
+	msga := {
+		"alertMessage": sprintf("CronJob: %v container %v has duplicate environment variable %v", [wl.metadata.name, container.name, env.name]),
+		"packagename": "armo_builtins",
+		"failedPaths": [path],
+		"fixPaths": [],
+		"alertScore": 3,
+		"alertObject": {
+			"k8sApiObjects": [wl],
+		},
+	}
+}

--- a/rules/duplicate-env-var/raw.rego
+++ b/rules/duplicate-env-var/raw.rego
@@ -1,18 +1,25 @@
 package armo_builtins
 
-deny[msga] {
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+same_name_at_other_index(envs, j, name) if {
+	k != j
+	envs[k].name == name
+}
+
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
 	env := container.env[j]
-	previous := container.env[k]
-	k < j
-	env.name == previous.name
+	same_name_at_other_index(container.env, j, env.name)
 
 	path := sprintf("spec.containers[%v].env[%v].name", [i, j])
 
 	msga := {
-		"alertMessage": sprintf("Pod: %v container %v has duplicate environment variable %v", [pod.metadata.name, container.name, env.name]),
+		"alertMessage": sprintf("Pod: %v container %v has duplicate environment variable name %v at this entry", [pod.metadata.name, container.name, env.name]),
 		"packagename": "armo_builtins",
 		"failedPaths": [path],
 		"fixPaths": [],
@@ -23,20 +30,17 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	workload_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
-	workload_kinds[wl.kind]
+	wl.kind in {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	container := wl.spec.template.spec.containers[i]
 	env := container.env[j]
-	previous := container.env[k]
-	k < j
-	env.name == previous.name
+	same_name_at_other_index(container.env, j, env.name)
 
 	path := sprintf("spec.template.spec.containers[%v].env[%v].name", [i, j])
 
 	msga := {
-		"alertMessage": sprintf("%v: %v container %v has duplicate environment variable %v", [wl.kind, wl.metadata.name, container.name, env.name]),
+		"alertMessage": sprintf("%v: %v container %v has duplicate environment variable name %v at this entry", [wl.kind, wl.metadata.name, container.name, env.name]),
 		"packagename": "armo_builtins",
 		"failedPaths": [path],
 		"fixPaths": [],
@@ -47,19 +51,17 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
 	env := container.env[j]
-	previous := container.env[k]
-	k < j
-	env.name == previous.name
+	same_name_at_other_index(container.env, j, env.name)
 
 	path := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].name", [i, j])
 
 	msga := {
-		"alertMessage": sprintf("CronJob: %v container %v has duplicate environment variable %v", [wl.metadata.name, container.name, env.name]),
+		"alertMessage": sprintf("CronJob: %v container %v has duplicate environment variable name %v at this entry", [wl.metadata.name, container.name, env.name]),
 		"packagename": "armo_builtins",
 		"failedPaths": [path],
 		"fixPaths": [],

--- a/rules/duplicate-env-var/rule.metadata.json
+++ b/rules/duplicate-env-var/rule.metadata.json
@@ -7,7 +7,7 @@
         {
             "apiGroups": [""],
             "apiVersions": ["v1"],
-            "resources": ["Pod"]
+            "resources": ["Pod", "ReplicationController"]
         },
         {
             "apiGroups": ["apps"],

--- a/rules/duplicate-env-var/rule.metadata.json
+++ b/rules/duplicate-env-var/rule.metadata.json
@@ -1,0 +1,27 @@
+{
+    "name": "duplicate-env-var",
+    "attributes": {
+    },
+    "ruleLanguage": "Rego",
+    "match": [
+        {
+            "apiGroups": [""],
+            "apiVersions": ["v1"],
+            "resources": ["Pod"]
+        },
+        {
+            "apiGroups": ["apps"],
+            "apiVersions": ["v1"],
+            "resources": ["Deployment", "ReplicaSet", "DaemonSet", "StatefulSet"]
+        },
+        {
+            "apiGroups": ["batch"],
+            "apiVersions": ["*"],
+            "resources": ["Job", "CronJob"]
+        }
+    ],
+    "ruleDependencies": [],
+    "description": "fails if a container defines the same environment variable name more than once",
+    "remediation": "Remove or rename duplicate environment variable entries so each container defines each environment variable name only once.",
+    "ruleQuery": "armo_builtins"
+}

--- a/rules/duplicate-env-var/test/all-container-types/expected.json
+++ b/rules/duplicate-env-var/test/all-container-types/expected.json
@@ -1,0 +1,122 @@
+[
+  {
+    "alertMessage": "Pod: duplicate-env-all-container-types container app has duplicate environment variable name APP_MODE at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.containers[0].env[0].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "v1",
+          "kind": "Pod",
+          "metadata": {
+            "name": "duplicate-env-all-container-types"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Pod: duplicate-env-all-container-types container app has duplicate environment variable name APP_MODE at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.containers[0].env[1].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "v1",
+          "kind": "Pod",
+          "metadata": {
+            "name": "duplicate-env-all-container-types"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Pod: duplicate-env-all-container-types container debug has duplicate environment variable name DEBUG_MODE at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.ephemeralContainers[0].env[0].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "v1",
+          "kind": "Pod",
+          "metadata": {
+            "name": "duplicate-env-all-container-types"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Pod: duplicate-env-all-container-types container debug has duplicate environment variable name DEBUG_MODE at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.ephemeralContainers[0].env[1].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "v1",
+          "kind": "Pod",
+          "metadata": {
+            "name": "duplicate-env-all-container-types"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Pod: duplicate-env-all-container-types container setup has duplicate environment variable name SETUP_MODE at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.initContainers[0].env[0].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "v1",
+          "kind": "Pod",
+          "metadata": {
+            "name": "duplicate-env-all-container-types"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Pod: duplicate-env-all-container-types container setup has duplicate environment variable name SETUP_MODE at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.initContainers[0].env[1].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "v1",
+          "kind": "Pod",
+          "metadata": {
+            "name": "duplicate-env-all-container-types"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/rules/duplicate-env-var/test/all-container-types/input/pod.yaml
+++ b/rules/duplicate-env-var/test/all-container-types/input/pod.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: duplicate-env-all-container-types
+spec:
+  initContainers:
+  - name: setup
+    image: busybox
+    env:
+    - name: SETUP_MODE
+      value: fast
+    - name: SETUP_MODE
+      value: slow
+  containers:
+  - name: app
+    image: nginx
+    env:
+    - name: APP_MODE
+      value: production
+    - name: APP_MODE
+      value: staging
+  ephemeralContainers:
+  - name: debug
+    image: busybox
+    env:
+    - name: DEBUG_MODE
+      value: shell
+    - name: DEBUG_MODE
+      value: trace

--- a/rules/duplicate-env-var/test/cronjob/expected.json
+++ b/rules/duplicate-env-var/test/cronjob/expected.json
@@ -1,9 +1,49 @@
 [
   {
-    "alertMessage": "CronJob: duplicate-env-cronjob container job has duplicate environment variable RETRY_COUNT",
+    "alertMessage": "CronJob: duplicate-env-cronjob container job has duplicate environment variable name RETRY_COUNT at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.jobTemplate.spec.template.spec.containers[0].env[0].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "batch/v1",
+          "kind": "CronJob",
+          "metadata": {
+            "name": "duplicate-env-cronjob"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "CronJob: duplicate-env-cronjob container job has duplicate environment variable name RETRY_COUNT at this entry",
     "packagename": "armo_builtins",
     "failedPaths": [
       "spec.jobTemplate.spec.template.spec.containers[0].env[1].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "batch/v1",
+          "kind": "CronJob",
+          "metadata": {
+            "name": "duplicate-env-cronjob"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "CronJob: duplicate-env-cronjob container job has duplicate environment variable name RETRY_COUNT at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.jobTemplate.spec.template.spec.containers[0].env[2].name"
     ],
     "fixPaths": [],
     "alertScore": 3,

--- a/rules/duplicate-env-var/test/cronjob/expected.json
+++ b/rules/duplicate-env-var/test/cronjob/expected.json
@@ -1,0 +1,22 @@
+[
+  {
+    "alertMessage": "CronJob: duplicate-env-cronjob container job has duplicate environment variable RETRY_COUNT",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.jobTemplate.spec.template.spec.containers[0].env[1].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "batch/v1",
+          "kind": "CronJob",
+          "metadata": {
+            "name": "duplicate-env-cronjob"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/rules/duplicate-env-var/test/cronjob/input/cronjob.yaml
+++ b/rules/duplicate-env-var/test/cronjob/input/cronjob.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: duplicate-env-cronjob
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: job
+            image: busybox
+            env:
+            - name: RETRY_COUNT
+              value: "1"
+            - name: RETRY_COUNT
+              value: "3"

--- a/rules/duplicate-env-var/test/cronjob/input/cronjob.yaml
+++ b/rules/duplicate-env-var/test/cronjob/input/cronjob.yaml
@@ -17,3 +17,5 @@ spec:
               value: "1"
             - name: RETRY_COUNT
               value: "3"
+            - name: RETRY_COUNT
+              value: "5"

--- a/rules/duplicate-env-var/test/job/expected.json
+++ b/rules/duplicate-env-var/test/job/expected.json
@@ -1,9 +1,49 @@
 [
   {
-    "alertMessage": "Job: duplicate-env-job container worker has duplicate environment variable WORKER_MODE",
+    "alertMessage": "Job: duplicate-env-job container worker has duplicate environment variable name WORKER_MODE at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.template.spec.containers[0].env[0].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "batch/v1",
+          "kind": "Job",
+          "metadata": {
+            "name": "duplicate-env-job"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Job: duplicate-env-job container worker has duplicate environment variable name WORKER_MODE at this entry",
     "packagename": "armo_builtins",
     "failedPaths": [
       "spec.template.spec.containers[0].env[1].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "batch/v1",
+          "kind": "Job",
+          "metadata": {
+            "name": "duplicate-env-job"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Job: duplicate-env-job container worker has duplicate environment variable name WORKER_MODE at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.template.spec.containers[0].env[2].name"
     ],
     "fixPaths": [],
     "alertScore": 3,

--- a/rules/duplicate-env-var/test/job/expected.json
+++ b/rules/duplicate-env-var/test/job/expected.json
@@ -1,0 +1,22 @@
+[
+  {
+    "alertMessage": "Job: duplicate-env-job container worker has duplicate environment variable WORKER_MODE",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.template.spec.containers[0].env[1].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "batch/v1",
+          "kind": "Job",
+          "metadata": {
+            "name": "duplicate-env-job"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/rules/duplicate-env-var/test/job/input/job.yaml
+++ b/rules/duplicate-env-var/test/job/input/job.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: duplicate-env-job
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: worker
+        image: busybox
+        env:
+        - name: WORKER_MODE
+          value: batch
+        - name: WORKER_MODE
+          value: retry

--- a/rules/duplicate-env-var/test/job/input/job.yaml
+++ b/rules/duplicate-env-var/test/job/input/job.yaml
@@ -14,3 +14,5 @@ spec:
           value: batch
         - name: WORKER_MODE
           value: retry
+        - name: WORKER_MODE
+          value: debug

--- a/rules/duplicate-env-var/test/pod/expected.json
+++ b/rules/duplicate-env-var/test/pod/expected.json
@@ -1,9 +1,49 @@
 [
   {
-    "alertMessage": "Pod: duplicate-env-pod container app has duplicate environment variable LOG_LEVEL",
+    "alertMessage": "Pod: duplicate-env-pod container app has duplicate environment variable name LOG_LEVEL at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.containers[0].env[0].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "v1",
+          "kind": "Pod",
+          "metadata": {
+            "name": "duplicate-env-pod"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Pod: duplicate-env-pod container app has duplicate environment variable name LOG_LEVEL at this entry",
     "packagename": "armo_builtins",
     "failedPaths": [
       "spec.containers[0].env[1].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "v1",
+          "kind": "Pod",
+          "metadata": {
+            "name": "duplicate-env-pod"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Pod: duplicate-env-pod container app has duplicate environment variable name LOG_LEVEL at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.containers[0].env[2].name"
     ],
     "fixPaths": [],
     "alertScore": 3,

--- a/rules/duplicate-env-var/test/pod/expected.json
+++ b/rules/duplicate-env-var/test/pod/expected.json
@@ -1,0 +1,22 @@
+[
+  {
+    "alertMessage": "Pod: duplicate-env-pod container app has duplicate environment variable LOG_LEVEL",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.containers[0].env[1].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "v1",
+          "kind": "Pod",
+          "metadata": {
+            "name": "duplicate-env-pod"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/rules/duplicate-env-var/test/pod/input/pod.yaml
+++ b/rules/duplicate-env-var/test/pod/input/pod.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: duplicate-env-pod
+spec:
+  containers:
+  - name: app
+    image: nginx
+    env:
+    - name: LOG_LEVEL
+      value: info
+    - name: LOG_LEVEL
+      value: debug
+  - name: sidecar
+    image: busybox
+    env:
+    - name: LOG_LEVEL
+      value: info
+    - name: CACHE_SIZE
+      value: "128"

--- a/rules/duplicate-env-var/test/pod/input/pod.yaml
+++ b/rules/duplicate-env-var/test/pod/input/pod.yaml
@@ -11,6 +11,8 @@ spec:
       value: info
     - name: LOG_LEVEL
       value: debug
+    - name: LOG_LEVEL
+      value: trace
   - name: sidecar
     image: busybox
     env:

--- a/rules/duplicate-env-var/test/replicationcontroller/expected.json
+++ b/rules/duplicate-env-var/test/replicationcontroller/expected.json
@@ -1,0 +1,42 @@
+[
+  {
+    "alertMessage": "ReplicationController: duplicate-env-replicationcontroller container app has duplicate environment variable name RC_MODE at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.template.spec.containers[0].env[0].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "v1",
+          "kind": "ReplicationController",
+          "metadata": {
+            "name": "duplicate-env-replicationcontroller"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "ReplicationController: duplicate-env-replicationcontroller container app has duplicate environment variable name RC_MODE at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.template.spec.containers[0].env[1].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "v1",
+          "kind": "ReplicationController",
+          "metadata": {
+            "name": "duplicate-env-replicationcontroller"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/rules/duplicate-env-var/test/replicationcontroller/input/replicationcontroller.yaml
+++ b/rules/duplicate-env-var/test/replicationcontroller/input/replicationcontroller.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: duplicate-env-replicationcontroller
+spec:
+  selector:
+    app: duplicate-env
+  template:
+    metadata:
+      labels:
+        app: duplicate-env
+    spec:
+      containers:
+      - name: app
+        image: nginx
+        env:
+        - name: RC_MODE
+          value: active
+        - name: RC_MODE
+          value: standby

--- a/rules/duplicate-env-var/test/workload/expected.json
+++ b/rules/duplicate-env-var/test/workload/expected.json
@@ -1,0 +1,22 @@
+[
+  {
+    "alertMessage": "Deployment: duplicate-env-deployment container app has duplicate environment variable APP_MODE",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.template.spec.containers[0].env[1].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "metadata": {
+            "name": "duplicate-env-deployment"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/rules/duplicate-env-var/test/workload/expected.json
+++ b/rules/duplicate-env-var/test/workload/expected.json
@@ -1,9 +1,49 @@
 [
   {
-    "alertMessage": "Deployment: duplicate-env-deployment container app has duplicate environment variable APP_MODE",
+    "alertMessage": "Deployment: duplicate-env-deployment container app has duplicate environment variable name APP_MODE at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.template.spec.containers[0].env[0].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "metadata": {
+            "name": "duplicate-env-deployment"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Deployment: duplicate-env-deployment container app has duplicate environment variable name APP_MODE at this entry",
     "packagename": "armo_builtins",
     "failedPaths": [
       "spec.template.spec.containers[0].env[1].name"
+    ],
+    "fixPaths": [],
+    "alertScore": 3,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "metadata": {
+            "name": "duplicate-env-deployment"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Deployment: duplicate-env-deployment container app has duplicate environment variable name APP_MODE at this entry",
+    "packagename": "armo_builtins",
+    "failedPaths": [
+      "spec.template.spec.containers[0].env[2].name"
     ],
     "fixPaths": [],
     "alertScore": 3,

--- a/rules/duplicate-env-var/test/workload/input/deployment.yaml
+++ b/rules/duplicate-env-var/test/workload/input/deployment.yaml
@@ -19,3 +19,5 @@ spec:
           value: production
         - name: APP_MODE
           value: staging
+        - name: APP_MODE
+          value: debug

--- a/rules/duplicate-env-var/test/workload/input/deployment.yaml
+++ b/rules/duplicate-env-var/test/workload/input/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: duplicate-env-deployment
+spec:
+  selector:
+    matchLabels:
+      app: duplicate-env
+  template:
+    metadata:
+      labels:
+        app: duplicate-env
+    spec:
+      containers:
+      - name: app
+        image: nginx
+        env:
+        - name: APP_MODE
+          value: production
+        - name: APP_MODE
+          value: staging


### PR DESCRIPTION
 Signed-off-by: GeneCodeSavvy hxrsh.09@gmail.com (hxrsh.09@gmail.com)

## Overview

  Adds Kubescape support for the kube-linter duplicate-env-var check.

  This PR introduces a new C-0295 control and Rego rule that flags containers defining the same environment variable name more than once. Duplicate env vars can cause confusing
  runtime behavior because later values may override earlier values.

  The rule covers Pods, standard workload pod templates, Jobs, and CronJobs, with focused test fixtures for each supported path.

## How to Test
```
cd testrunner
go test -v -tags="static" rego_test.go -run TestSingleRule -args -rule duplicate-env-var
```
## Related Issues/PRs:

  - Partial Resolves: https://github.com/kubescape/kubescape/issues/1396

## Checklist before requesting a review

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] If it is a core feature, I have added thorough tests.
  - [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added control C-0295 to detect duplicate environment variable names within a container across Pods, pod-template workloads (Deployments, ReplicaSets, DaemonSets, StatefulSets, Jobs, ReplicationControllers) and CronJobs, covering containers, initContainers and ephemeralContainers; emits alerts with failed path details and score.

* **Tests**
  * Added comprehensive fixtures and expected outputs for Pod, Workload, Job, CronJob, ReplicationController, and mixed-container scenarios to validate detection and alerts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/regolibrary/pull/725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->