### PR TITLE
fix: report namespaces instead of webhooks for CIS 5.2.x PSA controls

### DIFF
--- a/rules/pod-security-admission-baseline-applied-1/filter.rego
+++ b/rules/pod-security-admission-baseline-applied-1/filter.rego
@@ -20,7 +20,5 @@ deny[msga] {
 }
 
 baseline_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels
-    key == "pod-security.kubernetes.io/enforce"
-	value in ["baseline", "restricted"]
+	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] in ["baseline", "restricted"]
 }

--- a/rules/pod-security-admission-baseline-applied-1/filter.rego
+++ b/rules/pod-security-admission-baseline-applied-1/filter.rego
@@ -1,11 +1,11 @@
 package armo_builtins
 import future.keywords.in
 
-# if no 3rd party security admission exists - Fails if namespace does not have relevant labels
+# Fails if namespace does not have baseline pod security admission label
 deny[msga] {
-    not has_external_policy_control(input)
 	namespace := input[_]
 	namespace.kind == "Namespace"
+	not baseline_admission_policy_enabled(namespace)
 
 	msga := {
 		"alertMessage": sprintf("Namespace: %v does not enable baseline pod security admission", [namespace.metadata.name]),
@@ -19,37 +19,8 @@ deny[msga] {
 	}
 }
 
-# Fails if at least 1 namespace does not have relevant labels and 3rd party namespaced security admission EXISTS
-# returns webhook configuration for user to review
-deny[msga] {
-	some namespace in input
-	namespace.kind == "Namespace"
-	not baseline_admission_policy_enabled(namespace)
-
-    admissionwebhook := input[_]
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-
-	msga := {
-		"alertMessage": sprintf("Review webhook: %v ensure that it defines the required policy", [admissionwebhook.metadata.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 7,
-		"failedPaths": [],
-		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [admissionwebhook]
-		}
-	}
-}
-
-
 baseline_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels 
+	some key, value in namespace.metadata.labels
     key == "pod-security.kubernetes.io/enforce"
 	value in ["baseline", "restricted"]
-}
-
-has_external_policy_control(inp){
-    some admissionwebhook in inp
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
 }

--- a/rules/pod-security-admission-baseline-applied-1/raw.rego
+++ b/rules/pod-security-admission-baseline-applied-1/raw.rego
@@ -21,7 +21,5 @@ deny[msga] {
 }
 
 baseline_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels
-    key == "pod-security.kubernetes.io/enforce"
-	value in ["baseline", "restricted"]
+	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] in ["baseline", "restricted"]
 }

--- a/rules/pod-security-admission-baseline-applied-1/raw.rego
+++ b/rules/pod-security-admission-baseline-applied-1/raw.rego
@@ -1,12 +1,11 @@
 package armo_builtins
 import future.keywords.in
 
-# Fails if namespace does not have relevant labels and no 3rd party security admission exists
+# Fails if namespace does not have baseline pod security admission label
 deny[msga] {
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not baseline_admission_policy_enabled(namespace)
-    not has_external_policy_control(input)
 	fix_path = {"path": "metadata.labels[pod-security.kubernetes.io/enforce]", "value": "baseline"}
 
 	msga := {
@@ -21,38 +20,8 @@ deny[msga] {
 	}
 }
 
-# Fails if at least 1 namespace does not have relevant labels and 3rd party namespaced security admission EXISTS
-# returns webhook configuration for user to review
-deny[msga] {
-	some namespace in input
-	namespace.kind == "Namespace"
-	not baseline_admission_policy_enabled(namespace)
-
-    admissionwebhook := input[_]
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
-
-	msga := {
-		"alertMessage": sprintf("Review webhook: %v ensure that it defines the required policy", [admissionwebhook.metadata.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 7,
-		"failedPaths": [],
-		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [admissionwebhook]
-		}
-	}
-}
-
-
 baseline_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels 
+	some key, value in namespace.metadata.labels
     key == "pod-security.kubernetes.io/enforce"
 	value in ["baseline", "restricted"]
-}
-
-has_external_policy_control(inp){
-    some admissionwebhook in inp
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
 }

--- a/rules/pod-security-admission-baseline-applied-1/rule.metadata.json
+++ b/rules/pod-security-admission-baseline-applied-1/rule.metadata.json
@@ -14,21 +14,10 @@
             "resources": [
                 "Namespace"
             ]
-        },
-        {
-            "apiGroups": [
-                "admissionregistration.k8s.io"
-            ],
-            "apiVersions": [
-                "*"
-            ],
-            "resources": [
-                "ValidatingWebhookConfiguration"
-            ]
         }
     ],
     "ruleDependencies": [],
