### PR TITLE
fix: add initContainers coverage to hostpath and docker socket rules

### DIFF
--- a/rules/alert-any-hostpath/raw.rego
+++ b/rules/alert-any-hostpath/raw.rego
@@ -88,3 +88,76 @@ volume_mounts(name, volume_mounts, str) = [path] {
 	name == volume_mounts[j].name
 	path := sprintf("%s.volumeMounts[%v]", [str, j])
 } else = []
+# handles initContainers for Pod
+deny[msga] {
+	pod := input[_]
+	pod.kind == "Pod"
+	volumes := pod.spec.volumes
+	volume := volumes[i]
+	start_of_path := "spec."
+	result := is_dangerous_volume(volume, start_of_path, i)
+	podname := pod.metadata.name
+	volumeMounts := pod.spec.initContainers[j].volumeMounts
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.initContainers[%v]", [j]))
+	finalPath := array.concat([result], pathMounts)
+	msga := {
+		"alertMessage": sprintf("pod: %v has: %v as hostPath volume", [podname, volume.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"deletePaths": finalPath,
+		"failedPaths": finalPath,
+		"fixPaths":[],
+		"alertObject": {
+			"k8sApiObjects": [pod]
+		}
+	}
+}
+
+# handles initContainers for majority of workload resources
+deny[msga] {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns[wl.kind]
+	volumes := wl.spec.template.spec.volumes
+	volume := volumes[i]
+	start_of_path := "spec.template.spec."
+	result := is_dangerous_volume(volume, start_of_path, i)
+	volumeMounts := wl.spec.template.spec.initContainers[j].volumeMounts
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.template.spec.initContainers[%v]", [j]))
+	finalPath := array.concat([result], pathMounts)
+	msga := {
+		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"deletePaths": finalPath,
+		"failedPaths": finalPath,
+		"fixPaths":[],
+		"alertObject": {
+			"k8sApiObjects": [wl]
+		}
+	}
+}
+
+# handles initContainers for CronJobs
+deny[msga] {
+	wl := input[_]
+	wl.kind == "CronJob"
+	volumes := wl.spec.jobTemplate.spec.template.spec.volumes
+	volume := volumes[i]
+	start_of_path := "spec.jobTemplate.spec.template.spec."
+	result := is_dangerous_volume(volume, start_of_path, i)
+	volumeMounts := wl.spec.jobTemplate.spec.template.spec.initContainers[j].volumeMounts
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.jobTemplate.spec.template.spec.initContainers[%v]", [j]))
+	finalPath := array.concat([result], pathMounts)
+	msga := {
+		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"deletePaths": finalPath,
+		"failedPaths": finalPath,
+		"fixPaths":[],
+		"alertObject": {
+			"k8sApiObjects": [wl]
+		}
+	}
+}

--- a/rules/alert-any-hostpath/test/deployment-initcontainer/expected.json
+++ b/rules/alert-any-hostpath/test/deployment-initcontainer/expected.json
@@ -1,0 +1,31 @@
+[
+    {
+        "alertMessage": "Deployment: my-deployment has: test-volume as hostPath volume",
+        "failedPaths": [
+            "spec.template.spec.volumes[0]",
+            "spec.template.spec.initContainers[0].volumeMounts[0]"
+        ],
+        "deletePaths": [
+            "spec.template.spec.volumes[0]",
+            "spec.template.spec.initContainers[0].volumeMounts[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "purpose": "demonstrate-command"
+                        },
+                        "name": "my-deployment"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/alert-any-hostpath/test/deployment-initcontainer/input/deployment.yaml
+++ b/rules/alert-any-hostpath/test/deployment-initcontainer/input/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+  labels:
+    purpose: demonstrate-command
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      purpose: demonstrate-command
+  template:
+    metadata:
+      labels:
+        purpose: demonstrate-command
+    spec:
+      initContainers:
+        - image: k8s.gcr.io/test-webserver
+          name: init-container
+          volumeMounts:
+            - mountPath: /test-pd
+              name: test-volume
+      containers:
+        - image: k8s.gcr.io/test-webserver
+          name: test-container
+      volumes:
+        - name: test-volume
+          hostPath:
+            path: /var

--- a/rules/alert-any-hostpath/test/pod-initcontainer/expected.json
+++ b/rules/alert-any-hostpath/test/pod-initcontainer/expected.json
@@ -1,0 +1,28 @@
+[
+    {
+        "alertMessage": "pod: test-pd has: test-volume as hostPath volume",
+        "failedPaths": [
+            "spec.volumes[0]",
+            "spec.initContainers[0].volumeMounts[0]"
+        ],
+        "deletePaths": [
+            "spec.volumes[0]",
+            "spec.initContainers[0].volumeMounts[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "test-pd"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/alert-any-hostpath/test/pod-initcontainer/input/pod.yaml
+++ b/rules/alert-any-hostpath/test/pod-initcontainer/input/pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pd
+spec:
+  initContainers:
+  - image: k8s.gcr.io/test-webserver
+    name: init-container
+    volumeMounts:
+    - mountPath: /test-pd
+      name: test-volume
+  containers:
+  - image: k8s.gcr.io/test-webserver
+    name: test-container
+  volumes:
+  - name: test-volume
+    hostPath:
+      path: /var

--- a/rules/alert-rw-hostpath/raw.rego
+++ b/rules/alert-rw-hostpath/raw.rego
@@ -84,3 +84,79 @@ is_rw_mount(mount, start_of_path,  i, k) = fix_path {
 	not mount.readOnly == true
     fix_path = {"path": sprintf("%vcontainers[%v].volumeMounts[%v].readOnly", [start_of_path, i, k]), "value":"true"}
 }
+
+# handles initContainers for Pod
+deny[msga] {
+	pod := input[_]
+	pod.kind == "Pod"
+	volumes := pod.spec.volumes
+	volume := volumes[_]
+	volume.hostPath
+	container := pod.spec.initContainers[i]
+	volume_mount := container.volumeMounts[k]
+	volume_mount.name == volume.name
+	start_of_path := "spec."
+	fix_path := is_rw_mount_init(volume_mount, start_of_path, i, k)
+	podname := pod.metadata.name
+	msga := {
+		"alertMessage": sprintf("pod: %v has: %v as hostPath volume", [podname, volume.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"fixPaths": [fix_path],
+		"alertObject": {
+			"k8sApiObjects": [pod]
+		}
+	}
+}
+
+# handles initContainers for majority of workload resources
+deny[msga] {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns[wl.kind]
+	volumes := wl.spec.template.spec.volumes
+	volume := volumes[_]
+	volume.hostPath
+	container := wl.spec.template.spec.initContainers[i]
+	volume_mount := container.volumeMounts[k]
+	volume_mount.name == volume.name
+	start_of_path := "spec.template.spec."
+	fix_path := is_rw_mount_init(volume_mount, start_of_path, i, k)
+	msga := {
+		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"fixPaths": [fix_path],
+		"alertObject": {
+			"k8sApiObjects": [wl]
+		}
+	}
+}
+
+# handles initContainers for CronJobs
+deny[msga] {
+	wl := input[_]
+	wl.kind == "CronJob"
+	volumes := wl.spec.jobTemplate.spec.template.spec.volumes
+	volume := volumes[_]
+	volume.hostPath
+	container = wl.spec.jobTemplate.spec.template.spec.initContainers[i]
+	volume_mount := container.volumeMounts[k]
+	volume_mount.name == volume.name
+	start_of_path := "spec.jobTemplate.spec.template.spec."
+	fix_path := is_rw_mount_init(volume_mount, start_of_path, i, k)
+	msga := {
+		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"fixPaths": [fix_path],
+		"alertObject": {
+			"k8sApiObjects": [wl]
+		}
+	}
+}
+
+is_rw_mount_init(mount, start_of_path, i, k) = fix_path {
+	not mount.readOnly == true
+	fix_path = {"path": sprintf("%vinitContainers[%v].volumeMounts[%v].readOnly", [start_of_path, i, k]), "value":"true"}
+}

--- a/rules/alert-rw-hostpath/test/cronjob-initcontainer/expected.json
+++ b/rules/alert-rw-hostpath/test/cronjob-initcontainer/expected.json
@@ -1,0 +1,25 @@
+[
+    {
+        "alertMessage": "CronJob: hello has: test-volume as hostPath volume",
+        "fixPaths": [
+            {
+                "path": "spec.jobTemplate.spec.template.spec.initContainers[0].volumeMounts[0].readOnly",
+                "value": "true"
+            }
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "batch/v1",
+                    "kind": "CronJob",
+                    "metadata": {
+                        "name": "hello"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/alert-rw-hostpath/test/cronjob-initcontainer/input/cronjob.yaml
+++ b/rules/alert-rw-hostpath/test/cronjob-initcontainer/input/cronjob.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hello
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          initContainers:
+          - name: init-container
+            image: k8s.gcr.io/test-webserver
+            volumeMounts:
+            - mountPath: /test-pd
+              readOnly: false
+              name: test-volume
+          containers:
+          - name: test-container
+            image: k8s.gcr.io/test-webserver
+          volumes:
+          - name: test-volume
+            hostPath:
+              path: /var
+          restartPolicy: OnFailure

--- a/rules/alert-rw-hostpath/test/deployment-initcontainer/expected.json
+++ b/rules/alert-rw-hostpath/test/deployment-initcontainer/expected.json
@@ -1,0 +1,28 @@
+[
+    {
+        "alertMessage": "Deployment: my-deployment has: test-volume as hostPath volume",
+        "fixPaths": [
+            {
+                "path": "spec.template.spec.initContainers[0].volumeMounts[0].readOnly",
+                "value": "true"
+            }
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "purpose": "demonstrate-command"
+                        },
+                        "name": "my-deployment"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/alert-rw-hostpath/test/deployment-initcontainer/input/deployment.yaml
+++ b/rules/alert-rw-hostpath/test/deployment-initcontainer/input/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+  labels:
+    purpose: demonstrate-command
+spec:
+  selector:
+    matchLabels:
+      purpose: demonstrate-command
+  template:
+    metadata:
+      labels:
+        purpose: demonstrate-command
+    spec:
+      initContainers:
+        - name: init-container
+          image: k8s.gcr.io/test-webserver
+          volumeMounts:
+            - mountPath: /test-pd
+              readOnly: false
+              name: test-volume
+      containers:
+        - name: test-container
+          image: k8s.gcr.io/test-webserver
+      volumes:
+        - name: test-volume
+          hostPath:
+            path: /var

--- a/rules/alert-rw-hostpath/test/pod-initcontainer/expected.json
+++ b/rules/alert-rw-hostpath/test/pod-initcontainer/expected.json
@@ -1,0 +1,25 @@
+[
+    {
+        "alertMessage": "pod: test-pd has: test-volume as hostPath volume",
+        "fixPaths": [
+            {
+                "path": "spec.initContainers[0].volumeMounts[0].readOnly",
+                "value": "true"
+            }
+        ],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "test-pd"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/alert-rw-hostpath/test/pod-initcontainer/input/pod.yaml
+++ b/rules/alert-rw-hostpath/test/pod-initcontainer/input/pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pd
+spec:
+  initContainers:
+  - name: init-container
+    image: k8s.gcr.io/test-webserver
+    volumeMounts:
+    - mountPath: /test-pd
+      readOnly: false
+      name: test-volume
+  containers:
+  - name: test-container
+    image: k8s.gcr.io/test-webserver
+  volumes:
+  - name: test-volume
+    hostPath:
+      path: /var

--- a/rules/containers-mounting-docker-socket/raw.rego
+++ b/rules/containers-mounting-docker-socket/raw.rego
@@ -94,3 +94,76 @@ is_runtime_socket_mounting(host_path) {
 is_runtime_socket_mounting(host_path) {
 	host_path.path == "/var/run/crio/crio.sock"
 }
+
+# handles initContainers for Pod
+deny[msga] {
+	pod := input[_]
+	pod.kind == "Pod"
+	volume := pod.spec.volumes[i]
+	host_path := volume.hostPath
+	is_runtime_socket_mounting(host_path)
+	path := sprintf("spec.volumes[%v]", [format_int(i, 10)])
+	volumeMounts := pod.spec.initContainers[j].volumeMounts
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.initContainers[%v]", [j]))
+	finalPath := array.concat([path], pathMounts)
+	msga := {
+		"alertMessage": sprintf("volume: %v in pod: %v has mounting to Docker internals.", [volume.name, pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"deletePaths": finalPath,
+		"failedPaths": finalPath,
+		"fixPaths":[],
+		"alertScore": 5,
+		"alertObject": {
+			"k8sApiObjects": [pod]
+		}
+	}
+}
+
+# handles initContainers for majority of workload resources
+deny[msga] {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns[wl.kind]
+	volume := wl.spec.template.spec.volumes[i]
+	host_path := volume.hostPath
+	is_runtime_socket_mounting(host_path)
+	path := sprintf("spec.template.spec.volumes[%v]", [format_int(i, 10)])
+	volumeMounts := wl.spec.template.spec.initContainers[j].volumeMounts
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.template.spec.initContainers[%v]", [j]))
+	finalPath := array.concat([path], pathMounts)
+	msga := {
+		"alertMessage": sprintf("volume: %v in %v: %v has mounting to Docker internals.", [volume.name, wl.kind, wl.metadata.name]),
+		"packagename": "armo_builtins",
+		"deletePaths": finalPath,
+		"failedPaths": finalPath,
+		"fixPaths":[],
+		"alertScore": 5,
+		"alertObject": {
+			"k8sApiObjects": [wl]
+		}
+	}
+}
+
+# handles initContainers for CronJobs
+deny[msga] {
+	wl := input[_]
+	wl.kind == "CronJob"
+	volume = wl.spec.jobTemplate.spec.template.spec.volumes[i]
+	host_path := volume.hostPath
+	is_runtime_socket_mounting(host_path)
+	path := sprintf("spec.jobTemplate.spec.template.spec.volumes[%v]", [format_int(i, 10)])
+	volumeMounts := wl.spec.jobTemplate.spec.template.spec.initContainers[j].volumeMounts
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.jobTemplate.spec.template.spec.initContainers[%v]", [j]))
+	finalPath := array.concat([path], pathMounts)
+	msga := {
+		"alertMessage": sprintf("volume: %v in %v: %v has mounting to Docker internals.", [volume.name, wl.kind, wl.metadata.name]),
+		"packagename": "armo_builtins",
+		"deletePaths": finalPath,
+		"failedPaths": finalPath,
+		"fixPaths":[],
+		"alertScore": 5,
+		"alertObject": {
+			"k8sApiObjects": [wl]
+		}
+	}
+}

--- a/rules/containers-mounting-docker-socket/test/cronjob-initcontainer/expected.json
+++ b/rules/containers-mounting-docker-socket/test/cronjob-initcontainer/expected.json
@@ -1,0 +1,28 @@
+[
+    {
+        "alertMessage": "volume: test-volume in CronJob: hello has mounting to Docker internals.",
+        "deletePaths": [
+            "spec.jobTemplate.spec.template.spec.volumes[0]",
+            "spec.jobTemplate.spec.template.spec.initContainers[0].volumeMounts[0]"
+        ],
+        "failedPaths": [
+            "spec.jobTemplate.spec.template.spec.volumes[0]",
+            "spec.jobTemplate.spec.template.spec.initContainers[0].volumeMounts[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 5,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "batch/v1",
+                    "kind": "CronJob",
+                    "metadata": {
+                        "name": "hello"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/containers-mounting-docker-socket/test/cronjob-initcontainer/input/cronjob.yaml
+++ b/rules/containers-mounting-docker-socket/test/cronjob-initcontainer/input/cronjob.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hello
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          initContainers:
+          - name: init-container
+            image: k8s.gcr.io/test-webserver
+            volumeMounts:
+            - mountPath: /test-pd
+              name: test-volume
+          containers:
+          - name: test-container
+            image: k8s.gcr.io/test-webserver
+          volumes:
+          - name: test-volume
+            hostPath:
+              path: /var/run/docker.sock
+          restartPolicy: OnFailure

--- a/rules/containers-mounting-docker-socket/test/pod-initcontainer/expected.json
+++ b/rules/containers-mounting-docker-socket/test/pod-initcontainer/expected.json
@@ -1,0 +1,28 @@
+[
+    {
+        "alertMessage": "volume: test-volume in pod: test-pd has mounting to Docker internals.",
+        "deletePaths": [
+            "spec.volumes[0]",
+            "spec.initContainers[0].volumeMounts[0]"
+        ],
+        "failedPaths": [
+            "spec.volumes[0]",
+            "spec.initContainers[0].volumeMounts[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 5,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "test-pd"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/containers-mounting-docker-socket/test/pod-initcontainer/input/pod.yaml
+++ b/rules/containers-mounting-docker-socket/test/pod-initcontainer/input/pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pd
+spec:
+  initContainers:
+  - image: k8s.gcr.io/test-webserver
+    name: init-container
+    volumeMounts:
+    - mountPath: /var/run/docker.sock
+      name: test-volume
+  containers:
+  - image: k8s.gcr.io/test-webserver
+    name: test-container
+  volumes:
+  - name: test-volume
+    hostPath:
+      path: /var/run/docker.sock

--- a/rules/containers-mounting-docker-socket/test/workload-initcontainer/expected.json
+++ b/rules/containers-mounting-docker-socket/test/workload-initcontainer/expected.json
@@ -1,0 +1,31 @@
+[
+    {
+        "alertMessage": "volume: test-volume in Deployment: my-deployment has mounting to Docker internals.",
+        "deletePaths": [
+            "spec.template.spec.volumes[0]",
+            "spec.template.spec.initContainers[0].volumeMounts[0]"
+        ],
+        "failedPaths": [
+            "spec.template.spec.volumes[0]",
+            "spec.template.spec.initContainers[0].volumeMounts[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 5,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "purpose": "demonstrate-command"
+                        },
+                        "name": "my-deployment"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/containers-mounting-docker-socket/test/workload-initcontainer/input/deployment.yaml
+++ b/rules/containers-mounting-docker-socket/test/workload-initcontainer/input/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+  labels:
+    purpose: demonstrate-command
+spec:
+  selector:
+    matchLabels:
+      purpose: demonstrate-command
+  template:
+    metadata:
+      labels:
+        purpose: demonstrate-command
+    spec:
+      initContainers:
+      - name: init-container
+        image: k8s.gcr.io/test-webserver
+        volumeMounts:
+        - mountPath: /test-pd
+          name: test-volume
+      containers:
+      - name: test-container
+        image: k8s.gcr.io/test-webserver
+      volumes:
+      - name: test-volume
+        hostPath:
+          path: /var/run/docker.sock


### PR DESCRIPTION
## Overview
Three rules only checked `spec.containers` volumeMounts, skipping `initContainers` entirely. An init container mounting the Docker socket or a hostPath volume is just as dangerous as a regular container doing so — it can be used for container escape or host filesystem access. This PR adds initContainers deny blocks to all three rules following the exact same pattern already used for containers.

## How to Test
Run the test runner for each affected rule:

cd testrunner
go test -v -tags="static" -timeout 120s rego_test.go -run TestSingleRule -args -rule alert-any-hostpath
go test -v -tags="static" -timeout 120s rego_test.go -run TestSingleRule -args -rule alert-rw-hostpath
go test -v -tags="static" -timeout 120s rego_test.go -run TestSingleRule -args -rule containers-mounting-docker-socket

All rules pass including new initContainers test cases. Full TestAllRules also passes with zero failures.

## Related issues/PRs
* Resolves #731

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended security checks to detect hostPath volumes and Docker socket mounts mounted via initContainers.
  * Added validation for read-write access on hostPath volumes in initContainers.
  * Coverage now includes Pods, Deployments, DaemonSets, StatefulSets, ReplicaSets, Jobs, and CronJobs.

* **Tests**
  * Added test cases for new initContainer security validations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/regolibrary/pull/732)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->