### PR TITLE
fix: migrate rego rules batch-1 to OPA v1

### DIFF
--- a/rules/CVE-2021-25741/filter.rego
+++ b/rules/CVE-2021-25741/filter.rego
@@ -1,77 +1,72 @@
 package armo_builtins
 
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	nodes := input[_]
 	current_version := nodes.status.nodeInfo.kubeletVersion
-    isVulnerableVersion(current_version)
+	isVulnerableVersion(current_version)
 	versionPath = "status.nodeInfo.kubeletVersion"
-    pod := input[_]
-    pod.kind == "Pod"
+	pod := input[_]
+	pod.kind == "Pod"
 
-	msga := {
-			"alertMessage": "",
-			"alertObject": {"k8SApiObjects": [pod]},
-			"failedPaths": [],
-	}
-}
-
-
-deny[msga] {
-	nodes := input[_]
-	current_version := nodes.status.nodeInfo.kubeletVersion
-    isVulnerableVersion(current_version)
-	versionPath = "status.nodeInfo.kubeletVersion"
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-	spec_template_spec_patterns[wl.kind]
-       
-	msga := {
-	"alertMessage": "",
-			"alertObject": {"k8SApiObjects": [wl]},
-			"failedPaths": [],
-	}
-}
-
-
-
-deny[msga] {
-	nodes := input[_]
-	current_version := nodes.status.nodeInfo.kubeletVersion
-    isVulnerableVersion(current_version)
-	versionPath = "status.nodeInfo.kubeletVersion"
-    wl := input[_]
-	wl.kind == "CronJob"
-    
 	msga := {
 		"alertMessage": "",
-			"alertObject": {"k8SApiObjects": [wl]},
-			"failedPaths": [],
+		"alertObject": {"k8SApiObjects": [pod]},
+		"failedPaths": [],
 	}
 }
 