-    "description": "Checks that every namespace enabled baseline pod security admission, or if there are external policies applied for namespaced resources (validating/mutating webhooks) - returns them to be reviewed",
-    "remediation": "",
+    "description": "Checks that every namespace has baseline pod security admission enabled via the pod-security.kubernetes.io/enforce label set to baseline or restricted",
+    "remediation": "Add the label pod-security.kubernetes.io/enforce=baseline (or stricter) to every namespace that contains user workloads.\n\n#### Impact Statement\nWhere policy control systems are in place, there is a risk that workloads required for the operation of the cluster may be stopped from running. Care is required when implementing admission control policies to ensure that this does not occur.\n\n#### Default Value\nBy default, Pod Security Admission is enabled but no policies are in place.",
     "ruleQuery": "armo_builtins"
 }

--- a/rules/pod-security-admission-baseline-applied-1/test/test/expected.json
+++ b/rules/pod-security-admission-baseline-applied-1/test/test/expected.json
@@ -1,18 +1,18 @@
 [
     {
-        "alertMessage": "Review webhook: test-webhook ensure that it defines the required policy",
+        "alertMessage": "Namespace: my-namespace does not enable baseline pod security admission",
         "failedPaths": [],
-        "fixPaths": [],
+        "fixPaths": [{"path":"metadata.labels[pod-security.kubernetes.io/enforce]", "value":"baseline"}],
         "ruleStatus": "",
         "packagename": "armo_builtins",
         "alertScore": 7,
         "alertObject": {
             "k8sApiObjects": [
                 {
-                    "apiVersion": "admissionregistration.k8s.io/v1",
-                    "kind": "MutatingWebhookConfiguration",
+                    "apiVersion": "v1",
+                    "kind": "Namespace",
                     "metadata": {
-                        "name": "test-webhook"
+                        "name": "my-namespace"
                     }
                 }
             ]

--- a/rules/pod-security-admission-baseline-applied-2/filter.rego
+++ b/rules/pod-security-admission-baseline-applied-2/filter.rego
@@ -20,7 +20,5 @@ deny[msga] {
 }
 
 baseline_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels
-    key == "pod-security.kubernetes.io/enforce"
-	value in ["baseline", "restricted"]
+	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] in ["baseline", "restricted"]
 }

--- a/rules/pod-security-admission-baseline-applied-2/filter.rego
+++ b/rules/pod-security-admission-baseline-applied-2/filter.rego
@@ -1,11 +1,11 @@
 package armo_builtins
 import future.keywords.in
 
-# if no 3rd party security admission exists - Fails if namespace does not have relevant labels
+# Fails if namespace does not have baseline pod security admission label
 deny[msga] {
-    not has_external_policy_control(input)
 	namespace := input[_]
 	namespace.kind == "Namespace"
+	not baseline_admission_policy_enabled(namespace)
 
 	msga := {
 		"alertMessage": sprintf("Namespace: %v does not enable baseline pod security admission", [namespace.metadata.name]),
@@ -19,37 +19,8 @@ deny[msga] {
 	}
 }
 
-# Fails if at least 1 namespace does not have relevant labels and 3rd party namespaced security admission EXISTS
-# returns webhook configuration for user to review
-deny[msga] {
-	some namespace in input
-	namespace.kind == "Namespace"
-	not baseline_admission_policy_enabled(namespace)
-
-    admissionwebhook := input[_]
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-
-	msga := {
-		"alertMessage": sprintf("Review webhook: %v ensure that it defines the required policy", [admissionwebhook.metadata.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 7,
-		"failedPaths": [],
-		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [admissionwebhook]
-		}
-	}
-}
-
-
 baseline_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels 
+	some key, value in namespace.metadata.labels
     key == "pod-security.kubernetes.io/enforce"
 	value in ["baseline", "restricted"]
-}
-
-has_external_policy_control(inp){
-    some admissionwebhook in inp
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
 }

--- a/rules/pod-security-admission-baseline-applied-2/raw.rego
+++ b/rules/pod-security-admission-baseline-applied-2/raw.rego
@@ -21,7 +21,5 @@ deny[msga] {
 }
 
 baseline_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels
-    key == "pod-security.kubernetes.io/enforce"
-	value in ["baseline", "restricted"]
+	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] in ["baseline", "restricted"]
 }

