### PR TITLE
feat: new C-0298 rule for no-rolling-update-strategy

### DIFF
--- a/ControlID_RuleName.csv
+++ b/ControlID_RuleName.csv
@@ -227,3 +227,4 @@ CIS-5.7.4,pods-in-default-namespace
 CIS-5.7.4,resources-notpods-in-default-namespace
 C-0292,detect-nginx-ingress-controller-eol
 C-0293,service-with-no-workload
+C-0298,no-rolling-update-strategy

--- a/FWName_CID_CName.csv
+++ b/FWName_CID_CName.csv
@@ -287,4 +287,3 @@ nsa,C-0292,Nginx Ingress Controller End of Life
 DevOpsBest,C-0293,Service with no workload
 AllControls,C-0293,Service with no workload
 DevOpsBest,C-0298,No rolling update strategy
-AllControls,C-0298,No rolling update strategy

--- a/FWName_CID_CName.csv
+++ b/FWName_CID_CName.csv
@@ -286,3 +286,5 @@ ArmoBest,C-0292,Nginx Ingress Controller End of Life
 nsa,C-0292,Nginx Ingress Controller End of Life
 DevOpsBest,C-0293,Service with no workload
 AllControls,C-0293,Service with no workload
+DevOpsBest,C-0298,No rolling update strategy
+AllControls,C-0298,No rolling update strategy

--- a/controls/C-0298-norollingupdatestrategy.json
+++ b/controls/C-0298-norollingupdatestrategy.json
@@ -5,12 +5,12 @@
             "devops"
         ]
     },
-    "description": "A Deployment without a usable rolling update strategy can cause avoidable service interruption during workload updates.",
-    "remediation": "Set spec.strategy.type to RollingUpdate and configure spec.strategy.rollingUpdate with a non-zero maxSurge or maxUnavailable value.",
+    "description": "A Deployment that explicitly uses a non-rolling update strategy can cause avoidable service interruption during workload updates.",
+    "remediation": "Set spec.strategy.type to RollingUpdate.",
     "rulesNames": [
         "no-rolling-update-strategy"
     ],
-    "test": "Check that every Deployment defines a usable RollingUpdate strategy with at least one non-zero rolling update value.",
+    "test": "Check that Deployments with an explicit strategy type use a rolling update strategy.",
     "controlID": "C-0298",
     "baseScore": 3.0,
     "category": {

--- a/controls/C-0298-norollingupdatestrategy.json
+++ b/controls/C-0298-norollingupdatestrategy.json
@@ -1,0 +1,25 @@
+{
+    "name": "No rolling update strategy",
+    "attributes": {
+        "controlTypeTags": [
+            "devops"
+        ]
+    },
+    "description": "A Deployment without a usable rolling update strategy can cause avoidable service interruption during workload updates.",
+    "remediation": "Set spec.strategy.type to RollingUpdate and configure spec.strategy.rollingUpdate with a non-zero maxSurge or maxUnavailable value.",
+    "rulesNames": [
+        "no-rolling-update-strategy"
+    ],
+    "test": "Check that every Deployment defines a usable RollingUpdate strategy with at least one non-zero rolling update value.",
+    "controlID": "C-0298",
+    "baseScore": 3.0,
+    "category": {
+        "name": "Workload"
+    },
+    "scanningScope": {
+        "matches": [
+            "cluster",
+            "file"
+        ]
+    }
+}

--- a/frameworks/allcontrols.json
+++ b/frameworks/allcontrols.json
@@ -377,6 +377,12 @@
             "patch": {
                 "name": "Service with no workload"
             }
+        },
+        {
+            "controlID": "C-0298",
+            "patch": {
+                "name": "No rolling update strategy"
+            }
         }
     ]
 }

--- a/frameworks/allcontrols.json
+++ b/frameworks/allcontrols.json
@@ -377,12 +377,6 @@
             "patch": {
                 "name": "Service with no workload"
             }
-        },
-        {
-            "controlID": "C-0298",
-            "patch": {
-                "name": "No rolling update strategy"
-            }
         }
     ]
 }

--- a/frameworks/devopsbest.json
+++ b/frameworks/devopsbest.json
@@ -107,6 +107,12 @@
             "patch": {
                 "name": "Service with no workload"
             }
+        },
+        {
+            "controlID": "C-0298",
+            "patch": {
+                "name": "No rolling update strategy"
+            }
         }
     ]
 }

--- a/rules/no-rolling-update-strategy/raw.rego
+++ b/rules/no-rolling-update-strategy/raw.rego
@@ -2,41 +2,28 @@ package armo_builtins
 
 import future.keywords.contains
 import future.keywords.if