+deny contains msga if {
+	nodes := input[_]
+	current_version := nodes.status.nodeInfo.kubeletVersion
+	isVulnerableVersion(current_version)
+	versionPath = "status.nodeInfo.kubeletVersion"
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	spec_template_spec_patterns[wl.kind]
 
-isVulnerableVersion(version)  {
-    version <=  "v1.19.14"
+	msga := {
+		"alertMessage": "",
+		"alertObject": {"k8SApiObjects": [wl]},
+		"failedPaths": [],
+	}
 }
 
-isVulnerableVersion(version){
-    version >= "v1.22.0"
-    version <= "v1.22.1"
+deny contains msga if {
+	nodes := input[_]
+	current_version := nodes.status.nodeInfo.kubeletVersion
+	isVulnerableVersion(current_version)
+	versionPath = "status.nodeInfo.kubeletVersion"
+	wl := input[_]
+	wl.kind == "CronJob"
+
+	msga := {
+		"alertMessage": "",
+		"alertObject": {"k8SApiObjects": [wl]},
+		"failedPaths": [],
+	}
 }
 
-
-isVulnerableVersion(version){
-    version >= "v1.21.0"
-    version <= "v1.21.4"
+isVulnerableVersion(version) if {
+	version <= "v1.19.14"
 }
 
-
-isVulnerableVersion(version){
-    version >= "v1.20.0"
-    version <= "v1.20.9"
+isVulnerableVersion(version) if {
+	version >= "v1.22.0"
+	version <= "v1.22.1"
 }
 
-isVulnerableVersion(version){
+isVulnerableVersion(version) if {
+	version >= "v1.21.0"
+	version <= "v1.21.4"
+}
+
+isVulnerableVersion(version) if {
+	version >= "v1.20.0"
+	version <= "v1.20.9"
+}
+
+isVulnerableVersion(version) if {
 	version == "v1.20.10"
 }

--- a/rules/CVE-2021-25741/filter.rego
+++ b/rules/CVE-2021-25741/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -18,12 +19,12 @@ deny contains msga if {
 }
 
 deny contains msga if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	nodes := input[_]
 	current_version := nodes.status.nodeInfo.kubeletVersion
 	isVulnerableVersion(current_version)
 	versionPath = "status.nodeInfo.kubeletVersion"
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 
 	msga := {
@@ -67,6 +68,4 @@ isVulnerableVersion(version) if {
 	version <= "v1.20.9"
 }
 
-isVulnerableVersion(version) if {
-	version == "v1.20.10"
-}
+isVulnerableVersion("v1.20.10")

--- a/rules/CVE-2021-25741/raw.rego
+++ b/rules/CVE-2021-25741/raw.rego
@@ -1,97 +1,89 @@
 package armo_builtins
 
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	nodes := input[_]
 	current_version := nodes.status.nodeInfo.kubeletVersion
-    is_vulnerable_version(current_version)
-    pod := input[_]
-    pod.kind == "Pod"
+	is_vulnerable_version(current_version)
+	pod := input[_]
+	pod.kind == "Pod"
 	container := pod.spec.containers[i]
 	start_of_path := "spec."
-    final_path := is_sub_path_container(container, i, start_of_path)
+	final_path := is_sub_path_container(container, i, start_of_path)
 
 	msga := {
-			"alertMessage": sprintf("You may be vulnerable to CVE-2021-25741. You have a Node with a vulnerable version and the following container : %v in pod : %v with subPath/subPathExpr", [container.name, pod.metadata.name]),
-			"alertObject": {"k8SApiObjects": [pod]},
-			"deletePaths": final_path,
-			"failedPaths": final_path,
-			"fixPaths": [],
-		}
+		"alertMessage": sprintf("You may be vulnerable to CVE-2021-25741. You have a Node with a vulnerable version and the following container : %v in pod : %v with subPath/subPathExpr", [container.name, pod.metadata.name]),
+		"alertObject": {"k8SApiObjects": [pod]},
+		"deletePaths": final_path,
+		"failedPaths": final_path,
+		"fixPaths": [],
+	}
 }
 
-
-deny[msga] {
+deny contains msga if {
 	nodes := input[_]
 	current_version := nodes.status.nodeInfo.kubeletVersion
-    is_vulnerable_version(current_version)
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	is_vulnerable_version(current_version)
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
+	container := wl.spec.template.spec.containers[i]
 	start_of_path := "spec.template.spec."
-    final_path := is_sub_path_container(container, i, start_of_path)
-       
+	final_path := is_sub_path_container(container, i, start_of_path)
+
 	msga := {
-	"alertMessage": sprintf("You may be vulnerable to CVE-2021-25741. You have a Node with a vulnerable version and the following container : %v in %v : %v with subPath/subPathExpr", [container.name, wl.kind, wl.metadata.name]),
-			"alertObject": {"k8SApiObjects": [wl]},
-			"deletePaths": final_path,
-			"failedPaths": final_path,
-			"fixPaths": [],
-		}
+		"alertMessage": sprintf("You may be vulnerable to CVE-2021-25741. You have a Node with a vulnerable version and the following container : %v in %v : %v with subPath/subPathExpr", [container.name, wl.kind, wl.metadata.name]),
+		"alertObject": {"k8SApiObjects": [wl]},
+		"deletePaths": final_path,
+		"failedPaths": final_path,
+		"fixPaths": [],
+	}
 }
 
-
-
-deny[msga] {
+deny contains msga if {
 	nodes := input[_]
 	current_version := nodes.status.nodeInfo.kubeletVersion
-    is_vulnerable_version(current_version)
-    wl := input[_]
+	is_vulnerable_version(current_version)
+	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 	start_of_path := "spec.jobTemplate.spec.template.spec."
-    final_path := is_sub_path_container(container, i, start_of_path)
-    
+	final_path := is_sub_path_container(container, i, start_of_path)
+
 	msga := {
 		"alertMessage": sprintf("You may be vulnerable to CVE-2021-25741. You have a Node with a vulnerable version and the following container : %v in %v : %v with subPath/subPathExpr", [container.name, wl.kind, wl.metadata.name]),
-			"alertObject": {"k8SApiObjects": [wl]},
-			"deletePaths": final_path,
-			"failedPaths": final_path,
-			"fixPaths": [],
-		}
+		"alertObject": {"k8SApiObjects": [wl]},
+		"deletePaths": final_path,
+		"failedPaths": final_path,
+		"fixPaths": [],
+	}
 }
 
-
-
-is_sub_path_container(container, i, start_of_path) = path {
-	path = [sprintf("%vcontainers[%v].volumeMounts[%v].subPath" ,[start_of_path, format_int(i, 10), format_int(j, 10)]) | volume_mount = container.volumeMounts[j];  volume_mount.subPath]
+is_sub_path_container(container, i, start_of_path) := path if {
+	path = [sprintf("%vcontainers[%v].volumeMounts[%v].subPath", [start_of_path, format_int(i, 10), format_int(j, 10)]) | volume_mount = container.volumeMounts[j]; volume_mount.subPath]
 	count(path) > 0
 }
 
-is_vulnerable_version(version)  {
-    version <=  "v1.19.14"
+is_vulnerable_version(version) if {
+	version <= "v1.19.14"
 }
 
-is_vulnerable_version(version){
-    version >= "v1.22.0"
-    version <= "v1.22.1"
+is_vulnerable_version(version) if {
+	version >= "v1.22.0"
+	version <= "v1.22.1"
 }
 
-
-is_vulnerable_version(version){
-    version >= "v1.21.0"
-    version <= "v1.21.4"
+is_vulnerable_version(version) if {
+	version >= "v1.21.0"
+	version <= "v1.21.4"
 }
 
-
-is_vulnerable_version(version){
-    version >= "v1.20.0"
-    version <= "v1.20.9"
+is_vulnerable_version(version) if {
+	version >= "v1.20.0"
+	version <= "v1.20.9"
 }
 
-is_vulnerable_version(version){
+is_vulnerable_version(version) if {
 	version == "v1.20.10"
 }
-
-

--- a/rules/CVE-2021-25741/raw.rego
+++ b/rules/CVE-2021-25741/raw.rego
@@ -1,15 +1,16 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	start_of_path := "spec."
 	nodes := input[_]
 	current_version := nodes.status.nodeInfo.kubeletVersion
 	is_vulnerable_version(current_version)
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
-	start_of_path := "spec."
 	final_path := is_sub_path_container(container, i, start_of_path)
 
 	msga := {
@@ -22,14 +23,14 @@ deny contains msga if {
 }
 
 deny contains msga if {
+	start_of_path := "spec.template.spec."
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	nodes := input[_]
 	current_version := nodes.status.nodeInfo.kubeletVersion
 	is_vulnerable_version(current_version)
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
-	start_of_path := "spec.template.spec."
 	final_path := is_sub_path_container(container, i, start_of_path)
 
 	msga := {
@@ -42,13 +43,13 @@ deny contains msga if {
 }
 
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	nodes := input[_]
 	current_version := nodes.status.nodeInfo.kubeletVersion
 	is_vulnerable_version(current_version)
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	final_path := is_sub_path_container(container, i, start_of_path)
 
 	msga := {
@@ -84,6 +85,4 @@ is_vulnerable_version(version) if {
 	version <= "v1.20.9"
 }
 
-is_vulnerable_version(version) if {
-	version == "v1.20.10"
-}
+is_vulnerable_version("v1.20.10")

--- a/rules/CVE-2021-25742/filter.rego
+++ b/rules/CVE-2021-25742/filter.rego
@@ -1,6 +1,8 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	deployment := input[_]
 	deployment.kind == "Deployment"
 	image := deployment.spec.template.spec.containers[i].image
@@ -9,102 +11,101 @@ deny[msga] {
 	isVulnerable(image, deployment.metadata.namespace)
 	path := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])
 	msga := {
-			"alertMessage": sprintf("You may be vulnerable to CVE-2021-25742. %v", [deployment]),
-			"failedPaths": [path],
-			"alertObject": {"k8SApiObjects": [deployment]},
-		}
+		"alertMessage": sprintf("You may be vulnerable to CVE-2021-25742. %v", [deployment]),
+		"failedPaths": [path],
+		"alertObject": {"k8SApiObjects": [deployment]},
+	}
 }
 
-	
-isNginxImage(image) {
+isNginxImage(image) if {
 	contains(image, "nginx-controller")
 }
 
-isNginxImage(image) {
+isNginxImage(image) if {
 	contains(image, "ingress-controller")
 }
 
-isNginxImage(image) {
+isNginxImage(image) if {
 	contains(image, "ingress-nginx")
 }
 
-isVulnerable(image, namespace) {
+isVulnerable(image, namespace) if {
 	contains(image, "@")
 	version := split(image, ":")
-	tag := split(version[count(version)-2], "@")[0]
-    startswith(tag, "v")
-    tag <= "v0.49"
-}
-	
-isVulnerable(image, namespace) {
-	contains(image, "@")
-	version := split(image, ":")
-	tag := split(version[count(version)-2], "@")[0]
-    startswith(tag, "v")
-    tag  == "v1.0.0"
-}
-
-isVulnerable(image, namespace) {
-	not contains(image, "@")
-	version := split(image, ":")
-	tag := version[count(version)-1]
-    startswith(tag, "v")
+	tag := split(version[count(version) - 2], "@")[0]
+	startswith(tag, "v")
 	tag <= "v0.49"
 }
 
-isVulnerable(image, namespace) {
+isVulnerable(image, namespace) if {
+	contains(image, "@")
+	version := split(image, ":")
+	tag := split(version[count(version) - 2], "@")[0]
+	startswith(tag, "v")
+	tag == "v1.0.0"
+}
+
+isVulnerable(image, namespace) if {
 	not contains(image, "@")
 	version := split(image, ":")
-	tag := version[count(version)-1]
-    startswith(tag, "v")
-	tag  == "v1.0.0"
+	tag := version[count(version) - 1]
+	startswith(tag, "v")
+	tag <= "v0.49"
+}
+
+isVulnerable(image, namespace) if {
+	not contains(image, "@")
+	version := split(image, ":")
+	tag := version[count(version) - 1]
+	startswith(tag, "v")
+	tag == "v1.0.0"
 }
 
 ###### without 'v'
-	
-isVulnerable(image, namespace) {
-	contains(image, "@")
-	version := split(image, ":")
-	tag := split(version[count(version)-2], "@")[0]
-    not startswith(tag, "v")
-    tag <= "0.49"
-}
-	
-isVulnerable(image, namespace) {
-	contains(image, "@")
-	version := split(image, ":")
-	tag := split(version[count(version)-2], "@")[0]
-    not startswith(tag, "v")
-    tag  == "1.0.0"
-}
 
-isVulnerable(image, namespace) {
-	not contains(image, "@")
+isVulnerable(image, namespace) if {
+	contains(image, "@")
 	version := split(image, ":")
-	tag := version[count(version)-1]
-    not startswith(tag, "v")
+	tag := split(version[count(version) - 2], "@")[0]
+	not startswith(tag, "v")
 	tag <= "0.49"
 }
-isVulnerable(image, namespace) {
-	not contains(image, "@")
+
+isVulnerable(image, namespace) if {
+	contains(image, "@")
 	version := split(image, ":")
-	tag := version[count(version)-1]
-    not startswith(tag, "v")
-	tag  == "1.0.0"
+	tag := split(version[count(version) - 2], "@")[0]
+	not startswith(tag, "v")
+	tag == "1.0.0"
 }
 
-isVulnerable(image, namespace) {
-    configmaps := [configmap | configmap = input[_]; configmap.kind == "ConfigMap"]
-	configmapOnIngressNamespace := [configmap |  configmap= configmaps[_]; configmap.metadata.namespace == namespace]
-	configMapsWithSnippet := [configmap |  configmap= configmapOnIngressNamespace[_];  configmap.data["allow-snippet-annotations"] == "false"]
+isVulnerable(image, namespace) if {
+	not contains(image, "@")
+	version := split(image, ":")
+	tag := version[count(version) - 1]
+	not startswith(tag, "v")
+	tag <= "0.49"
+}
+
+isVulnerable(image, namespace) if {
+	not contains(image, "@")
+	version := split(image, ":")
+	tag := version[count(version) - 1]
+	not startswith(tag, "v")
+	tag == "1.0.0"
+}
+
+isVulnerable(image, namespace) if {
+	configmaps := [configmap | configmap = input[_]; configmap.kind == "ConfigMap"]
+	configmapOnIngressNamespace := [configmap | configmap = configmaps[_]; configmap.metadata.namespace == namespace]
+	configMapsWithSnippet := [configmap | configmap = configmapOnIngressNamespace[_]; configmap.data["allow-snippet-annotations"] == "false"]
 	count(configMapsWithSnippet) < 1
 }
 
-
-is_tag_image(image) {
-    reg := ":[\\w][\\w.-]{0,127}(\/)?"
-    version := regex.find_all_string_submatch_n(reg, image, -1)
-    v := version[_]
-    img := v[_]
-    not endswith(img, "/")
+is_tag_image(image) if {
+	reg := ":[\\w][\\w.-]{0,127}(\/)?"
+	version := regex.find_all_string_submatch_n(reg, image, -1)
+	v := version[_]
+	img := v[_]
+	not endswith(img, "/")
 }

--- a/rules/CVE-2021-25742/filter.rego
+++ b/rules/CVE-2021-25742/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/CVE-2021-25742/raw.rego
+++ b/rules/CVE-2021-25742/raw.rego
@@ -1,6 +1,8 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	deployment := input[_]
 	deployment.kind == "Deployment"
 	image := deployment.spec.template.spec.containers[i].image
@@ -9,66 +11,65 @@ deny[msga] {
 
 	# Extracting version from image tag
 	tag_version_match := regex.find_all_string_submatch_n(`[0-9]+\.[0-9]+\.[0-9]+`, image, -1)[0][0]
-    image_version_str_arr := split(tag_version_match,".")
-	image_version_arr := [to_number(image_version_str_arr[0]),to_number(image_version_str_arr[1]),to_number(image_version_str_arr[2])]
+	image_version_str_arr := split(tag_version_match, ".")
+	image_version_arr := [to_number(image_version_str_arr[0]), to_number(image_version_str_arr[1]), to_number(image_version_str_arr[2])]
 
 	# Check if vulnerable
 	is_vulnerable(image_version_arr, deployment.metadata.namespace)
 
 	path := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])
 	msga := {
-			"alertMessage": sprintf("You may be vulnerable to CVE-2021-25742. Deployment %v", [deployment.metadata.name]),
-			"reviewPaths": [path],
-			"failedPaths": [path],
-			"fixPaths":[],
-			"alertObject": {"k8SApiObjects": [deployment]},
-		}
+		"alertMessage": sprintf("You may be vulnerable to CVE-2021-25742. Deployment %v", [deployment.metadata.name]),
+		"reviewPaths": [path],
+		"failedPaths": [path],
+		"fixPaths": [],
+		"alertObject": {"k8SApiObjects": [deployment]},
+	}
 }
 
-
-is_nginx_image(image) {
+is_nginx_image(image) if {
 	contains(image, "nginx-controller")
 }
 
-is_nginx_image(image) {
+is_nginx_image(image) if {
 	contains(image, "ingress-controller")
 }
 
-is_nginx_image(image) {
+is_nginx_image(image) if {
 	contains(image, "ingress-nginx")
 }
 
-is_allow_snippet_annotation_on(namespace) {
-    configmaps := [configmap | configmap = input[_]; configmap.kind == "ConfigMap"]
-	configmap_on_ingress_namespace := [configmap |  configmap= configmaps[_]; configmap.metadata.namespace == namespace]
-	config_maps_with_snippet := [configmap |  configmap= configmap_on_ingress_namespace[_];  configmap.data["allow-snippet-annotations"] == "false"]
+is_allow_snippet_annotation_on(namespace) if {
+	configmaps := [configmap | configmap = input[_]; configmap.kind == "ConfigMap"]
+	configmap_on_ingress_namespace := [configmap | configmap = configmaps[_]; configmap.metadata.namespace == namespace]
+	config_maps_with_snippet := [configmap | configmap = configmap_on_ingress_namespace[_]; configmap.data["allow-snippet-annotations"] == "false"]
 	count(config_maps_with_snippet) < 1
 }
 
-is_vulnerable(image_version, namespace) {
+is_vulnerable(image_version, namespace) if {
 	image_version[0] == 0
 	image_version[1] < 49
 	is_allow_snippet_annotation_on(namespace)
 }
 
-is_vulnerable(image_version, namespace) {
+is_vulnerable(image_version, namespace) if {
 	image_version[0] == 0
 	image_version[1] == 49
 	image_version[2] == 0
 	is_allow_snippet_annotation_on(namespace)
 }
 
-is_vulnerable(image_version, namespace) {
+is_vulnerable(image_version, namespace) if {
 	image_version[0] == 1
 	image_version[1] == 0
 	image_version[2] == 0
 	is_allow_snippet_annotation_on(namespace)
 }
 
-is_tag_image(image) {
-    reg := ":[\\w][\\w.-]{0,127}(\/)?"
-    version := regex.find_all_string_submatch_n(reg, image, -1)
-    v := version[_]
-    img := v[_]
-    not endswith(img, "/")
+is_tag_image(image) if {
+	reg := ":[\\w][\\w.-]{0,127}(\/)?"
+	version := regex.find_all_string_submatch_n(reg, image, -1)
+	v := version[_]
+	img := v[_]
+	not endswith(img, "/")
 }

--- a/rules/CVE-2021-25742/raw.rego
+++ b/rules/CVE-2021-25742/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/CVE-2022-0185/filter.rego
+++ b/rules/CVE-2022-0185/filter.rego
@@ -1,28 +1,28 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	node := input[_]
-    node.kind == "Node"
-    
-    node.status.nodeInfo.operatingSystem == "linux"
+	node.kind == "Node"
 
-   linux_kernel_vars := [linux_kernel_var | linux_kernel_var = input[_]; linux_kernel_var.kind == "LinuxKernelVariables"]
-   linux_kernel_vars_for_node := [linux_kernel_var | linux_kernel_var = linux_kernel_vars[_]; linux_kernel_var.metadata.name == node.metadata.name]
+	node.status.nodeInfo.operatingSystem == "linux"
 
-   external_vector := {
-       "name": node.metadata.name,
+	linux_kernel_vars := [linux_kernel_var | linux_kernel_var = input[_]; linux_kernel_var.kind == "LinuxKernelVariables"]
+	linux_kernel_vars_for_node := [linux_kernel_var | linux_kernel_var = linux_kernel_vars[_]; linux_kernel_var.metadata.name == node.metadata.name]
+
+	external_vector := {
+		"name": node.metadata.name,
 		"namespace": "",
 		"kind": node.kind,
 		"relatedObjects": linux_kernel_vars_for_node,
-        "kernelVersion": node.status.nodeInfo.kernelVersion
-   }
+		"kernelVersion": node.status.nodeInfo.kernelVersion,
+	}
 
- 	msga := {
-			"alertMessage": "You are vulnerable to CVE-2022-0185",
-    		"alertObject": {
-               "externalObjects": external_vector
-            },
-			"failedPaths": [],
-            "fixPaths":[],
+	msga := {
+		"alertMessage": "You are vulnerable to CVE-2022-0185",
+		"alertObject": {"externalObjects": external_vector},
+		"failedPaths": [],
+		"fixPaths": [],
 	}
 }

--- a/rules/CVE-2022-0185/filter.rego
+++ b/rules/CVE-2022-0185/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/CVE-2022-0185/raw.rego
+++ b/rules/CVE-2022-0185/raw.rego
@@ -1,72 +1,71 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	node := input[_]
-    node.kind == "Node"
+	node.kind == "Node"
 
-    parsed_kernel_version_arr := parse_kernel_version_to_array(node.status.nodeInfo.kernelVersion)
-    is_azure := parsed_kernel_version_arr[4] == "azure"
+	parsed_kernel_version_arr := parse_kernel_version_to_array(node.status.nodeInfo.kernelVersion)
+	is_azure := parsed_kernel_version_arr[4] == "azure"
 
-    is_vulnerable_kernel_version(parsed_kernel_version_arr, is_azure)
+	is_vulnerable_kernel_version(parsed_kernel_version_arr, is_azure)
 
-    node.status.nodeInfo.operatingSystem == "linux"
-    path := "status.nodeInfo.kernelVersion"
+	node.status.nodeInfo.operatingSystem == "linux"
+	path := "status.nodeInfo.kernelVersion"
 
-   linux_kernel_vars := [linux_kernel_var | linux_kernel_var = input[_]; linux_kernel_var.kind == "LinuxKernelVariables"]
-   linux_kernel_vars_for_node := [linux_kernel_var | linux_kernel_var = linux_kernel_vars[_]; linux_kernel_var.metadata.name == node.metadata.name]
-   data_userns_clones := [linux_kernel_var | linux_kernel_var = linux_kernel_vars_for_node[_].data[_]; is_unprivileged_userns_clone_enabled(linux_kernel_var)]
-   count(data_userns_clones) > 0
+	linux_kernel_vars := [linux_kernel_var | linux_kernel_var = input[_]; linux_kernel_var.kind == "LinuxKernelVariables"]
+	linux_kernel_vars_for_node := [linux_kernel_var | linux_kernel_var = linux_kernel_vars[_]; linux_kernel_var.metadata.name == node.metadata.name]
+	data_userns_clones := [linux_kernel_var | linux_kernel_var = linux_kernel_vars_for_node[_].data[_]; is_unprivileged_userns_clone_enabled(linux_kernel_var)]
+	count(data_userns_clones) > 0
 
-   external_vector := {
-       "name": node.metadata.name,
+	external_vector := {
+		"name": node.metadata.name,
 		"namespace": "",
 		"kind": node.kind,
 		"relatedObjects": linux_kernel_vars_for_node,
-        "kernelVersion": node.status.nodeInfo.kernelVersion
-   }
+		"kernelVersion": node.status.nodeInfo.kernelVersion,
+	}
 
-
- 	msga := {
-			"alertMessage": "You are vulnerable to CVE-2022-0185",
-    		"alertObject": {
-                "externalObjects": external_vector
-            },
-            "reviewPaths": ["kernelVersion"],
-			"failedPaths": ["kernelVersion"],
-            "fixPaths":[],
+	msga := {
+		"alertMessage": "You are vulnerable to CVE-2022-0185",
+		"alertObject": {"externalObjects": external_vector},
+		"reviewPaths": ["kernelVersion"],
+		"failedPaths": ["kernelVersion"],
+		"fixPaths": [],
 	}
 }
 
 # General Kernel versions are between 5.1.1 and 5.16.2
-is_vulnerable_kernel_version(parsed_kernel_version_arr, is_azure) {
-    is_azure == false
-    parsed_kernel_version_arr[0] == 5
-    parsed_kernel_version_arr[1] >= 1
-    parsed_kernel_version_arr[1] <= 16
-    parsed_kernel_version_arr[2] < 2
+is_vulnerable_kernel_version(parsed_kernel_version_arr, is_azure) if {
+	is_azure == false
+	parsed_kernel_version_arr[0] == 5
+	parsed_kernel_version_arr[1] >= 1
+	parsed_kernel_version_arr[1] <= 16
+	parsed_kernel_version_arr[2] < 2
 }
 
 # Azure kernel version with is 5.4.0-1067-azure
-is_vulnerable_kernel_version(parsed_kernel_version_arr, is_azure) {
-    is_azure == true
-    parsed_kernel_version_arr[0] == 5
-    parsed_kernel_version_arr[1] >= 1
-    parsed_kernel_version_arr[1] <= 4
-    parsed_kernel_version_arr[2] == 0
-    parsed_kernel_version_arr[3] < 1067
+is_vulnerable_kernel_version(parsed_kernel_version_arr, is_azure) if {
+	is_azure == true
+	parsed_kernel_version_arr[0] == 5
+	parsed_kernel_version_arr[1] >= 1
+	parsed_kernel_version_arr[1] <= 4
+	parsed_kernel_version_arr[2] == 0
+	parsed_kernel_version_arr[3] < 1067
 }
 
-is_unprivileged_userns_clone_enabled(linux_kernel_var) {
+is_unprivileged_userns_clone_enabled(linux_kernel_var) if {
 	linux_kernel_var.key == "unprivileged_userns_clone"
-    linux_kernel_var.value == "1\n"
+	linux_kernel_var.value == "1\n"
 }
 
-parse_kernel_version_to_array(kernel_version_str) = output {
-	version_triplet := regex.find_n(`(\d+\.\d+\.\d+)`, kernel_version_str,-1)
-    version_triplet_array := split(version_triplet[0],".")
+parse_kernel_version_to_array(kernel_version_str) := output if {
+	version_triplet := regex.find_n(`(\d+\.\d+\.\d+)`, kernel_version_str, -1)
+	version_triplet_array := split(version_triplet[0], ".")
 
-    build_vendor := regex.find_n(`-(\d+)-(\w+)`, kernel_version_str,-1)
-    build_vendor_array := split(build_vendor[0],"-")
+	build_vendor := regex.find_n(`-(\d+)-(\w+)`, kernel_version_str, -1)
+	build_vendor_array := split(build_vendor[0], "-")
 
-    output := [to_number(version_triplet_array[0]),to_number(version_triplet_array[1]),to_number(version_triplet_array[2]),to_number(build_vendor_array[1]),build_vendor_array[2]]
+	output := [to_number(version_triplet_array[0]), to_number(version_triplet_array[1]), to_number(version_triplet_array[2]), to_number(build_vendor_array[1]), build_vendor_array[2]]
 }

--- a/rules/CVE-2022-0185/raw.rego
+++ b/rules/CVE-2022-0185/raw.rego
@@ -1,8 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	path := "status.nodeInfo.kernelVersion"
 	node := input[_]
 	node.kind == "Node"
 
@@ -12,7 +14,6 @@ deny contains msga if {
 	is_vulnerable_kernel_version(parsed_kernel_version_arr, is_azure)
 
 	node.status.nodeInfo.operatingSystem == "linux"
-	path := "status.nodeInfo.kernelVersion"
 
 	linux_kernel_vars := [linux_kernel_var | linux_kernel_var = input[_]; linux_kernel_var.kind == "LinuxKernelVariables"]
 	linux_kernel_vars_for_node := [linux_kernel_var | linux_kernel_var = linux_kernel_vars[_]; linux_kernel_var.metadata.name == node.metadata.name]

--- a/rules/CVE-2022-23648/raw.rego
+++ b/rules/CVE-2022-23648/raw.rego
@@ -1,56 +1,54 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	node := input[_]
-    node.kind == "Node"
-    
-    startswith(node.status.nodeInfo.containerRuntimeVersion,"containerd://")
-    containerd_version := substring(node.status.nodeInfo.containerRuntimeVersion,13,-1)
-    containerd_version_arr := split(containerd_version, ".")
-    major_version := to_number(containerd_version_arr[0]) 
-    minor_version := to_number(containerd_version_arr[1]) 
-    subVersion := to_number(containerd_version_arr[2]) 
-    
-    is_vulnerable_version(major_version,minor_version,subVersion)
+	node.kind == "Node"
 
-    path := "status.nodeInfo.containerRuntimeVersion"
+	startswith(node.status.nodeInfo.containerRuntimeVersion, "containerd://")
+	containerd_version := substring(node.status.nodeInfo.containerRuntimeVersion, 13, -1)
+	containerd_version_arr := split(containerd_version, ".")
+	major_version := to_number(containerd_version_arr[0])
+	minor_version := to_number(containerd_version_arr[1])
+	subVersion := to_number(containerd_version_arr[2])
 
- 	msga := {
-			"alertMessage": "You are vulnerable to CVE-2022-23648",
-    		"alertObject": {
-               "k8SApiObjects": [node]
-            },
-			"reviewPaths": [path],
-			"failedPaths": [path],
-            "fixPaths":[],
+	is_vulnerable_version(major_version, minor_version, subVersion)
+
+	path := "status.nodeInfo.containerRuntimeVersion"
+
+	msga := {
+		"alertMessage": "You are vulnerable to CVE-2022-23648",
+		"alertObject": {"k8SApiObjects": [node]},
+		"reviewPaths": [path],
+		"failedPaths": [path],
+		"fixPaths": [],
 	}
 }
 
-
-is_vulnerable_version(major_version, minor_version, subVersion) {
+is_vulnerable_version(major_version, minor_version, subVersion) if {
 	major_version == 0
-} 
+}
 
-is_vulnerable_version(major_version, minor_version, subVersion) {
+is_vulnerable_version(major_version, minor_version, subVersion) if {
 	major_version == 1
 	minor_version < 4
 }
 
-is_vulnerable_version(major_version, minor_version, subVersion) {
+is_vulnerable_version(major_version, minor_version, subVersion) if {
 	major_version == 1
 	minor_version == 4
 	subVersion < 12
 }
 
-is_vulnerable_version(major_version, minor_version, subVersion) {
+is_vulnerable_version(major_version, minor_version, subVersion) if {
 	major_version == 1
 	minor_version == 5
 	subVersion < 10
-}	
+}
 
-is_vulnerable_version(major_version, minor_version, subVersion) {
+is_vulnerable_version(major_version, minor_version, subVersion) if {
 	major_version == 1
 	minor_version == 6
 	subVersion < 1
-}	
-
+}

--- a/rules/CVE-2022-23648/raw.rego
+++ b/rules/CVE-2022-23648/raw.rego
@@ -1,8 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	path := "status.nodeInfo.containerRuntimeVersion"
 	node := input[_]
 	node.kind == "Node"
 
@@ -15,8 +17,6 @@ deny contains msga if {
 
 	is_vulnerable_version(major_version, minor_version, subVersion)
 
-	path := "status.nodeInfo.containerRuntimeVersion"
-
 	msga := {
 		"alertMessage": "You are vulnerable to CVE-2022-23648",
 		"alertObject": {"k8SApiObjects": [node]},
@@ -26,9 +26,7 @@ deny contains msga if {
 	}
 }
 
-is_vulnerable_version(major_version, minor_version, subVersion) if {
-	major_version == 0
-}
+is_vulnerable_version(0, _, _)
 
 is_vulnerable_version(major_version, minor_version, subVersion) if {
 	major_version == 1

--- a/rules/CVE-2022-24348/filter.rego
+++ b/rules/CVE-2022-24348/filter.rego
@@ -1,16 +1,16 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	deployment := input[_]
 	deployment.kind == "Deployment"
 	image := deployment.spec.template.spec.containers[i].image
 	contains(image, "argocd:v")
 	path := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])
-    msga := {
-			"alertMessage": "You may be vulnerable to CVE-2022-24348",
-			"failedPaths": [path],
-			"alertObject": { 
-                "k8SApiObjects": [deployment]
-            },
-		}
+	msga := {
+		"alertMessage": "You may be vulnerable to CVE-2022-24348",
+		"failedPaths": [path],
+		"alertObject": {"k8SApiObjects": [deployment]},
+	}
 }

--- a/rules/CVE-2022-24348/filter.rego
+++ b/rules/CVE-2022-24348/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/CVE-2022-24348/raw.rego
+++ b/rules/CVE-2022-24348/raw.rego
@@ -1,51 +1,50 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	deployment := input[_]
 	deployment.kind == "Deployment"
 	image := deployment.spec.template.spec.containers[i].image
 	contains(image, "argocd:v")
 	is_vulnerable_image(image)
 	path := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])
-    msga := {
-			"alertMessage": "You may be vulnerable to CVE-2022-24348",
-			"reviewPaths": [path],
-			"failedPaths": [path],
-			"fixPaths":[],
-			"alertObject": { 
-                "k8SApiObjects": [deployment]
-            },
-		}
+	msga := {
+		"alertMessage": "You may be vulnerable to CVE-2022-24348",
+		"reviewPaths": [path],
+		"failedPaths": [path],
+		"fixPaths": [],
+		"alertObject": {"k8SApiObjects": [deployment]},
+	}
 }
 
-is_vulnerable_image(image) {
+is_vulnerable_image(image) if {
 	version := split(image, ":v")[1]
 	versionTriplet := split(version, ".")
 	count(versionTriplet) == 3
 	major_version := to_number(versionTriplet[0])
 	minorVersion := to_number(versionTriplet[1])
-	subVersion := to_number(versionTriplet[2])  
-	isVulnerableVersion(major_version,minorVersion,subVersion)
+	subVersion := to_number(versionTriplet[2])
+	isVulnerableVersion(major_version, minorVersion, subVersion)
 }
 
-isVulnerableVersion(major_version, minorVersion, subVersion) {
+isVulnerableVersion(major_version, minorVersion, subVersion) if {
 	major_version == 1
-} 
+}
 
-isVulnerableVersion(major_version, minorVersion, subVersion) {
+isVulnerableVersion(major_version, minorVersion, subVersion) if {
 	major_version == 2
 	minorVersion == 0
 }
 
-isVulnerableVersion(major_version, minorVersion, subVersion) {
+isVulnerableVersion(major_version, minorVersion, subVersion) if {
 	major_version == 2
 	minorVersion == 1
 	subVersion < 9
 }
 
-isVulnerableVersion(major_version, minorVersion, subVersion) {
+isVulnerableVersion(major_version, minorVersion, subVersion) if {
 	major_version == 2
 	minorVersion == 2
 	subVersion < 4
-}	
-
+}

--- a/rules/CVE-2022-24348/raw.rego
+++ b/rules/CVE-2022-24348/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -28,9 +29,7 @@ is_vulnerable_image(image) if {
 	isVulnerableVersion(major_version, minorVersion, subVersion)
 }
 
-isVulnerableVersion(major_version, minorVersion, subVersion) if {
-	major_version == 1
-}
+isVulnerableVersion(1, _, _)
 
 isVulnerableVersion(major_version, minorVersion, subVersion) if {
 	major_version == 2

--- a/rules/CVE-2022-3172/filter.rego
+++ b/rules/CVE-2022-3172/filter.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
-deny[msg] {
+deny contains msg if {
 	# find aggregated API APIServices
 	obj = input[_]
 	obj.apiVersion == "apiregistration.k8s.io/v1"
@@ -18,16 +18,12 @@ deny[msg] {
 	]
 
 	# Find the service that exposes the extended API
-	services = [ obj |
+	services = [obj |
 		obj := input[j]
 		obj.apiVersion == "v1"
 		obj.kind == "Service"
 		obj.metadata.name == api_service.name
 	]
 
-
-	msg := {
-		"alertObject": {"k8sApiObjects": [obj]},
-	}
+	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }
-

--- a/rules/CVE-2022-3172/filter.rego
+++ b/rules/CVE-2022-3172/filter.rego
@@ -1,13 +1,14 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
+
 	# find aggregated API APIServices
-	obj = input[_]
+    some obj in input
 	obj.apiVersion == "apiregistration.k8s.io/v1"
 	obj.kind == "APIService"
-	api_service := obj.spec.service
 
 	# check API server version vulnerability
 	api_infos = [api_info |
@@ -16,6 +17,8 @@ deny contains msg if {
 		api_info.kind == "APIServerInfo"
 		api_info.metadata.name == "version"
 	]
+
+	api_service := obj.spec.service
 
 	# Find the service that exposes the extended API
 	services = [obj |

--- a/rules/CVE-2022-3172/raw.rego
+++ b/rules/CVE-2022-3172/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
-deny[msg] {
+deny contains msg if {
 	# find aggregated API APIServices
 	obj = input[_]
 	obj.apiVersion == "apiregistration.k8s.io/v1"
@@ -42,48 +42,48 @@ deny[msg] {
 }
 
 # current kubescpae version (v2.0.171) still not support this resource
-get_api_server_version(api_infos) = version {
+get_api_server_version(api_infos) := version if {
 	count(api_infos) == 1
 	v = replace(split(api_infos[0].data.gitVersion, "-")[0], "v", "")
 	semver.is_valid(v)
 	version = v
 }
 
-get_api_server_version(api_infos) = version {
+get_api_server_version(api_infos) := version if {
 	count(api_infos) == 1
 	v = replace(split(api_infos[0].data.gitVersion, "-")[0], "v", "")
 	not semver.is_valid(v)
 	version := ""
 }
 
-get_api_server_version(api_infos) = version {
+get_api_server_version(api_infos) := version if {
 	count(api_infos) != 1
 	version = ""
 }
 
-is_api_server_version_affected(version) {
+is_api_server_version_affected(version) if {
 	version == ""
 }
 
-is_api_server_version_affected(version) {
+is_api_server_version_affected(version) if {
 	semver.compare(version, "1.25.0") == 0
 }
 
-is_api_server_version_affected(version) {
+is_api_server_version_affected(version) if {
 	semver.compare(version, "1.24.0") >= 0
 	semver.compare(version, "1.24.4") <= 0
 }
 
-is_api_server_version_affected(version) {
+is_api_server_version_affected(version) if {
 	semver.compare(version, "1.23.0") >= 0
 	semver.compare(version, "1.23.10") <= 0
 }
 
-is_api_server_version_affected(version) {
+is_api_server_version_affected(version) if {
 	semver.compare(version, "1.22.0") >= 0
 	semver.compare(version, "1.22.13") <= 0
 }
 
-is_api_server_version_affected(version) {
+is_api_server_version_affected(version) if {
 	semver.compare(version, "1.21.14") <= 0
 }

--- a/rules/CVE-2022-3172/raw.rego
+++ b/rules/CVE-2022-3172/raw.rego
@@ -1,13 +1,13 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
 	# find aggregated API APIServices
-	obj = input[_]
+    some obj in input
 	obj.apiVersion == "apiregistration.k8s.io/v1"
 	obj.kind == "APIService"
-	api_service := obj.spec.service
 
 	# check API server version vulnerability
 	api_infos = [api_info |
@@ -19,6 +19,8 @@ deny contains msg if {
 
 	version = get_api_server_version(api_infos)
 	is_api_server_version_affected(version)
+
+    api_service := obj.spec.service
 
 	# Find the service that exposes the extended API
 	services = [obj |
@@ -61,9 +63,7 @@ get_api_server_version(api_infos) := version if {
 	version = ""
 }
 
-is_api_server_version_affected(version) if {
-	version == ""
-}
+is_api_server_version_affected("")
 
 is_api_server_version_affected(version) if {
 	semver.compare(version, "1.25.0") == 0

--- a/rules/CVE-2022-39328/filter.rego
+++ b/rules/CVE-2022-39328/filter.rego
@@ -1,16 +1,16 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	deployment := input[_]
 	deployment.kind == "Deployment"
 	image := deployment.spec.template.spec.containers[i].image
 	contains(image, "grafana:")
 	path := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])
-    msga := {
-			"alertMessage": "You may be vulnerable to CVE-2022-39328",
-			"failedPaths": [path],
-			"alertObject": { 
-                "k8SApiObjects": [deployment]
-            },
-		}
+	msga := {
+		"alertMessage": "You may be vulnerable to CVE-2022-39328",
+		"failedPaths": [path],
+		"alertObject": {"k8SApiObjects": [deployment]},
+	}
 }

--- a/rules/CVE-2022-39328/filter.rego
+++ b/rules/CVE-2022-39328/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/CVE-2022-39328/raw.rego
+++ b/rules/CVE-2022-39328/raw.rego
@@ -1,35 +1,35 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	deployment := input[_]
 	deployment.kind == "Deployment"
 	image := deployment.spec.template.spec.containers[i].image
 	contains(image, "grafana:")
 	is_vulnerable_image(image)
 	path := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])
-    msga := {
-			"alertMessage": "You may be vulnerable to CVE-2022-39328",
-			"reviewPaths": [path],
-			"failedPaths": [path],
-			"fixPaths":[],
-			"alertObject": { 
-                "k8SApiObjects": [deployment]
-            },
-		}
+	msga := {
+		"alertMessage": "You may be vulnerable to CVE-2022-39328",
+		"reviewPaths": [path],
+		"failedPaths": [path],
+		"fixPaths": [],
+		"alertObject": {"k8SApiObjects": [deployment]},
+	}
 }
 
-is_vulnerable_image(image) {
-	clean_image := replace(image,"-ubuntu","")
+is_vulnerable_image(image) if {
+	clean_image := replace(image, "-ubuntu", "")
 	version := split(clean_image, ":")[1]
 	versionTriplet := split(version, ".")
 	count(versionTriplet) == 3
 	major_version := to_number(versionTriplet[0])
 	minorVersion := to_number(versionTriplet[1])
-	subVersion := to_number(versionTriplet[2])  
-	isVulnerableVersion(major_version,minorVersion,subVersion)
+	subVersion := to_number(versionTriplet[2])
+	isVulnerableVersion(major_version, minorVersion, subVersion)
 }
 
-isVulnerableVersion(major_version, minorVersion, subVersion) {
+isVulnerableVersion(major_version, minorVersion, subVersion) if {
 	major_version == 9
 	minorVersion == 2
 	subVersion < 4

--- a/rules/CVE-2022-39328/raw.rego
+++ b/rules/CVE-2022-39328/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/CVE-2022-47633/filter.rego
+++ b/rules/CVE-2022-47633/filter.rego
@@ -1,16 +1,16 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	deployment := input[_]
 	deployment.kind == "Deployment"
 	image := deployment.spec.template.spec.containers[i].image
 	contains(image, "kyverno:")
 	path := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])
-    msga := {
-			"alertMessage": "You may be vulnerable to CVE-2022-47633",
-			"failedPaths": [path],
-			"alertObject": { 
-                "k8SApiObjects": [deployment]
-            },
-		}
+	msga := {
+		"alertMessage": "You may be vulnerable to CVE-2022-47633",
+		"failedPaths": [path],
+		"alertObject": {"k8SApiObjects": [deployment]},
+	}
 }

--- a/rules/CVE-2022-47633/filter.rego
+++ b/rules/CVE-2022-47633/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/CVE-2022-47633/raw.rego
+++ b/rules/CVE-2022-47633/raw.rego
@@ -1,34 +1,34 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	deployment := input[_]
 	deployment.kind == "Deployment"
 	image := deployment.spec.template.spec.containers[i].image
 	contains(image, "kyverno:")
 	is_vulnerable_image(image)
 	path := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])
-    msga := {
-			"alertMessage": "You may be vulnerable to CVE-2022-47633",
-			"reviewPaths": [path],
-			"failedPaths": [path],
-			"fixPaths":[],
-			"alertObject": { 
-                "k8SApiObjects": [deployment]
-            },
-		}
+	msga := {
+		"alertMessage": "You may be vulnerable to CVE-2022-47633",
+		"reviewPaths": [path],
+		"failedPaths": [path],
+		"fixPaths": [],
+		"alertObject": {"k8SApiObjects": [deployment]},
+	}
 }
 
-is_vulnerable_image(image) {
+is_vulnerable_image(image) if {
 	version := split(image, ":v")[1]
 	versionTriplet := split(version, ".")
 	count(versionTriplet) == 3
 	major_version := to_number(versionTriplet[0])
 	minorVersion := to_number(versionTriplet[1])
-	subVersion := to_number(versionTriplet[2])  
-	isVulnerableVersion(major_version,minorVersion,subVersion)
+	subVersion := to_number(versionTriplet[2])
+	isVulnerableVersion(major_version, minorVersion, subVersion)
 }
 
-isVulnerableVersion(major_version, minorVersion, subVersion) {
+isVulnerableVersion(major_version, minorVersion, subVersion) if {
 	major_version == 1
 	minorVersion == 8
 	3 <= subVersion

--- a/rules/CVE-2022-47633/raw.rego
+++ b/rules/CVE-2022-47633/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -31,6 +32,6 @@ is_vulnerable_image(image) if {
 isVulnerableVersion(major_version, minorVersion, subVersion) if {
 	major_version == 1
 	minorVersion == 8
-	3 <= subVersion
+	subVersion >=3
 	subVersion < 5
 }

--- a/rules/access-container-service-account-v1/filter.rego
+++ b/rules/access-container-service-account-v1/filter.rego
@@ -1,37 +1,37 @@
 package armo_builtins
 
+import rego.v1
 
 # Returns the rbac permission of each service account
-deny[msga] {
-    subjectVector := input[_]
-    subjectVector.kind == "ServiceAccount"
-    
+deny contains msga if {
+	subjectVector := input[_]
+	subjectVector.kind == "ServiceAccount"
+
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
 	endswith(role.kind, "Role")
 	endswith(rolebinding.kind, "Binding")
 
-    subject := rolebinding.subjects[k]
+	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
-
 
 	msga := {
 		"alertMessage": sprintf("service account: %v has the following permissions in the cluster", [subjectVector.name]),
 		"packagename": "armo_builtins",
-       "failedPaths": [],
-        "fixPaths":[],
+		"failedPaths": [],
+		"fixPaths": [],
 		"alertScore": 7,
-        "alertObject": {
+		"alertObject": {
 			"k8sApiObjects": [],
-            "externalObjects": subjectVector
-		}
+			"externalObjects": subjectVector,
+		},
 	}
 }
 
 # ===============================================================
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace

--- a/rules/access-container-service-account-v1/filter.rego
+++ b/rules/access-container-service-account-v1/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/access-container-service-account-v1/raw.rego
+++ b/rules/access-container-service-account-v1/raw.rego
@@ -1,37 +1,37 @@
 package armo_builtins
 
+import rego.v1
 
 # Returns the rbac permission of each service account
-deny[msga] {
-    subjectVector := input[_]
-    subjectVector.kind == "ServiceAccount"
-    
+deny contains msga if {
+	subjectVector := input[_]
+	subjectVector.kind == "ServiceAccount"
+
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
 	endswith(role.kind, "Role")
 	endswith(rolebinding.kind, "Binding")
 
-    subject := rolebinding.subjects[k]
+	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
-
 
 	msga := {
 		"alertMessage": sprintf("service account: %v has the following permissions in the cluster", [subjectVector.name]),
 		"packagename": "armo_builtins",
-       "failedPaths": [],
-        "fixPaths":[],
+		"failedPaths": [],
+		"fixPaths": [],
 		"alertScore": 7,
-        "alertObject": {
+		"alertObject": {
 			"k8sApiObjects": [],
-            "externalObjects": subjectVector
-		}
+			"externalObjects": subjectVector,
+		},
 	}
 }
 
 # ===============================================================
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace

--- a/rules/access-container-service-account-v1/raw.rego
+++ b/rules/access-container-service-account-v1/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/alert-any-hostpath/raw.rego
+++ b/rules/alert-any-hostpath/raw.rego
@@ -1,18 +1,18 @@
 package armo_builtins
 
+import rego.v1
 
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
-    volumes := pod.spec.volumes
-    volume := volumes[i]
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	volumes := pod.spec.volumes
+	volume := volumes[i]
 	start_of_path := "spec."
-	result  := is_dangerous_volume(volume, start_of_path, i)
-    podname := pod.metadata.name
+	result := is_dangerous_volume(volume, start_of_path, i)
+	podname := pod.metadata.name
 	volumeMounts := pod.spec.containers[j].volumeMounts
 	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.containers[%v]", [j]))
 	finalPath := array.concat([result], pathMounts)
-
 
 	msga := {
 		"alertMessage": sprintf("pod: %v has: %v as hostPath volume", [podname, volume.name]),
@@ -20,26 +20,23 @@ deny[msga] {
 		"alertScore": 7,
 		"deletePaths": finalPath,
 		"failedPaths": finalPath,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # handles majority of workload resources
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    volumes := wl.spec.template.spec.volumes
-    volume := volumes[i]
+	volumes := wl.spec.template.spec.volumes
+	volume := volumes[i]
 	start_of_path := "spec.template.spec."
-    result  := is_dangerous_volume(volume, start_of_path, i)
+	result := is_dangerous_volume(volume, start_of_path, i)
 	volumeMounts := wl.spec.template.spec.containers[j].volumeMounts
-	pathMounts = volume_mounts(volume.name,volumeMounts, sprintf("spec.template.spec.containers[%v]", [j]))
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.template.spec.containers[%v]", [j]))
 	finalPath := array.concat([result], pathMounts)
-
 
 	msga := {
 		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
@@ -47,23 +44,21 @@ deny[msga] {
 		"alertScore": 7,
 		"deletePaths": finalPath,
 		"failedPaths": finalPath,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # handles CronJobs
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
-    volumes := wl.spec.jobTemplate.spec.template.spec.volumes
-    volume := volumes[i]
+	volumes := wl.spec.jobTemplate.spec.template.spec.volumes
+	volume := volumes[i]
 	start_of_path := "spec.jobTemplate.spec.template.spec."
-    result  := is_dangerous_volume(volume, start_of_path, i)
+	result := is_dangerous_volume(volume, start_of_path, i)
 	volumeMounts := wl.spec.jobTemplate.spec.template.spec.containers[j].volumeMounts
-	pathMounts = volume_mounts(volume.name,volumeMounts, sprintf("spec.jobTemplate.spec.template.spec.containers[%v]", [j]))
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.jobTemplate.spec.template.spec.containers[%v]", [j]))
 	finalPath := array.concat([result], pathMounts)
 
 	msga := {
@@ -72,24 +67,23 @@ deny[msga] {
 		"alertScore": 7,
 		"deletePaths": finalPath,
 		"failedPaths": finalPath,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-is_dangerous_volume(volume, start_of_path, i) = path {
-    volume.hostPath.path
-    path = sprintf("%vvolumes[%v]", [start_of_path, format_int(i, 10)])
+is_dangerous_volume(volume, start_of_path, i) := path if {
+	volume.hostPath.path
+	path = sprintf("%vvolumes[%v]", [start_of_path, format_int(i, 10)])
 }
 
-volume_mounts(name, volume_mounts, str) = [path] {
+volume_mounts(name, volume_mounts, str) := [path] if {
 	name == volume_mounts[j].name
 	path := sprintf("%s.volumeMounts[%v]", [str, j])
-} else = []
+} else := []
+
 # handles initContainers for Pod
-deny[msga] {
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	volumes := pod.spec.volumes
@@ -106,17 +100,15 @@ deny[msga] {
 		"alertScore": 7,
 		"deletePaths": finalPath,
 		"failedPaths": finalPath,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # handles initContainers for majority of workload resources
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	volumes := wl.spec.template.spec.volumes
 	volume := volumes[i]
@@ -131,15 +123,13 @@ deny[msga] {
 		"alertScore": 7,
 		"deletePaths": finalPath,
 		"failedPaths": finalPath,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # handles initContainers for CronJobs
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	volumes := wl.spec.jobTemplate.spec.template.spec.volumes
@@ -155,9 +145,7 @@ deny[msga] {
 		"alertScore": 7,
 		"deletePaths": finalPath,
 		"failedPaths": finalPath,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }

--- a/rules/alert-any-hostpath/raw.rego
+++ b/rules/alert-any-hostpath/raw.rego
@@ -1,13 +1,14 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	start_of_path := "spec."
 	pod := input[_]
 	pod.kind == "Pod"
 	volumes := pod.spec.volumes
 	volume := volumes[i]
-	start_of_path := "spec."
 	result := is_dangerous_volume(volume, start_of_path, i)
 	podname := pod.metadata.name
 	volumeMounts := pod.spec.containers[j].volumeMounts
@@ -27,12 +28,12 @@ deny contains msga if {
 
 # handles majority of workload resources
 deny contains msga if {
-	wl := input[_]
+	start_of_path := "spec.template.spec."
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	volumes := wl.spec.template.spec.volumes
 	volume := volumes[i]
-	start_of_path := "spec.template.spec."
 	result := is_dangerous_volume(volume, start_of_path, i)
 	volumeMounts := wl.spec.template.spec.containers[j].volumeMounts
 	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.template.spec.containers[%v]", [j]))
@@ -51,16 +52,84 @@ deny contains msga if {
 
 # handles CronJobs
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
 	volumes := wl.spec.jobTemplate.spec.template.spec.volumes
 	volume := volumes[i]
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	result := is_dangerous_volume(volume, start_of_path, i)
 	volumeMounts := wl.spec.jobTemplate.spec.template.spec.containers[j].volumeMounts
 	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.jobTemplate.spec.template.spec.containers[%v]", [j]))
 	finalPath := array.concat([result], pathMounts)
 
+	msga := {
+		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"deletePaths": finalPath,
+		"failedPaths": finalPath,
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
+}
+
+# handles initContainers for Pod
+deny contains msga if {
+	start_of_path := "spec."
+	pod := input[_]
+	pod.kind == "Pod"
+	volumes := pod.spec.volumes
+	volume := volumes[i]
+	result := is_dangerous_volume(volume, start_of_path, i)
+	podname := pod.metadata.name
+	volumeMounts := pod.spec.initContainers[j].volumeMounts
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.initContainers[%v]", [j]))
+	finalPath := array.concat([result], pathMounts)
+	msga := {
+		"alertMessage": sprintf("pod: %v has: %v as hostPath volume", [podname, volume.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"deletePaths": finalPath,
+		"failedPaths": finalPath,
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [pod]},
+	}
+}
+
+# handles initContainers for majority of workload resources
+deny contains msga if {
+	start_of_path := "spec.template.spec."
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
+	spec_template_spec_patterns[wl.kind]
+	volumes := wl.spec.template.spec.volumes
+	volume := volumes[i]
+	result := is_dangerous_volume(volume, start_of_path, i)
+	volumeMounts := wl.spec.template.spec.initContainers[j].volumeMounts
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.template.spec.initContainers[%v]", [j]))
+	finalPath := array.concat([result], pathMounts)
+	msga := {
+		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"deletePaths": finalPath,
+		"failedPaths": finalPath,
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
+}
+
+# handles initContainers for CronJobs
+deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
+	wl := input[_]
+	wl.kind == "CronJob"
+	volumes := wl.spec.jobTemplate.spec.template.spec.volumes
+	volume := volumes[i]
+	result := is_dangerous_volume(volume, start_of_path, i)
+	volumeMounts := wl.spec.jobTemplate.spec.template.spec.initContainers[j].volumeMounts
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.jobTemplate.spec.template.spec.initContainers[%v]", [j]))
+	finalPath := array.concat([result], pathMounts)
 	msga := {
 		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
 		"packagename": "armo_builtins",
@@ -81,71 +150,3 @@ volume_mounts(name, volume_mounts, str) := [path] if {
 	name == volume_mounts[j].name
 	path := sprintf("%s.volumeMounts[%v]", [str, j])
 } else := []
-
-# handles initContainers for Pod
-deny contains msga if {
-	pod := input[_]
-	pod.kind == "Pod"
-	volumes := pod.spec.volumes
-	volume := volumes[i]
-	start_of_path := "spec."
-	result := is_dangerous_volume(volume, start_of_path, i)
-	podname := pod.metadata.name
-	volumeMounts := pod.spec.initContainers[j].volumeMounts
-	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.initContainers[%v]", [j]))
-	finalPath := array.concat([result], pathMounts)
-	msga := {
-		"alertMessage": sprintf("pod: %v has: %v as hostPath volume", [podname, volume.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 7,
-		"deletePaths": finalPath,
-		"failedPaths": finalPath,
-		"fixPaths": [],
-		"alertObject": {"k8sApiObjects": [pod]},
-	}
-}
-
-# handles initContainers for majority of workload resources
-deny contains msga if {
-	wl := input[_]
-	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
-	spec_template_spec_patterns[wl.kind]
-	volumes := wl.spec.template.spec.volumes
-	volume := volumes[i]
-	start_of_path := "spec.template.spec."
-	result := is_dangerous_volume(volume, start_of_path, i)
-	volumeMounts := wl.spec.template.spec.initContainers[j].volumeMounts
-	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.template.spec.initContainers[%v]", [j]))
-	finalPath := array.concat([result], pathMounts)
-	msga := {
-		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 7,
-		"deletePaths": finalPath,
-		"failedPaths": finalPath,
-		"fixPaths": [],
-		"alertObject": {"k8sApiObjects": [wl]},
-	}
-}
-
-# handles initContainers for CronJobs
-deny contains msga if {
-	wl := input[_]
-	wl.kind == "CronJob"
-	volumes := wl.spec.jobTemplate.spec.template.spec.volumes
-	volume := volumes[i]
-	start_of_path := "spec.jobTemplate.spec.template.spec."
-	result := is_dangerous_volume(volume, start_of_path, i)
-	volumeMounts := wl.spec.jobTemplate.spec.template.spec.initContainers[j].volumeMounts
-	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.jobTemplate.spec.template.spec.initContainers[%v]", [j]))
-	finalPath := array.concat([result], pathMounts)
-	msga := {
-		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
-		"packagename": "armo_builtins",
-		"alertScore": 7,
-		"deletePaths": finalPath,
-		"failedPaths": finalPath,
-		"fixPaths": [],
-		"alertObject": {"k8sApiObjects": [wl]},
-	}
-}

--- a/rules/alert-container-optimized-os-not-in-use/raw.rego
+++ b/rules/alert-container-optimized-os-not-in-use/raw.rego
@@ -1,16 +1,15 @@
 package armo_builtins
-import future.keywords.in
 
+import rego.v1
 
-# checks if a node is not using a "Container-Optimized OS". 
-# "Container-Optimized OS" prefixes are configured in 'container_optimized_os_prefixes'.  
+# checks if a node is not using a "Container-Optimized OS".
+# "Container-Optimized OS" prefixes are configured in 'container_optimized_os_prefixes'.
 # deny if 'nodes.status.nodeInfo.osImage' not starting with at least one item in 'container_optimized_os_prefixes'.
-deny[msga] {
-
+deny contains msga if {
 	nodes := input[_]
 	nodes.kind == "Node"
 
-	# list of "Container-Optimized OS" images prefixes 
+	# list of "Container-Optimized OS" images prefixes
 	container_optimized_os_prefixes = ["Bottlerocket"]
 
 	# check if osImage starts with at least one prefix
@@ -18,20 +17,17 @@ deny[msga] {
 	not startswith(nodes.status.nodeInfo.osImage, str)
 
 	# prepare message data.
-	alert_message :=  "Prefer using Container-Optimized OS when possible"
+	alert_message := "Prefer using Container-Optimized OS when possible"
 
-	failedPaths:= ["status.nodeInfo.osImage"]
+	failedPaths := ["status.nodeInfo.osImage"]
 
 	msga := {
 		"alertMessage": alert_message,
 		"packagename": "armo_builtins",
-
 		"alertScore": 7,
 		"reviewPaths": failedPaths,
 		"failedPaths": failedPaths,
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [nodes]
-		}
+		"alertObject": {"k8sApiObjects": [nodes]},
 	}
 }

--- a/rules/alert-container-optimized-os-not-in-use/raw.rego
+++ b/rules/alert-container-optimized-os-not-in-use/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -6,6 +7,11 @@ import rego.v1
 # "Container-Optimized OS" prefixes are configured in 'container_optimized_os_prefixes'.
 # deny if 'nodes.status.nodeInfo.osImage' not starting with at least one item in 'container_optimized_os_prefixes'.
 deny contains msga if {
+	# prepare message data.
+	alert_message := "Prefer using Container-Optimized OS when possible"
+
+	failedPaths := ["status.nodeInfo.osImage"]
+
 	nodes := input[_]
 	nodes.kind == "Node"
 
@@ -15,11 +21,6 @@ deny contains msga if {
 	# check if osImage starts with at least one prefix
 	some str in container_optimized_os_prefixes
 	not startswith(nodes.status.nodeInfo.osImage, str)
-
-	# prepare message data.
-	alert_message := "Prefer using Container-Optimized OS when possible"
-
-	failedPaths := ["status.nodeInfo.osImage"]
 
 	msga := {
 		"alertMessage": alert_message,

--- a/rules/alert-fargate-not-in-use/raw.rego
+++ b/rules/alert-fargate-not-in-use/raw.rego
@@ -1,35 +1,29 @@
 package armo_builtins
 
-
-
+import rego.v1
 
 # deny if fargate is not being used in any of the nodes in cluster.
 # a Node is identified as using fargate if it's name starts with 'fargate'.
-deny[msga] {
+deny contains msga if {
+	# get all nodes
+	nodes := [node | node = input[_]; node.kind == "Node"]
+	count(nodes) > 0
 
+	# get all nodes without fargate
+	nodes_not_fargate := [node | node = nodes[_]; not startswith(node.metadata.name, "fargate")]
 
-    # get all nodes
-    nodes := [node | node = input[_]; node.kind == "Node"]
-    count(nodes) > 0
-
-    # get all nodes without fargate
-    nodes_not_fargate := [node | node = nodes[_]; not startswith(node.metadata.name, "fargate")]
-
-    # if count of all nodes equals to count of nodes_not_fargate it means fargate is not being used.
-    count(nodes) == count(nodes_not_fargate)
+	# if count of all nodes equals to count of nodes_not_fargate it means fargate is not being used.
+	count(nodes) == count(nodes_not_fargate)
 
 	# prepare message data.
-	alert_message :=  "Consider Fargate for running untrusted workloads"
+	alert_message := "Consider Fargate for running untrusted workloads"
 
 	msga := {
 		"alertMessage": alert_message,
 		"packagename": "armo_builtins",
-
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": nodes_not_fargate
-		}
+		"alertObject": {"k8sApiObjects": nodes_not_fargate},
 	}
 }

--- a/rules/alert-fargate-not-in-use/raw.rego
+++ b/rules/alert-fargate-not-in-use/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -5,6 +6,9 @@ import rego.v1
 # deny if fargate is not being used in any of the nodes in cluster.
 # a Node is identified as using fargate if it's name starts with 'fargate'.
 deny contains msga if {
+	# prepare message data.
+	alert_message := "Consider Fargate for running untrusted workloads"
+
 	# get all nodes
 	nodes := [node | node = input[_]; node.kind == "Node"]
 	count(nodes) > 0
@@ -14,10 +18,7 @@ deny contains msga if {
 
 	# if count of all nodes equals to count of nodes_not_fargate it means fargate is not being used.
 	count(nodes) == count(nodes_not_fargate)
-
-	# prepare message data.
-	alert_message := "Consider Fargate for running untrusted workloads"
-
+	
 	msga := {
 		"alertMessage": alert_message,
 		"packagename": "armo_builtins",

--- a/rules/alert-mount-potential-credentials-paths/raw.rego
+++ b/rules/alert-mount-potential-credentials-paths/raw.rego
@@ -1,17 +1,17 @@
 package armo_builtins
-import future.keywords.if
 
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	provider := data.dataControlInputs.cloudProvider
 	provider != ""
 	resources := input[_]
 	spec_data := get_pod_spec(resources)
-	spec := spec_data["spec"]
-    volumes := spec.volumes
-    volume := volumes[i]
-	start_of_path := spec_data["start_of_path"]
-    result := is_unsafe_paths(volume, start_of_path, provider, i)
+	spec := spec_data.spec
+	volumes := spec.volumes
+	volume := volumes[i]
+	start_of_path := spec_data.start_of_path
+	result := is_unsafe_paths(volume, start_of_path, provider, i)
 	volumeMounts := spec.containers[j].volumeMounts
 	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("%vcontainers[%d]", [start_of_path, j]))
 	finalPath := array.concat([result], pathMounts)
@@ -22,77 +22,82 @@ deny[msga] {
 		"alertScore": 7,
 		"deletePaths": finalPath,
 		"failedPaths": finalPath,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [resources]
-		}
-	}	
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [resources]},
+	}
 }
 
 # get_volume - get resource spec paths for {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-get_pod_spec(resources) := result {
-	resources_kinds := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+get_pod_spec(resources) := result if {
+	resources_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	resources_kinds[resources.kind]
 	result = {"spec": resources.spec.template.spec, "start_of_path": "spec.template.spec."}
 }
 
 # get_volume - get resource spec paths for "Pod"
-get_pod_spec(resources) := result {
+get_pod_spec(resources) := result if {
 	resources.kind == "Pod"
 	result = {"spec": resources.spec, "start_of_path": "spec."}
 }
 
 # get_volume - get resource spec paths for "CronJob"
-get_pod_spec(resources) := result {
+get_pod_spec(resources) := result if {
 	resources.kind == "CronJob"
 	result = {"spec": resources.spec.jobTemplate.spec.template.spec, "start_of_path": "spec.jobTemplate.spec.template.spec."}
 }
 
-
 # is_unsafe_paths - looking for cloud provider (eks/gke/aks) paths that have the potential of accessing credentials
-is_unsafe_paths(volume, start_of_path, provider, i) = result {
-	unsafe :=  unsafe_paths(provider)
+is_unsafe_paths(volume, start_of_path, provider, i) := result if {
+	unsafe := unsafe_paths(provider)
 	unsafe[_] == fix_path(volume.hostPath.path)
 	result = sprintf("%vvolumes[%d]", [start_of_path, i])
 }
 
-
 # fix_path - adding "/" at the end of the path if doesn't exist and if not a file path.
 fix_path(path) := result if {
-
 	# filter file path
-    not regex.match(`[\\w-]+\\.`, path)
+	not regex.match(`[\\w-]+\\.`, path)
 
 	# filter path that doesn't end with "/"
-    not endswith(path, "/")
+	not endswith(path, "/")
 
 	# adding "/" to the end of the path
-    result = sprintf("%v/", [path])
+	result = sprintf("%v/", [path])
 } else := path
 
-
-
 # eks unsafe paths
-unsafe_paths(x) := ["/.aws/", 
-					"/.aws/config/", 
-					"/.aws/credentials/"] if {x=="eks"}
+unsafe_paths(x) := [
+	"/.aws/",
+	"/.aws/config/",
+	"/.aws/credentials/",
+] if {
+	x == "eks"
+}
 
 # aks unsafe paths
-unsafe_paths(x) := ["/etc/",
-					"/etc/kubernetes/",
-					"/etc/kubernetes/azure.json", 
-					"/.azure/",
-					"/.azure/credentials/", 
-					"/etc/kubernetes/azure.json"] if {x=="aks"}
+unsafe_paths(x) := [
+	"/etc/",
+	"/etc/kubernetes/",
+	"/etc/kubernetes/azure.json",
+	"/.azure/",
+	"/.azure/credentials/",
+	"/etc/kubernetes/azure.json",
+] if {
+	x == "aks"
+}
 
 # gke unsafe paths
-unsafe_paths(x) := ["/.config/gcloud/", 
-					"/.config/", 
-					"/gcloud/", 
-					"/.config/gcloud/application_default_credentials.json",
-					"/gcloud/application_default_credentials.json"] if {x=="gke"}
+unsafe_paths(x) := [
+	"/.config/gcloud/",
+	"/.config/",
+	"/gcloud/",
+	"/.config/gcloud/application_default_credentials.json",
+	"/gcloud/application_default_credentials.json",
+] if {
+	x == "gke"
+}
 
-volume_mounts(name, volume_mounts, str) = [path] {
+volume_mounts(name, volume_mounts, str) := [path] if {
 	name == volume_mounts[j].name
 	path := sprintf("%s.volumeMounts[%v]", [str, j])
-} else = []
+} else := []

--- a/rules/alert-mount-potential-credentials-paths/raw.rego
+++ b/rules/alert-mount-potential-credentials-paths/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -66,36 +67,30 @@ fix_path(path) := result if {
 } else := path
 
 # eks unsafe paths
-unsafe_paths(x) := [
+unsafe_paths("eks") := [
 	"/.aws/",
 	"/.aws/config/",
 	"/.aws/credentials/",
-] if {
-	x == "eks"
-}
+]
 
 # aks unsafe paths
-unsafe_paths(x) := [
+unsafe_paths("aks") := [
 	"/etc/",
 	"/etc/kubernetes/",
 	"/etc/kubernetes/azure.json",
 	"/.azure/",
 	"/.azure/credentials/",
 	"/etc/kubernetes/azure.json",
-] if {
-	x == "aks"
-}
+]
 
 # gke unsafe paths
-unsafe_paths(x) := [
+unsafe_paths("gke") := [
 	"/.config/gcloud/",
 	"/.config/",
 	"/gcloud/",
 	"/.config/gcloud/application_default_credentials.json",
 	"/gcloud/application_default_credentials.json",
-] if {
-	x == "gke"
-}
+]
 
 volume_mounts(name, volume_mounts, str) := [path] if {
 	name == volume_mounts[j].name

--- a/rules/alert-rw-hostpath/raw.rego
+++ b/rules/alert-rw-hostpath/raw.rego
@@ -1,92 +1,85 @@
 package armo_builtins
 
+import rego.v1
+
 # Fails if container has a hostPath volume which is not readOnly
 
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
-    volumes := pod.spec.volumes
-    volume := volumes[_]
-    volume.hostPath
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	volumes := pod.spec.volumes
+	volume := volumes[_]
+	volume.hostPath
 	container := pod.spec.containers[i]
 	volume_mount := container.volumeMounts[k]
 	volume_mount.name == volume.name
 	start_of_path := "spec."
-	fix_path := is_rw_mount(volume_mount, start_of_path,  i, k)
+	fix_path := is_rw_mount(volume_mount, start_of_path, i, k)
 
-    podname := pod.metadata.name
+	podname := pod.metadata.name
 
 	msga := {
 		"alertMessage": sprintf("pod: %v has: %v as hostPath volume", [podname, volume.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"fixPaths": [fix_path],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # handles majority of workload resources
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    volumes := wl.spec.template.spec.volumes
-    volume := volumes[_]
-    volume.hostPath
+	volumes := wl.spec.template.spec.volumes
+	volume := volumes[_]
+	volume.hostPath
 	container := wl.spec.template.spec.containers[i]
 	volume_mount := container.volumeMounts[k]
 	volume_mount.name == volume.name
 	start_of_path := "spec.template.spec."
-	fix_path := is_rw_mount(volume_mount, start_of_path,  i, k)
+	fix_path := is_rw_mount(volume_mount, start_of_path, i, k)
 
 	msga := {
 		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"fixPaths": [fix_path],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
-
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # handles CronJobs
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
-    volumes := wl.spec.jobTemplate.spec.template.spec.volumes
-    volume := volumes[_]
-    volume.hostPath
+	volumes := wl.spec.jobTemplate.spec.template.spec.volumes
+	volume := volumes[_]
+	volume.hostPath
 
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 	volume_mount := container.volumeMounts[k]
 	volume_mount.name == volume.name
 	start_of_path := "spec.jobTemplate.spec.template.spec."
-	fix_path := is_rw_mount(volume_mount, start_of_path,  i, k) 
-
+	fix_path := is_rw_mount(volume_mount, start_of_path, i, k)
 
 	msga := {
-	"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
-	"packagename": "armo_builtins",
-	"alertScore": 7,
-	"fixPaths": [fix_path],
-	"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"fixPaths": [fix_path],
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
-is_rw_mount(mount, start_of_path,  i, k) = fix_path {
+is_rw_mount(mount, start_of_path, i, k) := fix_path if {
 	not mount.readOnly == true
-    fix_path = {"path": sprintf("%vcontainers[%v].volumeMounts[%v].readOnly", [start_of_path, i, k]), "value":"true"}
+	fix_path = {"path": sprintf("%vcontainers[%v].volumeMounts[%v].readOnly", [start_of_path, i, k]), "value": "true"}
 }
 
 # handles initContainers for Pod
-deny[msga] {
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	volumes := pod.spec.volumes
@@ -103,16 +96,14 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"fixPaths": [fix_path],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # handles initContainers for majority of workload resources
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	volumes := wl.spec.template.spec.volumes
 	volume := volumes[_]
@@ -127,14 +118,12 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"fixPaths": [fix_path],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # handles initContainers for CronJobs
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	volumes := wl.spec.jobTemplate.spec.template.spec.volumes
@@ -150,13 +139,11 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"fixPaths": [fix_path],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-is_rw_mount_init(mount, start_of_path, i, k) = fix_path {
+is_rw_mount_init(mount, start_of_path, i, k) := fix_path if {
 	not mount.readOnly == true
-	fix_path = {"path": sprintf("%vinitContainers[%v].volumeMounts[%v].readOnly", [start_of_path, i, k]), "value":"true"}
+	fix_path = {"path": sprintf("%vinitContainers[%v].volumeMounts[%v].readOnly", [start_of_path, i, k]), "value": "true"}
 }

--- a/rules/alert-rw-hostpath/raw.rego
+++ b/rules/alert-rw-hostpath/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -5,6 +6,7 @@ import rego.v1
 # Fails if container has a hostPath volume which is not readOnly
 
 deny contains msga if {
+	start_of_path := "spec."
 	pod := input[_]
 	pod.kind == "Pod"
 	volumes := pod.spec.volumes
@@ -13,9 +15,7 @@ deny contains msga if {
 	container := pod.spec.containers[i]
 	volume_mount := container.volumeMounts[k]
 	volume_mount.name == volume.name
-	start_of_path := "spec."
 	fix_path := is_rw_mount(volume_mount, start_of_path, i, k)
-
 	podname := pod.metadata.name
 
 	msga := {
@@ -29,8 +29,9 @@ deny contains msga if {
 
 # handles majority of workload resources
 deny contains msga if {
-	wl := input[_]
+	start_of_path := "spec.template.spec."
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	volumes := wl.spec.template.spec.volumes
 	volume := volumes[_]
@@ -38,7 +39,6 @@ deny contains msga if {
 	container := wl.spec.template.spec.containers[i]
 	volume_mount := container.volumeMounts[k]
 	volume_mount.name == volume.name
-	start_of_path := "spec.template.spec."
 	fix_path := is_rw_mount(volume_mount, start_of_path, i, k)
 
 	msga := {
@@ -52,6 +52,7 @@ deny contains msga if {
 
 # handles CronJobs
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
 	volumes := wl.spec.jobTemplate.spec.template.spec.volumes
@@ -61,7 +62,6 @@ deny contains msga if {
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 	volume_mount := container.volumeMounts[k]
 	volume_mount.name == volume.name
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	fix_path := is_rw_mount(volume_mount, start_of_path, i, k)
 
 	msga := {
@@ -73,13 +73,9 @@ deny contains msga if {
 	}
 }
 
-is_rw_mount(mount, start_of_path, i, k) := fix_path if {
-	not mount.readOnly == true
-	fix_path = {"path": sprintf("%vcontainers[%v].volumeMounts[%v].readOnly", [start_of_path, i, k]), "value": "true"}
-}
-
 # handles initContainers for Pod
 deny contains msga if {
+	start_of_path := "spec."
 	pod := input[_]
 	pod.kind == "Pod"
 	volumes := pod.spec.volumes
@@ -88,7 +84,6 @@ deny contains msga if {
 	container := pod.spec.initContainers[i]
 	volume_mount := container.volumeMounts[k]
 	volume_mount.name == volume.name
-	start_of_path := "spec."
 	fix_path := is_rw_mount_init(volume_mount, start_of_path, i, k)
 	podname := pod.metadata.name
 	msga := {
@@ -102,8 +97,9 @@ deny contains msga if {
 
 # handles initContainers for majority of workload resources
 deny contains msga if {
-	wl := input[_]
+	start_of_path := "spec.template.spec."
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	volumes := wl.spec.template.spec.volumes
 	volume := volumes[_]
@@ -111,7 +107,6 @@ deny contains msga if {
 	container := wl.spec.template.spec.initContainers[i]
 	volume_mount := container.volumeMounts[k]
 	volume_mount.name == volume.name
-	start_of_path := "spec.template.spec."
 	fix_path := is_rw_mount_init(volume_mount, start_of_path, i, k)
 	msga := {
 		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
@@ -124,6 +119,7 @@ deny contains msga if {
 
 # handles initContainers for CronJobs
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
 	volumes := wl.spec.jobTemplate.spec.template.spec.volumes
@@ -132,7 +128,6 @@ deny contains msga if {
 	container = wl.spec.jobTemplate.spec.template.spec.initContainers[i]
 	volume_mount := container.volumeMounts[k]
 	volume_mount.name == volume.name
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	fix_path := is_rw_mount_init(volume_mount, start_of_path, i, k)
 	msga := {
 		"alertMessage": sprintf("%v: %v has: %v as hostPath volume", [wl.kind, wl.metadata.name, volume.name]),
@@ -141,6 +136,11 @@ deny contains msga if {
 		"fixPaths": [fix_path],
 		"alertObject": {"k8sApiObjects": [wl]},
 	}
+}
+
+is_rw_mount(mount, start_of_path, i, k) := fix_path if {
+	not mount.readOnly == true
+	fix_path = {"path": sprintf("%vcontainers[%v].volumeMounts[%v].readOnly", [start_of_path, i, k]), "value": "true"}
 }
 
 is_rw_mount_init(mount, start_of_path, i, k) := fix_path if {

--- a/rules/anonymous-access-enabled/raw.rego
+++ b/rules/anonymous-access-enabled/raw.rego
@@ -1,29 +1,28 @@
 package armo_builtins
 
+import rego.v1
+
 # Fails is rolebinding/clusterrolebinding gives permissions to anonymous user
-deny[msga] {
-    rolebindings := [rolebinding | rolebinding = input[_]; endswith(rolebinding.kind, "Binding")]
-    rolebinding := rolebindings[_]
-    subject := rolebinding.subjects[i]
-    isAnonymous(subject)
-    delete_path := sprintf("subjects[%d]", [i])
-    msga := {
-        "alertMessage": sprintf("the following RoleBinding: %v gives permissions to anonymous users", [rolebinding.metadata.name]),
-        "alertScore": 9,
-        "deletePaths": [delete_path],
-        "failedPaths": [delete_path],
-        "packagename": "armo_builtins",
-        "alertObject": {
-            "k8sApiObjects": [rolebinding]
-        }
-    }
+deny contains msga if {
+	rolebindings := [rolebinding | rolebinding = input[_]; endswith(rolebinding.kind, "Binding")]
+	rolebinding := rolebindings[_]
+	subject := rolebinding.subjects[i]
+	isAnonymous(subject)
+	delete_path := sprintf("subjects[%d]", [i])
+	msga := {
+		"alertMessage": sprintf("the following RoleBinding: %v gives permissions to anonymous users", [rolebinding.metadata.name]),
+		"alertScore": 9,
+		"deletePaths": [delete_path],
+		"failedPaths": [delete_path],
+		"packagename": "armo_builtins",
+		"alertObject": {"k8sApiObjects": [rolebinding]},
+	}
 }
 
-
-isAnonymous(subject) {
-    subject.name == "system:anonymous"
+isAnonymous(subject) if {
+	subject.name == "system:anonymous"
 }
 
-isAnonymous(subject) {
-    subject.name == "system:unauthenticated"
+isAnonymous(subject) if {
+	subject.name == "system:unauthenticated"
 }

--- a/rules/anonymous-access-enabled/raw.rego
+++ b/rules/anonymous-access-enabled/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/anonymous-requests-to-kubelet-updated/raw.rego
+++ b/rules/anonymous-requests-to-kubelet-updated/raw.rego
@@ -1,8 +1,10 @@
 package armo_builtins
 
+import rego.v1
+
 # CIS 4.2.1 https://workbench.cisecurity.org/sections/1126668/recommendations/1838638
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 	command := obj.data.cmdLine
@@ -22,8 +24,7 @@ deny[msga] {
 	}
 }
 
-
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 	command := obj.data.cmdLine
@@ -52,7 +53,7 @@ deny[msga] {
 }
 
 ## Host sensor failed to get config file content
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -77,7 +78,7 @@ deny[msga] {
 	}
 }
 
-is_kubelet_info(obj) {
+is_kubelet_info(obj) if {
 	obj.kind == "KubeletInfo"
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 }

--- a/rules/anonymous-requests-to-kubelet-updated/raw.rego
+++ b/rules/anonymous-requests-to-kubelet-updated/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/audit-policy-content/raw.rego
+++ b/rules/audit-policy-content/raw.rego
@@ -1,11 +1,10 @@
 package armo_builtins
 
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 # CIS 3.2.2 https://workbench.cisecurity.org/sections/1126657/recommendations/1838583
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_api_server_info(obj)
 	api_server_info := obj.data.APIServerInfo
@@ -27,7 +26,7 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_api_server_info(obj)
 
@@ -140,7 +139,7 @@ is_rule_concering_seeked_resource(rule, seeked_resource) if {
 validate_rule_audit_level(rule, value_of_seeked_resource) := result if {
 	value_of_seeked_resource.mode == "equal"
 	result := rule.level == value_of_seeked_resource.auditLevel
-} else := result {
+} else := result if {
 	result := rule.level != value_of_seeked_resource.auditLevel
 }
 

--- a/rules/audit-policy-content/raw.rego
+++ b/rules/audit-policy-content/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/automount-default-service-account/filter.rego
+++ b/rules/automount-default-service-account/filter.rego
@@ -1,19 +1,19 @@
 package armo_builtins
 
+import rego.v1
+
 # Fails if user account mount tokens in pod by default
-deny [msga]{
-    service_accounts := [service_account |  service_account= input[_]; service_account.kind == "ServiceAccount"]
-    service_account := service_accounts[_]
+deny contains msga if {
+	service_accounts := [service_account | service_account = input[_]; service_account.kind == "ServiceAccount"]
+	service_account := service_accounts[_]
 	service_account.metadata.name == "default"
 
-    msga := {
-	    "alertMessage": sprintf("the following service account: %v in the following namespace: %v mounts service account tokens in pods by default", [service_account.metadata.name, service_account.metadata.namespace]),
+	msga := {
+		"alertMessage": sprintf("the following service account: %v in the following namespace: %v mounts service account tokens in pods by default", [service_account.metadata.name, service_account.metadata.namespace]),
 		"alertScore": 9,
 		"packagename": "armo_builtins",
 		"fixPaths": [],
 		"failedPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [service_account]
-		}
+		"alertObject": {"k8sApiObjects": [service_account]},
 	}
-}    
+}

--- a/rules/automount-default-service-account/filter.rego
+++ b/rules/automount-default-service-account/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/automount-default-service-account/raw.rego
+++ b/rules/automount-default-service-account/raw.rego
@@ -1,47 +1,43 @@
 package armo_builtins
 
-# Fails if user account mount tokens in pod by default
-deny [msga]{
-    service_accounts := [service_account |  service_account= input[_]; service_account.kind == "ServiceAccount"]
-    service_account := service_accounts[_]
-	service_account.metadata.name == "default"
-    result := is_auto_mount(service_account)
-	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+import rego.v1
 
-    msga := {
-	    "alertMessage": sprintf("the following service account: %v in the following namespace: %v mounts service account tokens in pods by default", [service_account.metadata.name, service_account.metadata.namespace]),
+# Fails if user account mount tokens in pod by default
+deny contains msga if {
+	service_accounts := [service_account | service_account = input[_]; service_account.kind == "ServiceAccount"]
+	service_account := service_accounts[_]
+	service_account.metadata.name == "default"
+	result := is_auto_mount(service_account)
+	failed_path := get_failed_path(result)
+	fixed_path := get_fixed_path(result)
+
+	msga := {
+		"alertMessage": sprintf("the following service account: %v in the following namespace: %v mounts service account tokens in pods by default", [service_account.metadata.name, service_account.metadata.namespace]),
 		"alertScore": 9,
 		"packagename": "armo_builtins",
 		"fixPaths": fixed_path,
 		"deletePaths": failed_path,
 		"failedPaths": failed_path,
-		"alertObject": {
-			"k8sApiObjects": [service_account]
-		}
+		"alertObject": {"k8sApiObjects": [service_account]},
 	}
-}    
+}
 
-
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
+} else := []
 
-
-
- #  -- ----     For SAs     -- ----     
-is_auto_mount(service_account)  =  [failed_path, fix_path]  {
+#  -- ----     For SAs     -- ----
+is_auto_mount(service_account) := [failed_path, fix_path] if {
 	service_account.automountServiceAccountToken == true
 	failed_path = "automountServiceAccountToken"
 	fix_path = ""
 }
 
-is_auto_mount(service_account)=  [failed_path, fix_path]  {
+is_auto_mount(service_account) := [failed_path, fix_path] if {
 	not service_account.automountServiceAccountToken == false
 	not service_account.automountServiceAccountToken == true
 	fix_path = {"path": "automountServiceAccountToken", "value": "false"}

--- a/rules/automount-default-service-account/raw.rego
+++ b/rules/automount-default-service-account/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/automount-service-account/raw.rego
+++ b/rules/automount-service-account/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -9,10 +10,10 @@ import rego.v1
 
 # POD
 deny contains msga if {
+	start_of_path := "spec."
 	pod := input[_]
 	pod.kind == "Pod"
 
-	start_of_path := "spec."
 	wl_namespace := pod_namespace(pod)
 	result := is_sa_auto_mounted(pod.spec, start_of_path, wl_namespace)
 	failed_path := get_failed_path(result)
@@ -30,11 +31,11 @@ deny contains msga if {
 
 # WORKLOADS: Deployment / ReplicaSet / DaemonSet / StatefulSet / Job
 deny contains msga if {
-	wl := input[_]
+	start_of_path := "spec.template.spec."
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 
-	start_of_path := "spec.template.spec."
 	wl_namespace := pod_namespace(wl)
 	result := is_sa_auto_mounted(wl.spec.template.spec, start_of_path, wl_namespace)
 	failed_path := get_failed_path(result)
@@ -52,10 +53,10 @@ deny contains msga if {
 
 # CRONJOB
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
 
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl_namespace := pod_namespace(wl)
 	result := is_sa_auto_mounted(wl.spec.jobTemplate.spec.template.spec, start_of_path, wl_namespace)
 	failed_path := get_failed_path(result)
@@ -88,6 +89,8 @@ is_sa_auto_mounted(spec, start_of_path, wl_namespace) := [failed_path, fix_path]
 # referenced SA exists and does not explicitly disable auto-mount. Token
 # will mount by default. Fix by setting pod-level to false.
 is_sa_auto_mounted(spec, start_of_path, wl_namespace) := [failed_path, fix_path] if {
+	failed_path := ""
+	fix_path := {"path": sprintf("%vautomountServiceAccountToken", [start_of_path]), "value": "false"}
 	not spec.automountServiceAccountToken == false
 	not spec.automountServiceAccountToken == true
 
@@ -97,8 +100,6 @@ is_sa_auto_mounted(spec, start_of_path, wl_namespace) := [failed_path, fix_path]
 	is_same_namespace(sa.metadata.namespace, wl_namespace)
 	not sa.automountServiceAccountToken == false
 
-	fix_path := {"path": sprintf("%vautomountServiceAccountToken", [start_of_path]), "value": "false"}
-	failed_path := ""
 }
 
 # Branch 3: pod spec does not set automountServiceAccountToken, and no

--- a/rules/automount-service-account/raw.rego
+++ b/rules/automount-service-account/raw.rego
@@ -1,13 +1,14 @@
 package armo_builtins
 
+import rego.v1
+
 # This rule honours Kubernetes precedence: pod.spec.automountServiceAccountToken
 # overrides serviceAccount.automountServiceAccountToken. It alerts only on
 # workloads that will actually mount a token (pod-level true, or pod-level
 # unset with an SA that does not explicitly disable).
 
-
 # POD
-deny[msga] {
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 
@@ -28,7 +29,7 @@ deny[msga] {
 }
 
 # WORKLOADS: Deployment / ReplicaSet / DaemonSet / StatefulSet / Job
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
@@ -50,7 +51,7 @@ deny[msga] {
 }
 
 # CRONJOB
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 
@@ -70,14 +71,13 @@ deny[msga] {
 	}
 }
 
-
 # ----- decision helpers -----
 
 # Branch 1: pod spec explicitly sets automountServiceAccountToken: true.
 # Pod-level wins over SA, so this always mounts. Fix by setting the pod
 # field to false - deleting it is unsafe because it falls back to the SA,
 # which may also enable auto-mount.
-is_sa_auto_mounted(spec, start_of_path, wl_namespace) = [failed_path, fix_path] {
+is_sa_auto_mounted(spec, start_of_path, wl_namespace) := [failed_path, fix_path] if {
 	spec.automountServiceAccountToken == true
 
 	failed_path := sprintf("%vautomountServiceAccountToken", [start_of_path])
@@ -87,7 +87,7 @@ is_sa_auto_mounted(spec, start_of_path, wl_namespace) = [failed_path, fix_path] 
 # Branch 2: pod spec does not set automountServiceAccountToken, and the
 # referenced SA exists and does not explicitly disable auto-mount. Token
 # will mount by default. Fix by setting pod-level to false.
-is_sa_auto_mounted(spec, start_of_path, wl_namespace) = [failed_path, fix_path] {
+is_sa_auto_mounted(spec, start_of_path, wl_namespace) := [failed_path, fix_path] if {
 	not spec.automountServiceAccountToken == false
 	not spec.automountServiceAccountToken == true
 
@@ -104,7 +104,7 @@ is_sa_auto_mounted(spec, start_of_path, wl_namespace) = [failed_path, fix_path] 
 # Branch 3: pod spec does not set automountServiceAccountToken, and no
 # matching SA is in the input (YAML scan, or SA not scanned). Kubernetes
 # default is to mount, so flag it.
-is_sa_auto_mounted(spec, start_of_path, wl_namespace) = [failed_path, fix_path] {
+is_sa_auto_mounted(spec, start_of_path, wl_namespace) := [failed_path, fix_path] if {
 	not spec.automountServiceAccountToken == false
 	not spec.automountServiceAccountToken == true
 
@@ -117,51 +117,46 @@ is_sa_auto_mounted(spec, start_of_path, wl_namespace) = [failed_path, fix_path] 
 # No branch when spec.automountServiceAccountToken == false: pod-level
 # disable wins over any SA setting, so no deny.
 
-
-matching_sa_exists(spec, wl_namespace) {
+matching_sa_exists(spec, wl_namespace) if {
 	sa := input[_]
 	sa.kind == "ServiceAccount"
 	is_same_sa(spec, sa.metadata.name)
 	is_same_namespace(sa.metadata.namespace, wl_namespace)
 }
 
-
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
+} else := []
 
 # ----- matching helpers -----
 
-pod_namespace(obj) = ns {
+pod_namespace(obj) := ns if {
 	ns := obj.metadata.namespace
-} else = "default" {
-	true
-}
+} else := "default"
 
-is_same_sa(spec, serviceAccountName) {
+is_same_sa(spec, serviceAccountName) if {
 	spec.serviceAccountName == serviceAccountName
 }
 
-is_same_sa(spec, serviceAccountName) {
+is_same_sa(spec, serviceAccountName) if {
 	not spec.serviceAccountName
 	serviceAccountName == "default"
 }
 
-is_same_namespace(ns1, ns2) {
+is_same_namespace(ns1, ns2) if {
 	ns1 == ns2
 }
 
-is_same_namespace(ns1, ns2) {
+is_same_namespace(ns1, ns2) if {
 	not ns1
 	ns2 == "default"
 }
 
-is_same_namespace(ns1, ns2) {
+is_same_namespace(ns1, ns2) if {
 	not ns2
 	ns1 == "default"
 }

--- a/rules/cluster-access-manager-api-eks/raw.rego
+++ b/rules/cluster-access-manager-api-eks/raw.rego
@@ -1,15 +1,15 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
-# check if the EKS cluster is configured with the Cluster Access Manager API 
+# check if the EKS cluster is configured with the Cluster Access Manager API
 # by checking in the ClusterDescribe resource if accessConfig.AuthenticationMode is set to 'CONFIG_MAP'
 # If "authenticationmode": "API" or "authenticationmode": "API_AND_CONFIG_MAP", it means the Cluster Access Manager API is enabled.
-deny[msga] {
+deny contains msga if {
 	cluster_config := input[_]
 	cluster_config.apiVersion == "eks.amazonaws.com/v1"
 	cluster_config.kind == "ClusterDescribe"
-    cluster_config.metadata.provider == "eks"
+	cluster_config.metadata.provider == "eks"
 	config := cluster_config.data
 
 	config.Cluster.AccessConfig.AuthenticationMode == "CONFIG_MAP"
@@ -22,7 +22,7 @@ deny[msga] {
 		"fixPaths": [],
 		"alertObject": {
 			"k8sApiObjects": [],
-            "externalObjects": cluster_config
-		}
+			"externalObjects": cluster_config,
+		},
 	}
 }

--- a/rules/cluster-access-manager-api-eks/raw.rego
+++ b/rules/cluster-access-manager-api-eks/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/cluster-admin-role/raw.rego
+++ b/rules/cluster-admin-role/raw.rego
@@ -1,10 +1,10 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # returns subjects with cluster admin role
 # regal ignore:rule-length
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 
 	role := subjectVector.relatedObjects[i]
@@ -57,14 +57,14 @@ deny[msga] {
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/cluster-admin-role/raw.rego
+++ b/rules/cluster-admin-role/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -5,6 +6,9 @@ import rego.v1
 # returns subjects with cluster admin role
 # regal ignore:rule-length
 deny contains msga if {
+	verbs := ["*"]
+	resources := ["*"]
+	api_groups := ["*", ""]
 	subjectVector := input[_]
 
 	role := subjectVector.relatedObjects[i]
@@ -23,15 +27,12 @@ deny contains msga if {
 
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["*", ""]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/configmap-in-default-namespace/raw.rego
+++ b/rules/configmap-in-default-namespace/raw.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -12,30 +14,26 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
-
+} else := []

--- a/rules/configmap-in-default-namespace/raw.rego
+++ b/rules/configmap-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/configured-liveness-probe/raw.rego
+++ b/rules/configured-liveness-probe/raw.rego
@@ -1,60 +1,55 @@
 package armo_builtins
 
+import rego.v1
 
 # Fails if  container does not have livenessProbe - for pod
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
-    container := pod.spec.containers[i]
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.containers[i]
 	not container.livenessProbe
 	fix_path := {"path": sprintf("spec.containers[%v].livenessProbe", [format_int(i, 10)]), "value": "YOUR_VALUE"}
 	msga := {
-		"alertMessage": sprintf("Container: %v does not have livenessProbe", [ container.name]),
+		"alertMessage": sprintf("Container: %v does not have livenessProbe", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 4,
 		"fixPaths": [fix_path],
 		"failedPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # Fails if  container does not have livenessProbe - for wl
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
-    not container.livenessProbe
+	container := wl.spec.template.spec.containers[i]
+	not container.livenessProbe
 	fix_path := {"path": sprintf("spec.template.spec.containers[%v].livenessProbe", [format_int(i, 10)]), "value": "YOUR_VALUE"}
 	msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   does not have livenessProbe", [ container.name, wl.kind, wl.metadata.name]),
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have livenessProbe", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 4,
 		"fixPaths": [fix_path],
 		"failedPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if  container does not have livenessProbe - for cronjob
-deny[msga] {
-  	wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-    not container.livenessProbe
+	not container.livenessProbe
 	fix_path := {"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].livenessProbe", [format_int(i, 10)]), "value": "YOUR_VALUE"}
-    msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   does not have livenessProbe", [ container.name, wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have livenessProbe", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 4,
 		"fixPaths": [fix_path],
 		"failedPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }

--- a/rules/configured-liveness-probe/raw.rego
+++ b/rules/configured-liveness-probe/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -21,8 +22,8 @@ deny contains msga if {
 
 # Fails if  container does not have livenessProbe - for wl
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	not container.livenessProbe

--- a/rules/configured-readiness-probe/raw.rego
+++ b/rules/configured-readiness-probe/raw.rego
@@ -1,60 +1,55 @@
 package armo_builtins
 
+import rego.v1
 
 # Fails if pod does not have container with readinessProbe
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
-    container := pod.spec.containers[i]
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.containers[i]
 	not container.readinessProbe
 	fix_path := {"path": sprintf("spec.containers[%v].readinessProbe", [format_int(i, 10)]), "value": "YOUR_VALUE"}
 	msga := {
-		"alertMessage": sprintf("Container: %v does not have readinessProbe", [ container.name]),
+		"alertMessage": sprintf("Container: %v does not have readinessProbe", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 3,
 		"fixPaths": [fix_path],
 		"failedPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # Fails if workload does not have container with readinessProbe
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
-    not container.readinessProbe
+	container := wl.spec.template.spec.containers[i]
+	not container.readinessProbe
 	fix_path := {"path": sprintf("spec.template.spec.containers[%v].readinessProbe", [format_int(i, 10)]), "value": "YOUR_VALUE"}
 	msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   does not have readinessProbe", [ container.name, wl.kind, wl.metadata.name]),
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have readinessProbe", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 3,
 		"fixPaths": [fix_path],
 		"failedPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if cronjob does not have container with readinessProbe
-deny[msga] {
-  	wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-    not container.readinessProbe
+	not container.readinessProbe
 	fix_path := {"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].readinessProbe", [format_int(i, 10)]), "value": "YOUR_VALUE"}
-    msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   does not have readinessProbe", [ container.name, wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have readinessProbe", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 3,
 		"fixPaths": [fix_path],
 		"failedPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }

--- a/rules/configured-readiness-probe/raw.rego
+++ b/rules/configured-readiness-probe/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -21,8 +22,8 @@ deny contains msga if {
 
 # Fails if workload does not have container with readinessProbe
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	not container.readinessProbe

--- a/rules/container-hostPort/raw.rego
+++ b/rules/container-hostPort/raw.rego
@@ -1,70 +1,63 @@
 package armo_builtins
 
+import rego.v1
 
 # Fails if pod has container with hostPort
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
-    container := pod.spec.containers[i]
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.containers[i]
 	start_of_path := "spec."
 	path := is_host_port(container, i, start_of_path)
 	msga := {
-		"alertMessage": sprintf("Container: %v has Host-port", [ container.name]),
+		"alertMessage": sprintf("Container: %v has Host-port", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 4,
 		"deletePaths": path,
 		"failedPaths": path,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # Fails if workload has container with hostPort
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
+	container := wl.spec.template.spec.containers[i]
 	start_of_path := "spec.template.spec."
-    path := is_host_port(container, i, start_of_path)
+	path := is_host_port(container, i, start_of_path)
 	msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   has Host-port", [ container.name, wl.kind, wl.metadata.name]),
+		"alertMessage": sprintf("Container: %v in %v: %v   has Host-port", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 4,
 		"deletePaths": path,
 		"failedPaths": path,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if cronjob has container with hostPort
-deny[msga] {
-  	wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 	start_of_path := "spec.jobTemplate.spec.template.spec."
-    path := is_host_port(container, i, start_of_path)
-    msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   has Host-port", [ container.name, wl.kind, wl.metadata.name]),
+	path := is_host_port(container, i, start_of_path)
+	msga := {
+		"alertMessage": sprintf("Container: %v in %v: %v   has Host-port", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 4,
 		"deletePaths": path,
 		"failedPaths": path,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
-
-is_host_port(container, i, start_of_path) = path {
-	path = [sprintf("%vcontainers[%v].ports[%v].hostPort", [start_of_path, format_int(i, 10), format_int(j, 10)]) | port = container.ports[j];  port.hostPort]
+is_host_port(container, i, start_of_path) := path if {
+	path = [sprintf("%vcontainers[%v].ports[%v].hostPort", [start_of_path, format_int(i, 10), format_int(j, 10)]) | port = container.ports[j]; port.hostPort]
 	count(path) > 0
 }

--- a/rules/container-hostPort/raw.rego
+++ b/rules/container-hostPort/raw.rego
@@ -1,13 +1,14 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 # Fails if pod has container with hostPort
 deny contains msga if {
+	start_of_path := "spec."
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
-	start_of_path := "spec."
 	path := is_host_port(container, i, start_of_path)
 	msga := {
 		"alertMessage": sprintf("Container: %v has Host-port", [container.name]),
@@ -22,11 +23,11 @@ deny contains msga if {
 
 # Fails if workload has container with hostPort
 deny contains msga if {
-	wl := input[_]
+	start_of_path := "spec.template.spec."
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
-	start_of_path := "spec.template.spec."
 	path := is_host_port(container, i, start_of_path)
 	msga := {
 		"alertMessage": sprintf("Container: %v in %v: %v   has Host-port", [container.name, wl.kind, wl.metadata.name]),
@@ -41,10 +42,10 @@ deny contains msga if {
 
 # Fails if cronjob has container with hostPort
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	path := is_host_port(container, i, start_of_path)
 	msga := {
 		"alertMessage": sprintf("Container: %v in %v: %v   has Host-port", [container.name, wl.kind, wl.metadata.name]),

--- a/rules/container-image-repository-v1/raw.rego
+++ b/rules/container-image-repository-v1/raw.rego
@@ -1,6 +1,8 @@
 package armo_builtins
 
-untrustedImageRepo[msga] {
+import rego.v1
+
+untrustedImageRepo contains msga if {
 	wl := input[_]
 	containers_path := get_containers_path(wl)
 	containers := object.get(wl, containers_path, [])
@@ -21,7 +23,7 @@ untrustedImageRepo[msga] {
 }
 
 # image_in_allowed_list - rule to check if an image complies with imageRepositoryAllowList.
-image_in_allowed_list(image){
+image_in_allowed_list(image) if {
 	# see default-config-inputs.json for list values
 	allowedlist := data.postureControlInputs.imageRepositoryAllowList
 	registry := allowedlist[_]
@@ -29,20 +31,20 @@ image_in_allowed_list(image){
 }
 
 # get_containers_path - get resource containers paths for  {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-get_containers_path(resource) := result {
+get_containers_path(resource) := result if {
 	resource_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	resource_kinds[resource.kind]
 	result = ["spec", "template", "spec", "containers"]
 }
 
 # get_containers_path - get resource containers paths for "Pod"
-get_containers_path(resource) := result {
+get_containers_path(resource) := result if {
 	resource.kind == "Pod"
 	result = ["spec", "containers"]
 }
 
 # get_containers_path - get resource containers paths for  "CronJob"
-get_containers_path(resource) := result {
+get_containers_path(resource) := result if {
 	resource.kind == "CronJob"
 	result = ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
 }

--- a/rules/container-image-repository-v1/raw.rego
+++ b/rules/container-image-repository-v1/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/container-image-repository/raw.rego
+++ b/rules/container-image-repository/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.if
+import rego.v1
 
-untrusted_image_repo[msga] {
+untrusted_image_repo contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
@@ -13,69 +13,61 @@ untrusted_image_repo[msga] {
 	msga := {
 		"alertMessage": sprintf("image '%v' in container '%s' comes from untrusted registry", [image, container.name]),
 		"alertScore": 2,
-        "packagename": "armo_builtins",
+		"packagename": "armo_builtins",
 		"reviewPaths": [path],
 		"failedPaths": [path],
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-untrusted_image_repo[msga] {
+untrusted_image_repo contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	image := container.image
-    not image_in_allowed_list(image)
+	not image_in_allowed_list(image)
 
 	path := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])
 	msga := {
 		"alertMessage": sprintf("image '%v' in container '%s' comes from untrusted registry", [image, container.name]),
 		"alertScore": 2,
-        "packagename": "armo_builtins",
+		"packagename": "armo_builtins",
 		"reviewPaths": [path],
 		"failedPaths": [path],
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-untrusted_image_repo[msga] {
+untrusted_image_repo contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
 	image := container.image
-    not image_in_allowed_list(image)
+	not image_in_allowed_list(image)
 
 	path := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].image", [format_int(i, 10)])
 	msga := {
 		"alertMessage": sprintf("image '%v' in container '%s' comes from untrusted registry", [image, container.name]),
 		"alertScore": 2,
-        "packagename": "armo_builtins",
+		"packagename": "armo_builtins",
 		"reviewPaths": [path],
 		"failedPaths": [path],
-		"fixPaths":[],
-			"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # image_in_allowed_list - rule to check if an image complies with imageRepositoryAllowList.
-image_in_allowed_list(image){
-
+image_in_allowed_list(image) if {
 	# see default-config-inputs.json for list values
 	allowedlist := data.postureControlInputs.imageRepositoryAllowList
 	registry := allowedlist[_]
 
 	regex.match(regexify(registry), docker_host_wrapper(image))
 }
-
 
 # docker_host_wrapper - wrap an image without a host with a docker hub host 'docker.io'.
 # An image that doesn't contain '/' is assumed to not having a host and therefore associated with docker hub.
@@ -84,9 +76,8 @@ docker_host_wrapper(image) := result if {
 	result := sprintf("docker.io/%s", [image])
 } else := image
 
-
 # regexify - returns a registry regex to be searched only for the image host.
-regexify(registry) := result {
+regexify(registry) := result if {
 	endswith(registry, "/")
 	result = sprintf("^%s.*$", [registry])
 } else := sprintf("^%s\/.*$", [registry])

--- a/rules/container-image-repository/raw.rego
+++ b/rules/container-image-repository/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -22,8 +23,8 @@ untrusted_image_repo contains msga if {
 }
 
 untrusted_image_repo contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	image := container.image

--- a/rules/containers-mounting-docker-socket/raw.rego
+++ b/rules/containers-mounting-docker-socket/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -24,8 +25,8 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	volume := wl.spec.template.spec.volumes[i]
 	host_path := volume.hostPath
@@ -66,27 +67,6 @@ deny contains msga if {
 	}
 }
 
-volume_mounts(name, volume_mounts, str) := [path] if {
-	name == volume_mounts[j].name
-	path := sprintf("%s.volumeMounts[%v]", [str, j])
-} else := []
-
-is_runtime_socket_mounting(host_path) if {
-	host_path.path == "/var/run/docker.sock"
-}
-
-is_runtime_socket_mounting(host_path) if {
-	host_path.path == "/var/run/docker"
-}
-
-is_runtime_socket_mounting(host_path) if {
-	host_path.path == "/run/containerd/containerd.sock"
-}
-
-is_runtime_socket_mounting(host_path) if {
-	host_path.path == "/var/run/crio/crio.sock"
-}
-
 # handles initContainers for Pod
 deny contains msga if {
 	pod := input[_]
@@ -111,8 +91,8 @@ deny contains msga if {
 
 # handles initContainers for majority of workload resources
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	volume := wl.spec.template.spec.volumes[i]
 	host_path := volume.hostPath
@@ -152,4 +132,25 @@ deny contains msga if {
 		"alertScore": 5,
 		"alertObject": {"k8sApiObjects": [wl]},
 	}
+}
+
+volume_mounts(name, volume_mounts, str) := [path] if {
+	name == volume_mounts[j].name
+	path := sprintf("%s.volumeMounts[%v]", [str, j])
+} else := []
+
+is_runtime_socket_mounting(host_path) if {
+	host_path.path == "/var/run/docker.sock"
+}
+
+is_runtime_socket_mounting(host_path) if {
+	host_path.path == "/var/run/docker"
+}
+
+is_runtime_socket_mounting(host_path) if {
+	host_path.path == "/run/containerd/containerd.sock"
+}
+
+is_runtime_socket_mounting(host_path) if {
+	host_path.path == "/var/run/crio/crio.sock"
 }

--- a/rules/containers-mounting-docker-socket/raw.rego
+++ b/rules/containers-mounting-docker-socket/raw.rego
@@ -1,102 +1,94 @@
 package armo_builtins
 
+import rego.v1
 
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
-    volume := pod.spec.volumes[i]
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	volume := pod.spec.volumes[i]
 	host_path := volume.hostPath
-    is_runtime_socket_mounting(host_path)
+	is_runtime_socket_mounting(host_path)
 	path := sprintf("spec.volumes[%v]", [format_int(i, 10)])
 	volumeMounts := pod.spec.containers[j].volumeMounts
 	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.containers[%v]", [j]))
 	finalPath := array.concat([path], pathMounts)
-    msga := {
+	msga := {
 		"alertMessage": sprintf("volume: %v in pod: %v has mounting to Docker internals.", [volume.name, pod.metadata.name]),
 		"packagename": "armo_builtins",
-		"deletePaths":finalPath,
+		"deletePaths": finalPath,
 		"failedPaths": finalPath,
-		"fixPaths":[],
+		"fixPaths": [],
 		"alertScore": 5,
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
-	}	
+		"alertObject": {"k8sApiObjects": [pod]},
+	}
 }
 
-
-
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    volume := wl.spec.template.spec.volumes[i]
+	volume := wl.spec.template.spec.volumes[i]
 	host_path := volume.hostPath
-    is_runtime_socket_mounting(host_path)
+	is_runtime_socket_mounting(host_path)
 	path := sprintf("spec.template.spec.volumes[%v]", [format_int(i, 10)])
 	volumeMounts := wl.spec.template.spec.containers[j].volumeMounts
-	pathMounts = volume_mounts(volume.name,volumeMounts, sprintf("spec.template.spec.containers[%v]", [j]))
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.template.spec.containers[%v]", [j]))
 	finalPath := array.concat([path], pathMounts)
 	msga := {
-		"alertMessage": sprintf("volume: %v in %v: %v has mounting to Docker internals.", [ volume.name, wl.kind, wl.metadata.name]),
+		"alertMessage": sprintf("volume: %v in %v: %v has mounting to Docker internals.", [volume.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"deletePaths": finalPath,
 		"failedPaths": finalPath,
-		"fixPaths":[],
+		"fixPaths": [],
 		"alertScore": 5,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
-deny[msga] {
-  	wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
 	volume = wl.spec.jobTemplate.spec.template.spec.volumes[i]
-    host_path := volume.hostPath
-    is_runtime_socket_mounting(host_path)
+	host_path := volume.hostPath
+	is_runtime_socket_mounting(host_path)
 	path := sprintf("spec.jobTemplate.spec.template.spec.volumes[%v]", [format_int(i, 10)])
 	volumeMounts := wl.spec.jobTemplate.spec.template.spec.containers[j].volumeMounts
-	pathMounts = volume_mounts(volume.name,volumeMounts, sprintf("spec.jobTemplate.spec.template.spec.containers[%v]", [j]))
+	pathMounts = volume_mounts(volume.name, volumeMounts, sprintf("spec.jobTemplate.spec.template.spec.containers[%v]", [j]))
 	finalPath := array.concat([path], pathMounts)
-    msga := {
-		"alertMessage": sprintf("volume: %v in %v: %v has mounting to Docker internals.", [ volume.name, wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("volume: %v in %v: %v has mounting to Docker internals.", [volume.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"deletePaths": finalPath,
 		"failedPaths": finalPath,
-		"fixPaths":[],
+		"fixPaths": [],
 		"alertScore": 5,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-volume_mounts(name, volume_mounts, str) = [path] {
+volume_mounts(name, volume_mounts, str) := [path] if {
 	name == volume_mounts[j].name
 	path := sprintf("%s.volumeMounts[%v]", [str, j])
-} else = []
+} else := []
 
-is_runtime_socket_mounting(host_path) {
+is_runtime_socket_mounting(host_path) if {
 	host_path.path == "/var/run/docker.sock"
 }
 
-is_runtime_socket_mounting(host_path) {
+is_runtime_socket_mounting(host_path) if {
 	host_path.path == "/var/run/docker"
 }
 
-is_runtime_socket_mounting(host_path) {
+is_runtime_socket_mounting(host_path) if {
 	host_path.path == "/run/containerd/containerd.sock"
 }
 
-is_runtime_socket_mounting(host_path) {
+is_runtime_socket_mounting(host_path) if {
 	host_path.path == "/var/run/crio/crio.sock"
 }
 
 # handles initContainers for Pod
-deny[msga] {
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	volume := pod.spec.volumes[i]
@@ -111,18 +103,16 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"deletePaths": finalPath,
 		"failedPaths": finalPath,
-		"fixPaths":[],
+		"fixPaths": [],
 		"alertScore": 5,
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # handles initContainers for majority of workload resources
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	volume := wl.spec.template.spec.volumes[i]
 	host_path := volume.hostPath
@@ -136,16 +126,14 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"deletePaths": finalPath,
 		"failedPaths": finalPath,
-		"fixPaths":[],
+		"fixPaths": [],
 		"alertScore": 5,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # handles initContainers for CronJobs
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	volume = wl.spec.jobTemplate.spec.template.spec.volumes[i]
@@ -160,10 +148,8 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"deletePaths": finalPath,
 		"failedPaths": finalPath,
-		"fixPaths":[],
+		"fixPaths": [],
 		"alertScore": 5,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }

--- a/rules/csistoragecapacity-in-default-namespace/raw.rego
+++ b/rules/csistoragecapacity-in-default-namespace/raw.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -12,30 +14,26 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
-
+} else := []

--- a/rules/csistoragecapacity-in-default-namespace/raw.rego
+++ b/rules/csistoragecapacity-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1


### PR DESCRIPTION
## Overview

This PR migrates the first batch of Rego rules to OPA v1 syntax.
## Additional Information
 This batch cover rules from `rules/access-container-service-account-v1` through `rules/CVE-2022-47633`

- [x] New and existing unit tests pass locally with my changes 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated numerous security policies to Rego v1 and a unified rule/head syntax.
  * Modernized helper/predicate forms and assignment style for consistency.
  * Normalized alert payload formatting (messages, paths, and object structures) for more consistent output.
  * Preserved existing detection logic and alert semantics while improving readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->