--- a/rules/pod-security-admission-baseline-applied-2/raw.rego
+++ b/rules/pod-security-admission-baseline-applied-2/raw.rego
@@ -1,12 +1,11 @@
 package armo_builtins
 import future.keywords.in
 
-# Fails if namespace does not have relevant labels and no 3rd party security admission exists
+# Fails if namespace does not have baseline pod security admission label
 deny[msga] {
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not baseline_admission_policy_enabled(namespace)
-    not has_external_policy_control(input)
 	fix_path = {"path": "metadata.labels[pod-security.kubernetes.io/enforce]", "value": "baseline"}
 
 	msga := {
@@ -21,38 +20,8 @@ deny[msga] {
 	}
 }
 
-# Fails if at least 1 namespace does not have relevant labels and 3rd party namespaced security admission EXISTS
-# returns webhook configuration for user to review
-deny[msga] {
-	some namespace in input
-	namespace.kind == "Namespace"
-	not baseline_admission_policy_enabled(namespace)
-
-    admissionwebhook := input[_]
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
-
-	msga := {
-		"alertMessage": sprintf("Review webhook: %v ensure that it defines the required policy", [admissionwebhook.metadata.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 7,
-		"failedPaths": [],
-		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [admissionwebhook]
-		}
-	}
-}
-
-
 baseline_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels 
+	some key, value in namespace.metadata.labels
     key == "pod-security.kubernetes.io/enforce"
 	value in ["baseline", "restricted"]
-}
-
-has_external_policy_control(inp){
-    some admissionwebhook in inp
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
 }

--- a/rules/pod-security-admission-baseline-applied-2/rule.metadata.json
+++ b/rules/pod-security-admission-baseline-applied-2/rule.metadata.json
@@ -14,21 +14,10 @@
             "resources": [
                 "Namespace"
             ]
-        },
-        {
-            "apiGroups": [
-                "admissionregistration.k8s.io"
-            ],
-            "apiVersions": [
-                "*"
-            ],
-            "resources": [
-                "MutatingWebhookConfiguration"
-            ]
         }
     ],
     "ruleDependencies": [],
-    "description": "Checks that every namespace enabled baseline pod security admission, or if there are external policies applied for namespaced resources (validating/mutating webhooks) - returns them to be reviewed",
-    "remediation": "",
+    "description": "Checks that every namespace has baseline pod security admission enabled via the pod-security.kubernetes.io/enforce label set to baseline or restricted",
+    "remediation": "Add the label pod-security.kubernetes.io/enforce=baseline (or stricter) to every namespace that contains user workloads.\n\n#### Impact Statement\nWhere policy control systems are in place, there is a risk that workloads required for the operation of the cluster may be stopped from running. Care is required when implementing admission control policies to ensure that this does not occur.\n\n#### Default Value\nBy default, Pod Security Admission is enabled but no policies are in place.",
     "ruleQuery": "armo_builtins"
 }