-import future.keywords.in
 
 deny contains msga if {
 	deployment := input[_]
 	deployment.kind == "Deployment"
-	not usable_rolling_update_strategy(deployment.spec.strategy)
+	strategy_type := deployment.spec.strategy.type
+	not usable_rolling_update_strategy(strategy_type)
 
 	msga := {
-		"alertMessage": sprintf("Deployment: %v does not define a usable rolling update strategy", [deployment.metadata.name]),
+		"alertMessage": sprintf("Deployment: %v does not use a rolling update strategy", [deployment.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 3,
-		"reviewPaths": ["spec.strategy"],
-		"failedPaths": ["spec.strategy"],
-		"fixPaths": [{"path": "spec.strategy", "value": "RollingUpdate strategy with non-zero maxSurge or maxUnavailable"}],
+		"reviewPaths": ["spec.strategy.type"],
+		"failedPaths": ["spec.strategy.type"],
+		"fixPaths": [{"path": "spec.strategy.type", "value": "RollingUpdate"}],
 		"alertObject": {"k8sApiObjects": [deployment]},
 	}
 }
 
-usable_rolling_update_strategy(strategy) if {
-	strategy.type == "RollingUpdate"
-	usable_rolling_update_value(strategy.rollingUpdate.maxSurge)
+usable_rolling_update_strategy(strategy_type) if {
+	usable_rolling_update_value(strategy_type)
 }
 
-usable_rolling_update_strategy(strategy) if {
-	strategy.type == "RollingUpdate"
-	usable_rolling_update_value(strategy.rollingUpdate.maxUnavailable)
-}
-
-usable_rolling_update_value(value) if {
-	is_number(value)
-	value > 0
-}
-
-usable_rolling_update_value(value) if {
-	is_string(value)
-	value != "0"
-	value != "0%"
+usable_rolling_update_value(strategy_type) if {
+	strategy_type == "RollingUpdate"
 }

--- a/rules/no-rolling-update-strategy/raw.rego
+++ b/rules/no-rolling-update-strategy/raw.rego
@@ -1,0 +1,42 @@
+package armo_builtins
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+deny contains msga if {
+	deployment := input[_]
+	deployment.kind == "Deployment"
+	not usable_rolling_update_strategy(deployment.spec.strategy)
+
+	msga := {
+		"alertMessage": sprintf("Deployment: %v does not define a usable rolling update strategy", [deployment.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 3,
+		"reviewPaths": ["spec.strategy"],
+		"failedPaths": ["spec.strategy"],
+		"fixPaths": [{"path": "spec.strategy", "value": "RollingUpdate strategy with non-zero maxSurge or maxUnavailable"}],
+		"alertObject": {"k8sApiObjects": [deployment]},
+	}
+}
+
+usable_rolling_update_strategy(strategy) if {
+	strategy.type == "RollingUpdate"
+	usable_rolling_update_value(strategy.rollingUpdate.maxSurge)
+}
+
+usable_rolling_update_strategy(strategy) if {
+	strategy.type == "RollingUpdate"
+	usable_rolling_update_value(strategy.rollingUpdate.maxUnavailable)
+}
+
+usable_rolling_update_value(value) if {
+	is_number(value)
+	value > 0
+}
+
+usable_rolling_update_value(value) if {
+	is_string(value)
+	value != "0"
+	value != "0%"
+}

--- a/rules/no-rolling-update-strategy/rule.metadata.json
+++ b/rules/no-rolling-update-strategy/rule.metadata.json
@@ -18,7 +18,7 @@
     ],
     "ruleDependencies": [
     ],
-    "description": "Fails if a Deployment does not define a usable rolling update strategy.",
-    "remediation": "Set spec.strategy.type to RollingUpdate and configure spec.strategy.rollingUpdate with a non-zero maxSurge or maxUnavailable value.",
+    "description": "Fails if a Deployment explicitly defines a non-rolling update strategy.",
+    "remediation": "Set spec.strategy.type to RollingUpdate.",
     "ruleQuery": "armo_builtins"
 }

--- a/rules/no-rolling-update-strategy/rule.metadata.json
+++ b/rules/no-rolling-update-strategy/rule.metadata.json
@@ -1,0 +1,24 @@
+{
+    "name": "no-rolling-update-strategy",
+    "attributes": {
+    },
+    "ruleLanguage": "Rego",
+    "match": [
+        {
+            "apiGroups": [
+                "apps"
+            ],
+            "apiVersions": [
+                "v1"
+            ],
+            "resources": [
+                "Deployment"
+            ]
+        }
+    ],
+    "ruleDependencies": [
+    ],
+    "description": "Fails if a Deployment does not define a usable rolling update strategy.",
+    "remediation": "Set spec.strategy.type to RollingUpdate and configure spec.strategy.rollingUpdate with a non-zero maxSurge or maxUnavailable value.",
+    "ruleQuery": "armo_builtins"
+}

--- a/rules/no-rolling-update-strategy/test/deployment/expected.json
+++ b/rules/no-rolling-update-strategy/test/deployment/expected.json
@@ -1,50 +1,18 @@
 [
   {
-    "alertMessage": "Deployment: missing-strategy does not define a usable rolling update strategy",
+    "alertMessage": "Deployment: recreate-strategy does not use a rolling update strategy",
     "packagename": "armo_builtins",
     "alertScore": 3,
     "reviewPaths": [
-      "spec.strategy"
+      "spec.strategy.type"
     ],
     "failedPaths": [
-      "spec.strategy"
+      "spec.strategy.type"
     ],
     "fixPaths": [
       {
-        "path": "spec.strategy",
-        "value": "RollingUpdate strategy with non-zero maxSurge or maxUnavailable"
-      }
-    ],
-    "ruleStatus": "",
-    "alertObject": {
-      "k8sApiObjects": [
-        {
-          "apiVersion": "apps/v1",
-          "kind": "Deployment",
-          "metadata": {
-            "labels": {
-              "app": "missing-strategy"
-            },
-            "name": "missing-strategy"
-          }
-        }
-      ]
-    }
-  },
-  {
-    "alertMessage": "Deployment: recreate-strategy does not define a usable rolling update strategy",
-    "packagename": "armo_builtins",
-    "alertScore": 3,
-    "reviewPaths": [
-      "spec.strategy"
-    ],
-    "failedPaths": [
-      "spec.strategy"
-    ],
-    "fixPaths": [
-      {
-        "path": "spec.strategy",
-        "value": "RollingUpdate strategy with non-zero maxSurge or maxUnavailable"
+        "path": "spec.strategy.type",
+        "value": "RollingUpdate"
       }
     ],
     "ruleStatus": "",
@@ -58,70 +26,6 @@
               "app": "recreate-strategy"
             },
             "name": "recreate-strategy"
-          }
-        }
-      ]
-    }
-  },
-  {
-    "alertMessage": "Deployment: empty-rolling-update does not define a usable rolling update strategy",
-    "packagename": "armo_builtins",
-    "alertScore": 3,
-    "reviewPaths": [
-      "spec.strategy"
-    ],
-    "failedPaths": [
-      "spec.strategy"
-    ],
-    "fixPaths": [
-      {
-        "path": "spec.strategy",
-        "value": "RollingUpdate strategy with non-zero maxSurge or maxUnavailable"
-      }
-    ],
-    "ruleStatus": "",
-    "alertObject": {
-      "k8sApiObjects": [
-        {
-          "apiVersion": "apps/v1",
-          "kind": "Deployment",
-          "metadata": {
-            "labels": {
-              "app": "empty-rolling-update"
-            },
-            "name": "empty-rolling-update"
-          }
-        }
-      ]
-    }
-  },
-  {
-    "alertMessage": "Deployment: zero-rolling-update does not define a usable rolling update strategy",
-    "packagename": "armo_builtins",
-    "alertScore": 3,
-    "reviewPaths": [
-      "spec.strategy"
-    ],
-    "failedPaths": [
-      "spec.strategy"
-    ],
-    "fixPaths": [
-      {
-        "path": "spec.strategy",
-        "value": "RollingUpdate strategy with non-zero maxSurge or maxUnavailable"
-      }
-    ],
-    "ruleStatus": "",
-    "alertObject": {
-      "k8sApiObjects": [
-        {
-          "apiVersion": "apps/v1",
-          "kind": "Deployment",
-          "metadata": {
-            "labels": {
-              "app": "zero-rolling-update"
-            },
-            "name": "zero-rolling-update"
           }
         }
       ]

--- a/rules/no-rolling-update-strategy/test/deployment/expected.json
+++ b/rules/no-rolling-update-strategy/test/deployment/expected.json
@@ -1,0 +1,130 @@
+[
+  {
+    "alertMessage": "Deployment: missing-strategy does not define a usable rolling update strategy",
+    "packagename": "armo_builtins",
+    "alertScore": 3,
+    "reviewPaths": [
+      "spec.strategy"
+    ],
+    "failedPaths": [
+      "spec.strategy"
+    ],
+    "fixPaths": [
+      {
+        "path": "spec.strategy",
+        "value": "RollingUpdate strategy with non-zero maxSurge or maxUnavailable"
+      }
+    ],
+    "ruleStatus": "",
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "metadata": {
+            "labels": {
+              "app": "missing-strategy"
+            },
+            "name": "missing-strategy"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Deployment: recreate-strategy does not define a usable rolling update strategy",
+    "packagename": "armo_builtins",
+    "alertScore": 3,
+    "reviewPaths": [
+      "spec.strategy"
+    ],
+    "failedPaths": [
+      "spec.strategy"
+    ],
+    "fixPaths": [
+      {
+        "path": "spec.strategy",
+        "value": "RollingUpdate strategy with non-zero maxSurge or maxUnavailable"
+      }
+    ],
+    "ruleStatus": "",
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "metadata": {
+            "labels": {
+              "app": "recreate-strategy"
+            },
+            "name": "recreate-strategy"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Deployment: empty-rolling-update does not define a usable rolling update strategy",
+    "packagename": "armo_builtins",
+    "alertScore": 3,
+    "reviewPaths": [
+      "spec.strategy"
+    ],
+    "failedPaths": [
+      "spec.strategy"
+    ],
+    "fixPaths": [
+      {
+        "path": "spec.strategy",
+        "value": "RollingUpdate strategy with non-zero maxSurge or maxUnavailable"
+      }
+    ],
+    "ruleStatus": "",
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "metadata": {
+            "labels": {
+              "app": "empty-rolling-update"
+            },
+            "name": "empty-rolling-update"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "alertMessage": "Deployment: zero-rolling-update does not define a usable rolling update strategy",
+    "packagename": "armo_builtins",
+    "alertScore": 3,
+    "reviewPaths": [
+      "spec.strategy"
+    ],
+    "failedPaths": [
+      "spec.strategy"
+    ],
+    "fixPaths": [
+      {
+        "path": "spec.strategy",
+        "value": "RollingUpdate strategy with non-zero maxSurge or maxUnavailable"
+      }
+    ],
+    "ruleStatus": "",
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "metadata": {
+            "labels": {
+              "app": "zero-rolling-update"
+            },
+            "name": "zero-rolling-update"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/rules/no-rolling-update-strategy/test/deployment/input/empty-rolling-update.yaml
+++ b/rules/no-rolling-update-strategy/test/deployment/input/empty-rolling-update.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: empty-rolling-update
+  labels:
+    app: empty-rolling-update
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate: {}
+  selector:
+    matchLabels:
+      app: empty-rolling-update
+  template:
+    metadata:
+      labels:
+        app: empty-rolling-update
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.25

--- a/rules/no-rolling-update-strategy/test/deployment/input/missing-strategy.yaml
+++ b/rules/no-rolling-update-strategy/test/deployment/input/missing-strategy.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: missing-strategy
+  labels:
+    app: missing-strategy
+spec:
+  strategy: null
+  selector:
+    matchLabels:
+      app: missing-strategy
+  template:
+    metadata:
+      labels:
+        app: missing-strategy
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.25

--- a/rules/no-rolling-update-strategy/test/deployment/input/recreate-strategy.yaml
+++ b/rules/no-rolling-update-strategy/test/deployment/input/recreate-strategy.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recreate-strategy
+  labels:
+    app: recreate-strategy
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: recreate-strategy
+  template:
+    metadata:
+      labels:
+        app: recreate-strategy
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.25

--- a/rules/no-rolling-update-strategy/test/deployment/input/usable-rolling-update.yaml
+++ b/rules/no-rolling-update-strategy/test/deployment/input/usable-rolling-update.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: usable-rolling-update
+  labels:
+    app: usable-rolling-update
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: usable-rolling-update
+  template:
+    metadata:
+      labels:
+        app: usable-rolling-update
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.25

--- a/rules/no-rolling-update-strategy/test/deployment/input/zero-rolling-update.yaml
+++ b/rules/no-rolling-update-strategy/test/deployment/input/zero-rolling-update.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zero-rolling-update
+  labels:
+    app: zero-rolling-update
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: zero-rolling-update
+  template:
+    metadata:
+      labels:
+        app: zero-rolling-update
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.25


### PR DESCRIPTION
Signed-off-by: GeneCodeSavvy <hxrsh.09@gmail.com>

## Overview

Adds Kubescape support for the kube-linter no-rolling-update-strategy check.

This PR introduces a new C-0298 control and Rego rule that flags Deployments without a usable RollingUpdate strategy. The rule fails Deployments with a missing strategy, Recreate
  strategy, empty rollingUpdate config, or zero maxSurge/maxUnavailable values, and passes Deployments with a non-zero rolling update value.

The control is wired into DevOpsBest and intentionally kept out of AllControls.

## How to Test

  ```bash
cd testrunner
go test -v -tags="static" rego_test.go -run TestSingleRule -args -rule no-rolling-update-strategy
```

## Related Issues/PRs:

- Partial Resolves: https://github.com/kubescape/kubescape/issues/1396

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compliance control C-0298 to detect Kubernetes Deployments using non‑RollingUpdate strategies; recommends switching to RollingUpdate and targets Deployments during scans.
  * Integrated C-0298 into the DevOps Best Practices framework for automated validation.

* **Tests**
  * Added test manifests and expected results covering Recreate, RollingUpdate (various values), missing/null strategies, and the expected alert/fix behavior for validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/regolibrary/pull/729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->