--- a/rules/pod-security-admission-baseline-applied-2/test/test/expected.json
+++ b/rules/pod-security-admission-baseline-applied-2/test/test/expected.json
@@ -1,18 +1,18 @@
 [
     {
-        "alertMessage": "Review webhook: test-webhook ensure that it defines the required policy",
+        "alertMessage": "Namespace: my-namespace does not enable baseline pod security admission",
         "failedPaths": [],
-        "fixPaths": [],
+        "fixPaths": [{"path":"metadata.labels[pod-security.kubernetes.io/enforce]", "value":"baseline"}],
         "ruleStatus": "",
         "packagename": "armo_builtins",
         "alertScore": 7,
         "alertObject": {
             "k8sApiObjects": [
                 {
-                    "apiVersion": "admissionregistration.k8s.io/v1",
-                    "kind": "MutatingWebhookConfiguration",
+                    "apiVersion": "v1",
+                    "kind": "Namespace",
                     "metadata": {
-                        "name": "test-webhook"
+                        "name": "my-namespace"
                     }
                 }
             ]

--- a/rules/pod-security-admission-restricted-applied-1/filter.rego
+++ b/rules/pod-security-admission-restricted-applied-1/filter.rego
@@ -20,7 +20,5 @@ deny[msga] {
 }
 
 restricted_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels
-    key == "pod-security.kubernetes.io/enforce"
-	value ==  "restricted"
+	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] == "restricted"
 }

--- a/rules/pod-security-admission-restricted-applied-1/filter.rego
+++ b/rules/pod-security-admission-restricted-applied-1/filter.rego
@@ -1,11 +1,11 @@
 package armo_builtins
 import future.keywords.every
 
-# if no 3rd party security admission exists - Fails if namespace does not have relevant labels 
+# Fails if namespace does not have restricted pod security admission label
 deny[msga] {
-    not has_external_policy_control(input)
 	namespace := input[_]
 	namespace.kind == "Namespace"
+	not restricted_admission_policy_enabled(namespace)
 
 	msga := {
 		"alertMessage": sprintf("Namespace: %v does not enable restricted pod security admission", [namespace.metadata.name]),
@@ -19,36 +19,8 @@ deny[msga] {
 	}
 }
 
-# Fails if at least 1 namespace does not have relevant labels and 3rd party security admission EXISTS
-# returns webhook configuration for user to review
-deny[msga] {
-	some namespace in input
-	namespace.kind == "Namespace"
-	not restricted_admission_policy_enabled(namespace)
-
-    admissionwebhook := input[_]
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-
-	msga := {
-		"alertMessage": sprintf("Review webhook: %v ensure that it defines the required policy", [admissionwebhook.metadata.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 7,
-		"failedPaths": [],
-		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [admissionwebhook]
-		}
-	}
-}
-
 restricted_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels 
+	some key, value in namespace.metadata.labels
     key == "pod-security.kubernetes.io/enforce"
 	value ==  "restricted"
-}
-
-has_external_policy_control(inp){
-    some admissionwebhook in inp
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
 }

--- a/rules/pod-security-admission-restricted-applied-1/raw.rego
+++ b/rules/pod-security-admission-restricted-applied-1/raw.rego
@@ -21,7 +21,5 @@ deny[msga] {
 }
 
 restricted_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels
-    key == "pod-security.kubernetes.io/enforce"
-	value ==  "restricted"
+	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] == "restricted"
 }

--- a/rules/pod-security-admission-restricted-applied-1/raw.rego
+++ b/rules/pod-security-admission-restricted-applied-1/raw.rego
@@ -1,12 +1,11 @@
 package armo_builtins
 import future.keywords.every
 
-# Fails if namespace does not have relevant labels and no 3rd party security admission exists
+# Fails if namespace does not have restricted pod security admission label
 deny[msga] {
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not restricted_admission_policy_enabled(namespace)
-    not has_external_policy_control(input)
 	fix_path = {"path": "metadata.labels[pod-security.kubernetes.io/enforce]", "value": "restricted"}
 
 	msga := {
@@ -21,37 +20,8 @@ deny[msga] {
 	}
 }
 
-# Fails if at least 1 namespace does not have relevant labels and 3rd party security admission EXISTS
-# returns webhook configuration for user to review
-deny[msga] {
-	some namespace in input
-	namespace.kind == "Namespace"
-	not restricted_admission_policy_enabled(namespace)
-
-    admissionwebhook := input[_]
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
-
-	msga := {
-		"alertMessage": sprintf("Review webhook: %v ensure that it defines the required policy", [admissionwebhook.metadata.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 7,
-		"failedPaths": [],
-		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [admissionwebhook]
-		}
-	}
-}
-
 restricted_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels 
+	some key, value in namespace.metadata.labels
     key == "pod-security.kubernetes.io/enforce"
 	value ==  "restricted"
-}
-
-has_external_policy_control(inp){
-    some admissionwebhook in inp
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
 }

--- a/rules/pod-security-admission-restricted-applied-1/rule.metadata.json
+++ b/rules/pod-security-admission-restricted-applied-1/rule.metadata.json
@@ -14,21 +14,10 @@
             "resources": [
                 "Namespace"
             ]
-        },
-        {
-            "apiGroups": [
-                "admissionregistration.k8s.io"
-            ],
-            "apiVersions": [
-                "*"
-            ],
-            "resources": [
-                "MutatingWebhookConfiguration"
-            ]
         }
     ],
     "ruleDependencies": [],
-    "description": "Checks that every namespace enabled restricted pod security admission, or if there are external policies applied for namespaced resources (validating/mutating webhooks) - returns them to be reviewed",
-    "remediation": "Ensure that either Pod Security Admission or an external policy control system is in place for every namespace which contains user workloads.\n\n#### Impact Statement\nWhere policy control systems are in place, there is a risk that workloads required for the operation of the cluster may be stopped from running. Care is required when implementing admission control policies to ensure that this does not occur.\n\n#### Default Value\nBy default, Pod Security Admission is enabled but no policies are in place.",
+    "description": "Checks that every namespace has restricted pod security admission enabled via the pod-security.kubernetes.io/enforce=restricted label",
+    "remediation": "Add the label pod-security.kubernetes.io/enforce=restricted to every namespace that contains user workloads.\n\n#### Impact Statement\nWhere policy control systems are in place, there is a risk that workloads required for the operation of the cluster may be stopped from running. Care is required when implementing admission control policies to ensure that this does not occur.\n\n#### Default Value\nBy default, Pod Security Admission is enabled but no policies are in place.",
     "ruleQuery": "armo_builtins"
 }

--- a/rules/pod-security-admission-restricted-applied-1/test/test/expected.json
+++ b/rules/pod-security-admission-restricted-applied-1/test/test/expected.json
@@ -1,18 +1,18 @@
 [
     {
-        "alertMessage": "Review webhook: test-webhook ensure that it defines the required policy",
+        "alertMessage": "Namespace: my-baseline-namespace does not enable restricted pod security admission",
         "failedPaths": [],
-        "fixPaths": [],
+        "fixPaths": [{"path":"metadata.labels[pod-security.kubernetes.io/enforce]", "value":"restricted"}],
         "ruleStatus": "",
         "packagename": "armo_builtins",
         "alertScore": 7,
         "alertObject": {
             "k8sApiObjects": [
                 {
-                    "apiVersion": "admissionregistration.k8s.io/v1",
-                    "kind": "MutatingWebhookConfiguration",
+                    "apiVersion": "v1",
+                    "kind": "Namespace",
                     "metadata": {
-                        "name": "test-webhook"
+                        "name": "my-baseline-namespace"
                     }
                 }
             ]

--- a/rules/pod-security-admission-restricted-applied-2/filter.rego
+++ b/rules/pod-security-admission-restricted-applied-2/filter.rego
@@ -20,7 +20,5 @@ deny[msga] {
 }
 
 restricted_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels
-    key == "pod-security.kubernetes.io/enforce"
-	value ==  "restricted"
+	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] == "restricted"
 }

--- a/rules/pod-security-admission-restricted-applied-2/filter.rego
+++ b/rules/pod-security-admission-restricted-applied-2/filter.rego
@@ -1,11 +1,11 @@
 package armo_builtins
 import future.keywords.every
 
-# if no 3rd party security admission exists - Fails if namespace does not have relevant labels 
+# Fails if namespace does not have restricted pod security admission label
 deny[msga] {
-    not has_external_policy_control(input)
 	namespace := input[_]
 	namespace.kind == "Namespace"
+	not restricted_admission_policy_enabled(namespace)
 
 	msga := {
 		"alertMessage": sprintf("Namespace: %v does not enable restricted pod security admission", [namespace.metadata.name]),
@@ -19,36 +19,8 @@ deny[msga] {
 	}
 }
 
-# Fails if at least 1 namespace does not have relevant labels and 3rd party security admission EXISTS
-# returns webhook configuration for user to review
-deny[msga] {
-	some namespace in input
-	namespace.kind == "Namespace"
-	not restricted_admission_policy_enabled(namespace)
-
-    admissionwebhook := input[_]
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-
-	msga := {
-		"alertMessage": sprintf("Review webhook: %v ensure that it defines the required policy", [admissionwebhook.metadata.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 7,
-		"failedPaths": [],
-		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [admissionwebhook]
-		}
-	}
-}
-
 restricted_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels 
+	some key, value in namespace.metadata.labels
     key == "pod-security.kubernetes.io/enforce"
 	value ==  "restricted"
-}
-
-has_external_policy_control(inp){
-    some admissionwebhook in inp
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
 }

--- a/rules/pod-security-admission-restricted-applied-2/raw.rego
+++ b/rules/pod-security-admission-restricted-applied-2/raw.rego
@@ -21,7 +21,5 @@ deny[msga] {
 }
 
 restricted_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels
-    key == "pod-security.kubernetes.io/enforce"
-	value ==  "restricted"
+	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] == "restricted"
 }

--- a/rules/pod-security-admission-restricted-applied-2/raw.rego
+++ b/rules/pod-security-admission-restricted-applied-2/raw.rego
@@ -1,12 +1,11 @@
 package armo_builtins
 import future.keywords.every
 
-# Fails if namespace does not have relevant labels and no 3rd party security admission exists
+# Fails if namespace does not have restricted pod security admission label
 deny[msga] {
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not restricted_admission_policy_enabled(namespace)
-    not has_external_policy_control(input)
 	fix_path = {"path": "metadata.labels[pod-security.kubernetes.io/enforce]", "value": "restricted"}
 
 	msga := {
@@ -21,37 +20,8 @@ deny[msga] {
 	}
 }
 
-# Fails if at least 1 namespace does not have relevant labels and 3rd party security admission EXISTS
-# returns webhook configuration for user to review
-deny[msga] {
-	some namespace in input
-	namespace.kind == "Namespace"
-	not restricted_admission_policy_enabled(namespace)
-
-    admissionwebhook := input[_]
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
-
-	msga := {
-		"alertMessage": sprintf("Review webhook: %v ensure that it defines the required policy", [admissionwebhook.metadata.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 7,
-		"failedPaths": [],
-		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [admissionwebhook]
-		}
-	}
-}
-
 restricted_admission_policy_enabled(namespace){
-	some key, value in namespace.metadata.labels 
+	some key, value in namespace.metadata.labels
     key == "pod-security.kubernetes.io/enforce"
 	value ==  "restricted"
-}
-
-has_external_policy_control(inp){
-    some admissionwebhook in inp
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
 }

--- a/rules/pod-security-admission-restricted-applied-2/rule.metadata.json
+++ b/rules/pod-security-admission-restricted-applied-2/rule.metadata.json
@@ -14,21 +14,10 @@
             "resources": [
                 "Namespace"
             ]
-        },
-        {
-            "apiGroups": [
-                "admissionregistration.k8s.io"
-            ],
-            "apiVersions": [
-                "*"
-            ],
-            "resources": [
-                "ValidatingWebhookConfiguration"
-            ]
         }
     ],
     "ruleDependencies": [],
-    "description": "Checks that every namespace enabled restricted pod security admission, or if there are external policies applied for namespaced resources (validating/mutating webhooks) - returns them to be reviewed",
-    "remediation": "Ensure that either Pod Security Admission or an external policy control system is in place for every namespace which contains user workloads.\n\n#### Impact Statement\nWhere policy control systems are in place, there is a risk that workloads required for the operation of the cluster may be stopped from running. Care is required when implementing admission control policies to ensure that this does not occur.\n\n#### Default Value\nBy default, Pod Security Admission is enabled but no policies are in place.",
+    "description": "Checks that every namespace has restricted pod security admission enabled via the pod-security.kubernetes.io/enforce=restricted label",
+    "remediation": "Add the label pod-security.kubernetes.io/enforce=restricted to every namespace that contains user workloads.\n\n#### Impact Statement\nWhere policy control systems are in place, there is a risk that workloads required for the operation of the cluster may be stopped from running. Care is required when implementing admission control policies to ensure that this does not occur.\n\n#### Default Value\nBy default, Pod Security Admission is enabled but no policies are in place.",
     "ruleQuery": "armo_builtins"
 }

--- a/rules/pod-security-admission-restricted-applied-2/test/test/expected.json
+++ b/rules/pod-security-admission-restricted-applied-2/test/test/expected.json
@@ -1,18 +1,18 @@
 [
     {
-        "alertMessage": "Review webhook: test-webhook ensure that it defines the required policy",
+        "alertMessage": "Namespace: my-baseline-namespace does not enable restricted pod security admission",
         "failedPaths": [],
-        "fixPaths": [],
+        "fixPaths": [{"path":"metadata.labels[pod-security.kubernetes.io/enforce]", "value":"restricted"}],
         "ruleStatus": "",
         "packagename": "armo_builtins",
         "alertScore": 7,
         "alertObject": {
             "k8sApiObjects": [
                 {
-                    "apiVersion": "admissionregistration.k8s.io/v1",
-                    "kind": "MutatingWebhookConfiguration",
+                    "apiVersion": "v1",
+                    "kind": "Namespace",
                     "metadata": {
-                        "name": "test-webhook"
+                        "name": "my-baseline-namespace"
                     }
                 }
             ]


### PR DESCRIPTION
## Problem

Controls C-0197, C-0198, C-0200, C-0201, C-0202, C-0203, C-0204 (CIS 5.2.2, 5.2.6–5.2.13) all use `pod-security-admission-restricted-applied-1/2` or `pod-security-admission-baseline-applied-1/2`. These rules had two issues:

1. When any namespaced-scope webhook existed in the cluster, they **stopped reporting namespaces** lacking the required PSA label, and instead reported the **webhook itself** with the message `"Review webhook: <name> ensure that it defines the required policy"`.

2. Infrastructure webhooks like `cert-manager-webhook` (which only intercepts `certificaterequests`, not pods) were surfaced as failed resources — confusing customers into thinking cert-manager was responsible for capabilities policy enforcement.

## Root Cause

The rules contained a second `deny` block that cross-joined unprotected namespaces with any namespaced-scope webhook (`scope != "Cluster"`), reporting the webhook as the failing resource. The first `deny` block was also guarded by `not has_external_policy_control(input)`, suppressing namespace findings entirely when webhooks were present.

## Fix

Remove the webhook-surfacing `deny` block and the `has_external_policy_control` guard from all four rule files (`raw.rego` and `filter.rego` for both `restricted-applied` and `baseline-applied` pairs). Namespaces lacking the required PSA label are now always reported with a `fixPath`, regardless of what webhooks exist.

This matches the CIS Kubernetes Benchmark v1.12.0 audit procedure, which states:

> *"List the policies in use for each namespace in the cluster, ensure that at least one policy requires that capabilities are dropped by all containers."*

The unit of failure is the **namespace**, not the webhook.

## Affected rules

- `pod-security-admission-restricted-applied-1` / `-2` (`raw.rego` + `filter.rego`)
- `pod-security-admission-baseline-applied-1` / `-2` (`raw.rego` + `filter.rego`)

## Affected controls

C-0193, C-0197, C-0198, C-0199, C-0200, C-0201, C-0202, C-0203, C-0204

## Testing

Verified against a kind cluster with cert-manager installed. Before this fix, both `MutatingWebhookConfiguration/cert-manager-webhook` and `ValidatingWebhookConfiguration/cert-manager-webhook` were reported as failed resources for each of the above controls. After this fix, the failing namespaces (those without PSA labels) are reported instead, with a fix path pointing to `metadata.labels[pod-security.kubernetes.io/enforce]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Namespace checks now consistently flag namespaces missing Pod Security Admission enforce labels (baseline/restricted); webhook-based exceptions and “review webhook” alerts removed.
  * Alerts now reference the Namespace and include remediation guidance to add the enforce label.

* **Chores**
  * Simplified and unified label-validation logic across enforcement rules to use direct label checks.

* **Tests**
  * Test fixtures updated to expect namespace-targeted alerts and label-fix remediation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/regolibrary/pull/728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->