### PR TITLE
fix: migrate rego rules batch-6 to OPA v1

### DIFF
--- a/rules/exec-into-container-v1/raw.rego
+++ b/rules/exec-into-container-v1/raw.rego
@@ -1,11 +1,11 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # input: regoResponseVectorObject
 # returns subjects that can exec into container
 
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -53,14 +53,14 @@ deny[msga] {
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/exec-into-container-v1/raw.rego
+++ b/rules/exec-into-container-v1/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -6,6 +7,9 @@ import rego.v1
 # returns subjects that can exec into container
 
 deny contains msga if {
+	verbs := ["create", "*"]
+	api_groups := ["", "*"]
+	resources := ["pods/exec", "pods/*", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -19,15 +23,12 @@ deny contains msga if {
 
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["create", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["pods/exec", "pods/*", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/exposed-critical-pods/filter.rego
+++ b/rules/exposed-critical-pods/filter.rego
@@ -1,67 +1,67 @@
 package armo_builtins
 
+import rego.v1
+
 # regal ignore:rule-length
-deny[msga] {
-  services := [ x | x = input[_]; x.kind == "Service" ]
-  pods     := [ x | x = input[_]; x.kind == "Pod" ]
-  vulns    := [ x | x = input[_]; x.kind == "ImageVulnerabilities"]
+deny contains msga if {
+	services := [x | x = input[_]; x.kind == "Service"]
+	pods := [x | x = input[_]; x.kind == "Pod"]
+	vulns := [x | x = input[_]; x.kind == "ImageVulnerabilities"]
 
-  pod     := pods[_]
-  service := services[_]
-  vuln    := vulns[_]
+	pod := pods[_]
+	service := services[_]
+	vuln := vulns[_]
 
-  # vuln data is relevant
-  count(vuln.data) > 0
+	# vuln data is relevant
+	count(vuln.data) > 0
 
-  # service is external-facing
-  filter_external_access(service)
+	# service is external-facing
+	filter_external_access(service)
 
-  # pod has the current service
-  service_to_pod(service, pod) > 0
+	# pod has the current service
+	service_to_pod(service, pod) > 0
 
-  # get container image name
-  container := pod.spec.containers[i]
+	# get container image name
+	container := pod.spec.containers[i]
 
-  # image has vulnerabilities
-  container.image == vuln.metadata.name
+	# image has vulnerabilities
+	container.image == vuln.metadata.name
 
-  related_objects := [pod, vuln]
+	related_objects := [pod, vuln]
 
-  path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
+	path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
 
-  metadata = {
-    "name": pod.metadata.name,
-    "namespace": pod.metadata.namespace
-  }
+	metadata = {
+		"name": pod.metadata.name,
+		"namespace": pod.metadata.namespace,
+	}
 
-  external_objects = {
-    "apiVersion": "result.vulnscan.com/v1",
-    "kind": pod.kind,
-    "metadata": metadata,
-    "relatedObjects": related_objects
-  }
+	external_objects = {
+		"apiVersion": "result.vulnscan.com/v1",
+		"kind": pod.kind,
+		"metadata": metadata,
+		"relatedObjects": related_objects,
+	}
 
-  msga := {
-    "alertMessage": sprintf("pod '%v' exposed with critical vulnerabilities", [pod.metadata.name]),
-    "packagename": "armo_builtins",
-    "alertScore": 7,
-   "failedPaths": [path],
-    "fixPaths": [],
-    "alertObject": {
-        "externalObjects": external_objects
-    }
-  }
+	msga := {
+		"alertMessage": sprintf("pod '%v' exposed with critical vulnerabilities", [pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [path],
+		"fixPaths": [],
+		"alertObject": {"externalObjects": external_objects},
+	}
 }
 
-filter_external_access(service) {
-  service.spec.type != "ClusterIP"
+filter_external_access(service) if {
+	service.spec.type != "ClusterIP"
 }
 
-service_to_pod(service, pod) = res {
-  # Make sure we're looking on the same namespace
-  service.metadata.namespace == pod.metadata.namespace
+service_to_pod(service, pod) := res if {
+	# Make sure we're looking on the same namespace
+	service.metadata.namespace == pod.metadata.namespace
 
-  service_selectors := [ x | x = service.spec.selector[_] ]
+	service_selectors := [x | x = service.spec.selector[_]]
 
-  res := count([ x | x = pod.metadata.labels[_]; x == service_selectors[_] ])
+	res := count([x | x = pod.metadata.labels[_]; x == service_selectors[_]])
 }

--- a/rules/exposed-critical-pods/filter.rego
+++ b/rules/exposed-critical-pods/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -27,14 +28,12 @@ deny contains msga if {
 	# image has vulnerabilities
 	container.image == vuln.metadata.name
 
-	related_objects := [pod, vuln]
-
-	path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
-
 	metadata = {
 		"name": pod.metadata.name,
 		"namespace": pod.metadata.namespace,
 	}
+
+	related_objects := [pod, vuln]
 
 	external_objects = {
 		"apiVersion": "result.vulnscan.com/v1",
@@ -42,6 +41,8 @@ deny contains msga if {
 		"metadata": metadata,
 		"relatedObjects": related_objects,
 	}
+
+	path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
 
 	msga := {
 		"alertMessage": sprintf("pod '%v' exposed with critical vulnerabilities", [pod.metadata.name]),

--- a/rules/exposed-critical-pods/raw.rego
+++ b/rules/exposed-critical-pods/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -31,14 +32,12 @@ deny contains msga if {
 	# At least one critical vulnerabilities
 	filter_critical_vulnerabilities(vuln)
 
-	related_objects := [pod, vuln]
-
-	path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
-
 	metadata = {
 		"name": pod.metadata.name,
 		"namespace": pod.metadata.namespace,
 	}
+
+	related_objects := [pod, vuln]
 
 	external_objects = {
 		"apiVersion": "result.vulnscan.com/v1",
@@ -46,6 +45,8 @@ deny contains msga if {
 		"metadata": metadata,
 		"relatedObjects": related_objects,
 	}
+
+	path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
 
 	msga := {
 		"alertMessage": sprintf("pod '%v' exposed with critical vulnerabilities", [pod.metadata.name]),

--- a/rules/exposed-critical-pods/raw.rego
+++ b/rules/exposed-critical-pods/raw.rego
@@ -1,77 +1,77 @@
 package armo_builtins
 
+import rego.v1
+
 # regal ignore:rule-length
-deny[msga] {
-  services := [ x | x = input[_]; x.kind == "Service" ]
-  pods     := [ x | x = input[_]; x.kind == "Pod" ]
-  vulns    := [ x | x = input[_]; x.kind == "ImageVulnerabilities"]
+deny contains msga if {
+	services := [x | x = input[_]; x.kind == "Service"]
+	pods := [x | x = input[_]; x.kind == "Pod"]
+	vulns := [x | x = input[_]; x.kind == "ImageVulnerabilities"]
 
-  pod     := pods[_]
-  service := services[_]
-  vuln    := vulns[_]
+	pod := pods[_]
+	service := services[_]
+	vuln := vulns[_]
 
-  # vuln data is relevant
-  count(vuln.data) > 0
+	# vuln data is relevant
+	count(vuln.data) > 0
 
-  # service is external-facing
-  filter_external_access(service)
+	# service is external-facing
+	filter_external_access(service)
 
-  # pod has the current service
-  service_to_pod(service, pod) > 0
+	# pod has the current service
+	service_to_pod(service, pod) > 0
 
-  # get container image name
-  container := pod.spec.containers[i]
+	# get container image name
+	container := pod.spec.containers[i]
 
-  # image has vulnerabilities
+	# image has vulnerabilities
 
-  container.image == vuln.metadata.name
+	container.image == vuln.metadata.name
 
-  # At least one critical vulnerabilities
-  filter_critical_vulnerabilities(vuln)
+	# At least one critical vulnerabilities
+	filter_critical_vulnerabilities(vuln)
 
-  related_objects := [pod, vuln]
+	related_objects := [pod, vuln]
 
-  path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
+	path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
 
-  metadata = {
-    "name": pod.metadata.name,
-    "namespace": pod.metadata.namespace
-  }
+	metadata = {
+		"name": pod.metadata.name,
+		"namespace": pod.metadata.namespace,
+	}
 
-  external_objects = {
-    "apiVersion": "result.vulnscan.com/v1",
-    "kind": pod.kind,
-    "metadata": metadata,
-    "relatedObjects": related_objects
-  }
+	external_objects = {
+		"apiVersion": "result.vulnscan.com/v1",
+		"kind": pod.kind,
+		"metadata": metadata,
+		"relatedObjects": related_objects,
+	}
 
-  msga := {
-    "alertMessage": sprintf("pod '%v' exposed with critical vulnerabilities", [pod.metadata.name]),
-    "packagename": "armo_builtins",
-    "alertScore": 7,
+	msga := {
+		"alertMessage": sprintf("pod '%v' exposed with critical vulnerabilities", [pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
 		"reviewPaths": [path],
-   "failedPaths": [path],
-    "fixPaths": [],
-    "alertObject": {
-        "externalObjects": external_objects
-    }
-  }
+		"failedPaths": [path],
+		"fixPaths": [],
+		"alertObject": {"externalObjects": external_objects},
+	}
 }
 
-filter_critical_vulnerabilities(vuln) {
-  data := vuln.data[_]
-  data.severity == "Critical"
+filter_critical_vulnerabilities(vuln) if {
+	vuln_data := vuln.data[_]
+	vuln_data.severity == "Critical"
 }
 
-filter_external_access(service) {
-  service.spec.type != "ClusterIP"
+filter_external_access(service) if {
+	service.spec.type != "ClusterIP"
 }
 
-service_to_pod(service, pod) = res {
-  # Make sure we're looking on the same namespace
-  service.metadata.namespace == pod.metadata.namespace
+service_to_pod(service, pod) := res if {
+	# Make sure we're looking on the same namespace
+	service.metadata.namespace == pod.metadata.namespace
 
-  service_selectors := [ x | x = service.spec.selector[_] ]
+	service_selectors := [x | x = service.spec.selector[_]]
 
-  res := count([ x | x = pod.metadata.labels[_]; x == service_selectors[_] ])
+	res := count([x | x = pod.metadata.labels[_]; x == service_selectors[_]])
 }

--- a/rules/exposed-rce-pods/filter.rego
+++ b/rules/exposed-rce-pods/filter.rego
@@ -1,67 +1,67 @@
 package armo_builtins
 
+import rego.v1
+
 # regal ignore:rule-length
-deny[msga] {
-  services := [ x | x = input[_]; x.kind == "Service" ; x.apiVersion == "v1"]
-  pods     := [ x | x = input[_]; x.kind == "Pod" ; x.apiVersion == "v1"]
-  vulns    := [ x | x = input[_]; x.kind == "ImageVulnerabilities"] # TODO: x.apiVersion == "--input--" || x.apiVersion == "--input--"  ]
+deny contains msga if {
+	services := [x | x = input[_]; x.kind == "Service"; x.apiVersion == "v1"]
+	pods := [x | x = input[_]; x.kind == "Pod"; x.apiVersion == "v1"]
+	vulns := [x | x = input[_]; x.kind == "ImageVulnerabilities"] # TODO: x.apiVersion == "--input--" || x.apiVersion == "--input--"  ]
 
-  pod     := pods[_]
-  service := services[_]
-  vuln    := vulns[_]
+	pod := pods[_]
+	service := services[_]
+	vuln := vulns[_]
 
-  # vuln data is relevant
-  count(vuln.data) > 0
+	# vuln data is relevant
+	count(vuln.data) > 0
 
-  # service is external-facing
-  filter_external_access(service)
+	# service is external-facing
+	filter_external_access(service)
 
-  # pod has the current service
-  service_to_pod(service, pod) > 0
+	# pod has the current service
+	service_to_pod(service, pod) > 0
 
-  # get container image name
-  container := pod.spec.containers[i]
+	# get container image name
+	container := pod.spec.containers[i]
 
-  # image has vulnerabilities
-  container.image == vuln.metadata.name
+	# image has vulnerabilities
+	container.image == vuln.metadata.name
 
-  related_objects := [pod, vuln]
+	related_objects := [pod, vuln]
 
-  path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
+	path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
 
-  metadata = {
-    "name": pod.metadata.name,
-    "namespace": pod.metadata.namespace
-  }
+	metadata = {
+		"name": pod.metadata.name,
+		"namespace": pod.metadata.namespace,
+	}
 
-  external_objects = {
-    "apiVersion": "result.vulnscan.com/v1",
-    "kind": pod.kind,
-    "metadata": metadata,
-    "relatedObjects": related_objects
-  }
+	external_objects = {
+		"apiVersion": "result.vulnscan.com/v1",
+		"kind": pod.kind,
+		"metadata": metadata,
+		"relatedObjects": related_objects,
+	}
 
-  msga := {
-    "alertMessage": sprintf("pod '%v' exposed with rce vulnerability", [pod.metadata.name]),
-    "packagename": "armo_builtins",
-    "alertScore": 8,
-   "failedPaths": [path],
-    "fixPaths": [],
-    "alertObject": {
-      "externalObjects": external_objects
-    }
-  }
+	msga := {
+		"alertMessage": sprintf("pod '%v' exposed with rce vulnerability", [pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 8,
+		"failedPaths": [path],
+		"fixPaths": [],
+		"alertObject": {"externalObjects": external_objects},
+	}
 }
 
-filter_external_access(service) {
-  service.spec.type != "ClusterIP"
+filter_external_access(service) if {
+	service.spec.type != "ClusterIP"
 }
 
-service_to_pod(service, pod) = res {
-  # Make sure we're looking on the same namespace
-  service.metadata.namespace == pod.metadata.namespace
+service_to_pod(service, pod) := res if {
+	# Make sure we're looking on the same namespace
+	service.metadata.namespace == pod.metadata.namespace
 
-  service_selectors := [ x | x = service.spec.selector[_] ]
+	service_selectors := [x | x = service.spec.selector[_]]
 
-  res := count([ x | x = pod.metadata.labels[_]; x == service_selectors[_] ])
+	res := count([x | x = pod.metadata.labels[_]; x == service_selectors[_]])
 }

--- a/rules/exposed-rce-pods/filter.rego
+++ b/rules/exposed-rce-pods/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -27,14 +28,12 @@ deny contains msga if {
 	# image has vulnerabilities
 	container.image == vuln.metadata.name
 
-	related_objects := [pod, vuln]
-
-	path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
-
 	metadata = {
 		"name": pod.metadata.name,
 		"namespace": pod.metadata.namespace,
 	}
+
+	related_objects := [pod, vuln]
 
 	external_objects = {
 		"apiVersion": "result.vulnscan.com/v1",
@@ -42,6 +41,8 @@ deny contains msga if {
 		"metadata": metadata,
 		"relatedObjects": related_objects,
 	}
+
+	path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
 
 	msga := {
 		"alertMessage": sprintf("pod '%v' exposed with rce vulnerability", [pod.metadata.name]),

--- a/rules/exposed-rce-pods/raw.rego
+++ b/rules/exposed-rce-pods/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -30,14 +31,12 @@ deny contains msga if {
 	# At least one rce vulnerability
 	filter_rce_vulnerabilities(vuln)
 
-	related_objects := [pod, vuln]
-
-	path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
-
 	metadata = {
 		"name": pod.metadata.name,
 		"namespace": pod.metadata.namespace,
 	}
+
+	related_objects := [pod, vuln]
 
 	external_objects = {
 		"apiVersion": "result.vulnscan.com/v1",
@@ -45,6 +44,8 @@ deny contains msga if {
 		"metadata": metadata,
 		"relatedObjects": related_objects,
 	}
+
+	path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
 
 	msga := {
 		"alertMessage": sprintf("pod '%v' exposed with rce vulnerability", [pod.metadata.name]),

--- a/rules/exposed-rce-pods/raw.rego
+++ b/rules/exposed-rce-pods/raw.rego
@@ -1,76 +1,76 @@
 package armo_builtins
 
+import rego.v1
+
 # regal ignore:rule-length
-deny[msga] {
-  services := [ x | x = input[_]; x.kind == "Service" ]
-  pods     := [ x | x = input[_]; x.kind == "Pod" ]
-  vulns    := [ x | x = input[_]; x.kind == "ImageVulnerabilities" ]
+deny contains msga if {
+	services := [x | x = input[_]; x.kind == "Service"]
+	pods := [x | x = input[_]; x.kind == "Pod"]
+	vulns := [x | x = input[_]; x.kind == "ImageVulnerabilities"]
 
-  pod     := pods[_]
-  service := services[_]
-  vuln    := vulns[_]
+	pod := pods[_]
+	service := services[_]
+	vuln := vulns[_]
 
-  # vuln data is relevant
-  count(vuln.data) > 0
+	# vuln data is relevant
+	count(vuln.data) > 0
 
-  # service is external-facing
-  filter_external_access(service)
+	# service is external-facing
+	filter_external_access(service)
 
-  # pod has the current service
-  service_to_pod(service, pod) > 0
+	# pod has the current service
+	service_to_pod(service, pod) > 0
 
-  # get container image name
-  container := pod.spec.containers[i]
+	# get container image name
+	container := pod.spec.containers[i]
 
-  # image has vulnerabilities
-  container.image == vuln.metadata.name
+	# image has vulnerabilities
+	container.image == vuln.metadata.name
 
-  # At least one rce vulnerability
-  filter_rce_vulnerabilities(vuln)
+	# At least one rce vulnerability
+	filter_rce_vulnerabilities(vuln)
 
-  related_objects := [pod, vuln]
+	related_objects := [pod, vuln]
 
-  path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
+	path := sprintf("status.containerStatuses[%v].imageID", [format_int(i, 10)])
 
-  metadata = {
-    "name": pod.metadata.name,
-    "namespace": pod.metadata.namespace
-  }
+	metadata = {
+		"name": pod.metadata.name,
+		"namespace": pod.metadata.namespace,
+	}
 
-  external_objects = {
-    "apiVersion": "result.vulnscan.com/v1",
-    "kind": pod.kind,
-    "metadata": metadata,
-    "relatedObjects": related_objects
-  }
+	external_objects = {
+		"apiVersion": "result.vulnscan.com/v1",
+		"kind": pod.kind,
+		"metadata": metadata,
+		"relatedObjects": related_objects,
+	}
 
-  msga := {
-    "alertMessage": sprintf("pod '%v' exposed with rce vulnerability", [pod.metadata.name]),
-    "packagename": "armo_builtins",
-    "alertScore": 8,
+	msga := {
+		"alertMessage": sprintf("pod '%v' exposed with rce vulnerability", [pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 8,
 		"reviewPaths": [path],
-   "failedPaths": [path],
-    "fixPaths": [],
-    "alertObject": {
-      "externalObjects": external_objects
-    }
-  }
+		"failedPaths": [path],
+		"fixPaths": [],
+		"alertObject": {"externalObjects": external_objects},
+	}
 }
 
-filter_rce_vulnerabilities(vuln) {
-  data := vuln.data[_]
-  data.categories.isRce == true
+filter_rce_vulnerabilities(vuln) if {
+	vuln_data := vuln.data[_]
+	vuln_data.categories.isRce == true
 }
 
-filter_external_access(service) {
-  service.spec.type != "ClusterIP"
+filter_external_access(service) if {
+	service.spec.type != "ClusterIP"
 }
 
-service_to_pod(service, pod) = res {
-  # Make sure we're looking on the same namespace
-  service.metadata.namespace == pod.metadata.namespace
+service_to_pod(service, pod) := res if {
+	# Make sure we're looking on the same namespace
+	service.metadata.namespace == pod.metadata.namespace
 
-  service_selectors := [ x | x = service.spec.selector[_] ]
+	service_selectors := [x | x = service.spec.selector[_]]
 
-  res := count([ x | x = pod.metadata.labels[_]; x == service_selectors[_] ])
+	res := count([x | x = pod.metadata.labels[_]; x == service_selectors[_]])
 }

--- a/rules/exposed-sensitive-interfaces-v1/filter.rego
+++ b/rules/exposed-sensitive-interfaces-v1/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -5,12 +6,12 @@ import rego.v1
 import data.kubernetes.api.client
 
 deny contains msga if {
+	wl_names := data.postureControlInputs.sensitiveInterfaces
 	wl := input[_]
 	workload_types = {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "Pod", "CronJob"}
 	workload_types[wl.kind]
 
 	# see default-config-inputs.json for list values
-	wl_names := data.postureControlInputs.sensitiveInterfaces
 	wl_name := wl_names[_]
 	contains(wl.metadata.name, wl_name)
 

--- a/rules/exposed-sensitive-interfaces-v1/raw.rego
+++ b/rules/exposed-sensitive-interfaces-v1/raw.rego
@@ -1,31 +1,35 @@
 package armo_builtins
 
+import rego.v1
+
 import data.kubernetes.api.client
 
 # loadbalancer
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	workload_types = {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "Pod", "CronJob"}
 	workload_types[wl.kind]
 
-    # see default-config-inputs.json for list values
-    wl_names := data.postureControlInputs.sensitiveInterfaces
+	# see default-config-inputs.json for list values
+	wl_names := data.postureControlInputs.sensitiveInterfaces
 	wl_name := wl_names[_]
 	contains(wl.metadata.name, wl_name)
 
-	service := 	input[_]
+	service := input[_]
 	service.kind == "Service"
 	service.spec.type == "LoadBalancer"
 
 	result := wl_connectedto_service(wl, service)
 
-    # externalIP := service.spec.externalIPs[_]
+	# externalIP := service.spec.externalIPs[_]
 	externalIP := service.status.loadBalancer.ingress[0].ip
 
-	wlvector = {"name": wl.metadata.name,
-				"namespace": wl.metadata.namespace,
-				"kind": wl.kind,
-				"relatedObjects": [service]}
+	wlvector = {
+		"name": wl.metadata.name,
+		"namespace": wl.metadata.namespace,
+		"kind": wl.kind,
+		"relatedObjects": [service],
+	}
 
 	msga := {
 		"alertMessage": sprintf("service: %v is exposed", [service.metadata.name]),
@@ -33,37 +37,38 @@ deny[msga] {
 		"alertScore": 7,
 		"reviewPaths": result,
 		"failedPaths": result,
-		"fixPaths":[],
+		"fixPaths": [],
 		"alertObject": {
 			"k8sApiObjects": [],
-            "externalObjects": wlvector
-		}
+			"externalObjects": wlvector,
+		},
 	}
 }
-
 
 # nodePort
 # get a pod connected to that service, get nodeIP (hostIP?)
 # use ip + nodeport
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "Pod"
 
-    # see default-config-inputs.json for list values
-    wl_names := data.postureControlInputs.sensitiveInterfaces
+	# see default-config-inputs.json for list values
+	wl_names := data.postureControlInputs.sensitiveInterfaces
 	wl_name := wl_names[_]
 	contains(wl.metadata.name, wl_name)
 
-	service := 	input[_]
+	service := input[_]
 	service.kind == "Service"
 	service.spec.type == "NodePort"
 
 	result := wl_connectedto_service(wl, service)
 
-	wlvector = {"name": wl.metadata.name,
-				"namespace": wl.metadata.namespace,
-				"kind": wl.kind,
-				"relatedObjects": [service]}
+	wlvector = {
+		"name": wl.metadata.name,
+		"namespace": wl.metadata.namespace,
+		"kind": wl.kind,
+		"relatedObjects": [service],
+	}
 
 	msga := {
 		"alertMessage": sprintf("service: %v is exposed", [service.metadata.name]),
@@ -71,37 +76,39 @@ deny[msga] {
 		"alertScore": 7,
 		"reviewPaths": result,
 		"failedPaths": result,
-		"fixPaths":[],
+		"fixPaths": [],
 		"alertObject": {
 			"k8sApiObjects": [],
-            "externalObjects": wlvector
-		}
+			"externalObjects": wlvector,
+		},
 	}
 }
 
 # nodePort
 # get a workload connected to that service, get nodeIP (hostIP?)
 # use ip + nodeport
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "CronJob"}
 	spec_template_spec_patterns[wl.kind]
 
-    # see default-config-inputs.json for list values
-    wl_names := data.postureControlInputs.sensitiveInterfaces
+	# see default-config-inputs.json for list values
+	wl_names := data.postureControlInputs.sensitiveInterfaces
 	wl_name := wl_names[_]
 	contains(wl.metadata.name, wl_name)
 
-	service := 	input[_]
+	service := input[_]
 	service.kind == "Service"
 	service.spec.type == "NodePort"
 
 	result := wl_connectedto_service(wl, service)
 
-	wlvector = {"name": wl.metadata.name,
-				"namespace": wl.metadata.namespace,
-				"kind": wl.kind,
-				"relatedObjects": [service]}
+	wlvector = {
+		"name": wl.metadata.name,
+		"namespace": wl.metadata.namespace,
+		"kind": wl.kind,
+		"relatedObjects": [service],
+	}
 
 	msga := {
 		"alertMessage": sprintf("service: %v is exposed", [service.metadata.name]),
@@ -109,22 +116,22 @@ deny[msga] {
 		"alertScore": 7,
 		"reviewPaths": result,
 		"failedPaths": result,
-		"fixPaths":[],
+		"fixPaths": [],
 		"alertObject": {
 			"k8sApiObjects": [],
-            "externalObjects": wlvector
-		}
+			"externalObjects": wlvector,
+		},
 	}
 }
 
 # ====================================================================================
 
-wl_connectedto_service(wl, service) = paths{
+wl_connectedto_service(wl, service) := paths if {
 	count({x | service.spec.selector[x] == wl.metadata.labels[x]}) == count(service.spec.selector)
 	paths = ["spec.selector.matchLabels", "spec.selector"]
 }
 
-wl_connectedto_service(wl, service) = paths {
+wl_connectedto_service(wl, service) := paths if {
 	wl.spec.selector.matchLabels == service.spec.selector
 	paths = ["spec.selector.matchLabels", "spec.selector"]
 }

--- a/rules/exposed-sensitive-interfaces-v1/raw.rego
+++ b/rules/exposed-sensitive-interfaces-v1/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -6,12 +7,12 @@ import data.kubernetes.api.client
 
 # loadbalancer
 deny contains msga if {
+	wl_names := data.postureControlInputs.sensitiveInterfaces
 	wl := input[_]
 	workload_types = {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "Pod", "CronJob"}
 	workload_types[wl.kind]
 
 	# see default-config-inputs.json for list values
-	wl_names := data.postureControlInputs.sensitiveInterfaces
 	wl_name := wl_names[_]
 	contains(wl.metadata.name, wl_name)
 
@@ -22,6 +23,7 @@ deny contains msga if {
 	result := wl_connectedto_service(wl, service)
 
 	# externalIP := service.spec.externalIPs[_]
+	# regal ignore:defer-assignment
 	externalIP := service.status.loadBalancer.ingress[0].ip
 
 	wlvector = {
@@ -49,11 +51,11 @@ deny contains msga if {
 # get a pod connected to that service, get nodeIP (hostIP?)
 # use ip + nodeport
 deny contains msga if {
+	wl_names := data.postureControlInputs.sensitiveInterfaces
 	wl := input[_]
 	wl.kind == "Pod"
 
 	# see default-config-inputs.json for list values
-	wl_names := data.postureControlInputs.sensitiveInterfaces
 	wl_name := wl_names[_]
 	contains(wl.metadata.name, wl_name)
 
@@ -61,14 +63,14 @@ deny contains msga if {
 	service.kind == "Service"
 	service.spec.type == "NodePort"
 
-	result := wl_connectedto_service(wl, service)
-
 	wlvector = {
 		"name": wl.metadata.name,
 		"namespace": wl.metadata.namespace,
 		"kind": wl.kind,
 		"relatedObjects": [service],
 	}
+
+	result := wl_connectedto_service(wl, service)
 
 	msga := {
 		"alertMessage": sprintf("service: %v is exposed", [service.metadata.name]),
@@ -88,12 +90,12 @@ deny contains msga if {
 # get a workload connected to that service, get nodeIP (hostIP?)
 # use ip + nodeport
 deny contains msga if {
-	wl := input[_]
+	wl_names := data.postureControlInputs.sensitiveInterfaces
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "CronJob"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 
 	# see default-config-inputs.json for list values
-	wl_names := data.postureControlInputs.sensitiveInterfaces
 	wl_name := wl_names[_]
 	contains(wl.metadata.name, wl_name)
 
@@ -101,14 +103,14 @@ deny contains msga if {
 	service.kind == "Service"
 	service.spec.type == "NodePort"
 
-	result := wl_connectedto_service(wl, service)
-
 	wlvector = {
 		"name": wl.metadata.name,
 		"namespace": wl.metadata.namespace,
 		"kind": wl.kind,
 		"relatedObjects": [service],
 	}
+
+	result := wl_connectedto_service(wl, service)
 
 	msga := {
 		"alertMessage": sprintf("service: %v is exposed", [service.metadata.name]),

--- a/rules/exposure-to-internet-via-gateway-api/raw.rego
+++ b/rules/exposure-to-internet-via-gateway-api/raw.rego
@@ -1,117 +1,104 @@
 package armo_builtins
-import future.keywords.in
 
+import rego.v1
 
-deny[msga] {
-    httproute := input[_]
-    httproute.kind in ["HTTPRoute", "TCPRoute", "UDPRoute"]
+deny contains msga if {
+	httproute := input[_]
+	httproute.kind in ["HTTPRoute", "TCPRoute", "UDPRoute"]
 
-    svc := input[_]
-    svc.kind == "Service"
+	svc := input[_]
+	svc.kind == "Service"
 
-    # Make sure that they belong to the same namespace
-    svc.metadata.namespace == httproute.metadata.namespace
+	# Make sure that they belong to the same namespace
+	svc.metadata.namespace == httproute.metadata.namespace
 
-    # avoid duplicate alerts
-    # if service is already exposed through NodePort or LoadBalancer workload will fail on that
-    not is_exposed_service(svc)
+	# avoid duplicate alerts
+	# if service is already exposed through NodePort or LoadBalancer workload will fail on that
+	not is_exposed_service(svc)
 
-    wl := input[_]
-    is_same_namespace(wl.metadata, svc.metadata)
-    spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
-    spec_template_spec_patterns[wl.kind]
-    pod := get_pod_spec(wl)["spec"]
-    wl_connected_to_service(pod, svc)
+	wl := input[_]
+	is_same_namespace(wl.metadata, svc.metadata)
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
+	spec_template_spec_patterns[wl.kind]
+	pod := get_pod_spec(wl).spec
+	wl_connected_to_service(pod, svc)
 
-    result := svc_connected_to_httproute(svc, httproute)
+	result := svc_connected_to_httproute(svc, httproute)
 
-    msga := {
-        "alertMessage": sprintf("workload '%v' is exposed through httproute '%v'", [wl.metadata.name, httproute.metadata.name]),
-        "packagename": "armo_builtins",
-        "failedPaths": [],
-        "fixPaths": [],
-        "alertScore": 7,
-        "alertObject": {
-            "k8sApiObjects": [wl]
-        },
-        "relatedObjects": [
-		{
-	            "object": httproute,
-		    "reviewPaths": result,
-	            "failedPaths": result,
-	        },
-		{
-	            "object": svc,
-		}
-        ]
-    }
+	msga := {
+		"alertMessage": sprintf("workload '%v' is exposed through httproute '%v'", [wl.metadata.name, httproute.metadata.name]),
+		"packagename": "armo_builtins",
+		"failedPaths": [],
+		"fixPaths": [],
+		"alertScore": 7,
+		"alertObject": {"k8sApiObjects": [wl]},
+		"relatedObjects": [
+			{
+				"object": httproute,
+				"reviewPaths": result,
+				"failedPaths": result,
+			},
+			{"object": svc},
+		],
+	}
 }
 
 # ====================================================================================
 
-is_exposed_service(svc) {
-    svc.spec.type == "NodePort"
+is_exposed_service(svc) if {
+	svc.spec.type == "NodePort"
 }
 
-is_exposed_service(svc) {
-    svc.spec.type == "LoadBalancer"
+is_exposed_service(svc) if {
+	svc.spec.type == "LoadBalancer"
 }
 
-wl_connected_to_service(wl, svc) {    
-    
-
-    count({x | svc.spec.selector[x] == wl.metadata.labels[x]}) == count(svc.spec.selector)
+wl_connected_to_service(wl, svc) if {
+	count({x | svc.spec.selector[x] == wl.metadata.labels[x]}) == count(svc.spec.selector)
 }
 
-
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	metadata1.namespace == metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	not metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata2.namespace
 	metadata1.namespace == "default"
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	metadata2.namespace == "default"
 }
 
-
-
 # get_volume - get resource spec paths for {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-get_pod_spec(resources) := result {
-	resources_kinds := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+get_pod_spec(resources) := result if {
+	resources_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	resources_kinds[resources.kind]
 	result = {"spec": resources.spec.template, "start_of_path": "spec.template."}
 }
 
 # get_volume - get resource spec paths for "Pod"
-get_pod_spec(resources) := result {
+get_pod_spec(resources) := result if {
 	resources.kind == "Pod"
 	result = {"spec": resources, "start_of_path": ""}
 }
 
 # get_volume - get resource spec paths for "CronJob"
-get_pod_spec(resources) := result {
+get_pod_spec(resources) := result if {
 	resources.kind == "CronJob"
 	result = {"spec": resources.spec.jobTemplate.spec.template.spec, "start_of_path": "spec.jobTemplate.spec.template.spec."}
 }
 
-
-
-
-svc_connected_to_httproute(svc, httproute) = result {
-    rule := httproute.spec.rules[i]
-    ref := rule.backendRefs[j]
-    ref.kind == "Service"
-    svc.metadata.name == ref.name
-    result := [sprintf("spec.rules[%d].backendRefs[%d].name", [i,j])]
+svc_connected_to_httproute(svc, httproute) := result if {
+	rule := httproute.spec.rules[i]
+	ref := rule.backendRefs[j]
+	ref.kind == "Service"
+	svc.metadata.name == ref.name
+	result := [sprintf("spec.rules[%d].backendRefs[%d].name", [i, j])]
 }
-

--- a/rules/exposure-to-internet-via-gateway-api/raw.rego
+++ b/rules/exposure-to-internet-via-gateway-api/raw.rego
@@ -1,8 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
 	httproute := input[_]
 	httproute.kind in ["HTTPRoute", "TCPRoute", "UDPRoute"]
 
@@ -18,7 +20,6 @@ deny contains msga if {
 
 	wl := input[_]
 	is_same_namespace(wl.metadata, svc.metadata)
-	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
 	spec_template_spec_patterns[wl.kind]
 	pod := get_pod_spec(wl).spec
 	wl_connected_to_service(pod, svc)

--- a/rules/exposure-to-internet-via-istio-ingress/raw.rego
+++ b/rules/exposure-to-internet-via-istio-ingress/raw.rego
@@ -1,209 +1,202 @@
 package armo_builtins
-import future.keywords.in
 
+import rego.v1
 
-deny[msga] {
-    virtualservice := input[_]
-    virtualservice.kind == "VirtualService"
+deny contains msga if {
+	virtualservice := input[_]
+	virtualservice.kind == "VirtualService"
 
-    # Get the namescape of the VirtualService
-    vs_ns := get_namespace(virtualservice)
-    # Looping over the gateways of the VirtualService
-    vs_gw_name := virtualservice.spec.gateways[_]
-    # Get the namespace of the Gateway
-    vs_gw = get_vs_gw_ns(vs_ns, vs_gw_name)
+	# Get the namescape of the VirtualService
+	vs_ns := get_namespace(virtualservice)
 
-    # Check if the VirtualService is connected to a Gateway
-    gateway := input[_]
-    gateway.kind == "Gateway"
-    gateway.metadata.name == vs_gw.name
-    get_namespace(gateway) == vs_gw.namespace
+	# Looping over the gateways of the VirtualService
+	vs_gw_name := virtualservice.spec.gateways[_]
 
-    # print("Found the gateway that the virtualservice is connected to", gateway)
+	# Get the namespace of the Gateway
+	vs_gw = get_vs_gw_ns(vs_ns, vs_gw_name)
 
-    # Either the gateway is exposed via LoadBalancer service OR has "public" suffix
-    gateway_service := is_gateway_public(gateway, input)
+	# Check if the VirtualService is connected to a Gateway
+	gateway := input[_]
+	gateway.kind == "Gateway"
+	gateway.metadata.name == vs_gw.name
+	get_namespace(gateway) == vs_gw.namespace
 
-    # print("Gateway is public", gateway)
+	# print("Found the gateway that the virtualservice is connected to", gateway)
 
-    # Check if the VirtualService is connected to an workload
-    # First, find the service that the VirtualService is connected to
-    connected_service := input[_]
-    connected_service.kind == "Service"
-    fqsn := get_fqsn(get_namespace(virtualservice), virtualservice.spec.http[i].route[j].destination.host)
-    target_ns := split(fqsn,".")[1]
-    target_name := split(fqsn,".")[0]
-    # Check if the service is in the same namespace as the VirtualService
-    get_namespace(connected_service) == target_ns
-    # Check if the service is the target of the VirtualService
-    connected_service.metadata.name == target_name
+	# Either the gateway is exposed via LoadBalancer service OR has "public" suffix
+	gateway_service := is_gateway_public(gateway, input)
 
-    # print("Found the service that the virtualservice is connected to", connected_service)
+	# print("Gateway is public", gateway)
 
-    # Check if the service is connected to a workload
-    wl := input[_]
-    is_same_namespace(connected_service, wl)
-    spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
-    spec_template_spec_patterns[wl.kind]
-    pod := get_pod_spec(wl)["spec"]
-    wl_connected_to_service(pod, connected_service)
+	# Check if the VirtualService is connected to an workload
+	# First, find the service that the VirtualService is connected to
+	connected_service := input[_]
+	connected_service.kind == "Service"
+	fqsn := get_fqsn(get_namespace(virtualservice), virtualservice.spec.http[i].route[j].destination.host)
+	target_ns := split(fqsn, ".")[1]
+	target_name := split(fqsn, ".")[0]
 
-    # print("Found the workload that the service is connected to", wl)
+	# Check if the service is in the same namespace as the VirtualService
+	get_namespace(connected_service) == target_ns
 
-    failedPaths := [sprintf("spec.http[%d].routes[%d].destination.host", [i,j])]
+	# Check if the service is the target of the VirtualService
+	connected_service.metadata.name == target_name
 
-    # print("Found the failed paths", failedPaths)
+	# print("Found the service that the virtualservice is connected to", connected_service)
 
-    msga := {
-        "alertMessage": sprintf("workload '%v' is exposed through virtualservice '%v'", [wl.metadata.name, virtualservice.metadata.name]),
-        "packagename": "armo_builtins",
-        "failedPaths": [],
-        "fixPaths": [],
-        "alertScore": 7,
-        "alertObject": {
-            "k8sApiObjects": [wl]
-        },
-        "relatedObjects": [
-	    {
-	            "object": virtualservice,
-	            "reviewPaths": failedPaths,
-	            "failedPaths": failedPaths,
-	        },
-	    {
-	            "object": gateway_service,
-	        },
-	    {
-	            "object": gateway,
-	        },
-            {
-                    "object": connected_service,
-            }
-        ]
-    }
+	# Check if the service is connected to a workload
+	wl := input[_]
+	is_same_namespace(connected_service, wl)
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
+	spec_template_spec_patterns[wl.kind]
+	pod := get_pod_spec(wl).spec
+	wl_connected_to_service(pod, connected_service)
+
+	# print("Found the workload that the service is connected to", wl)
+
+	failedPaths := [sprintf("spec.http[%d].routes[%d].destination.host", [i, j])]
+
+	# print("Found the failed paths", failedPaths)
+
+	msga := {
+		"alertMessage": sprintf("workload '%v' is exposed through virtualservice '%v'", [wl.metadata.name, virtualservice.metadata.name]),
+		"packagename": "armo_builtins",
+		"failedPaths": [],
+		"fixPaths": [],
+		"alertScore": 7,
+		"alertObject": {"k8sApiObjects": [wl]},
+		"relatedObjects": [
+			{
+				"object": virtualservice,
+				"reviewPaths": failedPaths,
+				"failedPaths": failedPaths,
+			},
+			{"object": gateway_service},
+			{"object": gateway},
+			{"object": connected_service},
+		],
+	}
 }
 
 # ====================================================================================
 
-is_gateway_public(gateway, inputs) = svc {
-    endswith(gateway.metadata.name, "public")
-    inputs[i].kind == "Service"
-    inputs[i].metadata.namespace == "istio-system"
-    gateway.spec.selector[_] == inputs[i].metadata.labels[_]
-    svc := inputs[i]
+is_gateway_public(gateway, inputs) := svc if {
+	endswith(gateway.metadata.name, "public")
+	inputs[i].kind == "Service"
+	inputs[i].metadata.namespace == "istio-system"
+	gateway.spec.selector[_] == inputs[i].metadata.labels[_]
+	svc := inputs[i]
 }
 
-is_gateway_public(gateway, inputs) = svc {
-    inputs[i].kind == "Service"
-    inputs[i].metadata.namespace == "istio-system"
-    gateway.spec.selector[_] == inputs[i].metadata.labels[_]
-    is_exposed_service(inputs[i])
-    svc := inputs[i]
+is_gateway_public(gateway, inputs) := svc if {
+	inputs[i].kind == "Service"
+	inputs[i].metadata.namespace == "istio-system"
+	gateway.spec.selector[_] == inputs[i].metadata.labels[_]
+	is_exposed_service(inputs[i])
+	svc := inputs[i]
 }
 
-get_namespace(obj) = namespace {
-    obj.metadata
-    obj.metadata.namespace
-    namespace := obj.metadata.namespace
+get_namespace(obj) := namespace if {
+	obj.metadata
+	obj.metadata.namespace
+	namespace := obj.metadata.namespace
 }
 
-get_namespace(obj) = namespace {
-    not obj.metadata.namespace
-    namespace := "default"
+get_namespace(obj) := namespace if {
+	not obj.metadata.namespace
+	namespace := "default"
 }
 
-get_vs_gw_ns(vs_ns, vs_gw_name) = {"name": name, "namespace": ns} {
-    # Check if there is a / in the gateway name
-    count(split(vs_gw_name, "/")) == 2
-    ns := split(vs_gw_name, "/")[0]
-    name := split(vs_gw_name, "/")[1]
+get_vs_gw_ns(vs_ns, vs_gw_name) := {"name": name, "namespace": ns} if {
+	# Check if there is a / in the gateway name
+	count(split(vs_gw_name, "/")) == 2
+	ns := split(vs_gw_name, "/")[0]
+	name := split(vs_gw_name, "/")[1]
 }
 
-get_vs_gw_ns(vs_ns, vs_gw_name) = {"name": name, "namespace": ns} {
-    # Check if there is no / in the gateway name
-    count(split(vs_gw_name, "/")) == 1
-    ns := vs_ns
-    name := vs_gw_name
+get_vs_gw_ns(vs_ns, vs_gw_name) := {"name": name, "namespace": ns} if {
+	# Check if there is no / in the gateway name
+	count(split(vs_gw_name, "/")) == 1
+	ns := vs_ns
+	name := vs_gw_name
 }
 
-is_same_namespace(obj1, obj2) {
-    obj1.metadata.namespace == obj2.metadata.namespace
+is_same_namespace(obj1, obj2) if {
+	obj1.metadata.namespace == obj2.metadata.namespace
 }
 
-is_same_namespace(obj1, obj2) {
-    not obj1.metadata.namespace
-    obj2.metadata.namespace == "default"
+is_same_namespace(obj1, obj2) if {
+	not obj1.metadata.namespace
+	obj2.metadata.namespace == "default"
 }
 
-is_same_namespace(obj1, obj2) {
-    not obj2.metadata.namespace
-    obj1.metadata.namespace == "default"
+is_same_namespace(obj1, obj2) if {
+	not obj2.metadata.namespace
+	obj1.metadata.namespace == "default"
 }
 
-is_same_namespace(obj1, obj2) {
-    not obj1.metadata.namespace
-    not obj2.metadata.namespace
+is_same_namespace(obj1, obj2) if {
+	not obj1.metadata.namespace
+	not obj2.metadata.namespace
 }
 
-is_exposed_service(svc) {
-    svc.spec.type == "NodePort"
+is_exposed_service(svc) if {
+	svc.spec.type == "NodePort"
 }
 
-is_exposed_service(svc) {
-    svc.spec.type == "LoadBalancer"
+is_exposed_service(svc) if {
+	svc.spec.type == "LoadBalancer"
 }
 
-
-wl_connected_to_service(wl, svc) {
-    count({x | svc.spec.selector[x] == wl.metadata.labels[x]}) == count(svc.spec.selector)
+wl_connected_to_service(wl, svc) if {
+	count({x | svc.spec.selector[x] == wl.metadata.labels[x]}) == count(svc.spec.selector)
 }
 
-wl_connected_to_service(wl, svc) {
-    wl.spec.selector.matchLabels == svc.spec.selector
+wl_connected_to_service(wl, svc) if {
+	wl.spec.selector.matchLabels == svc.spec.selector
 }
 
-wl_connected_to_service(wl, svc) {
-    count({x | svc.spec.selector[x] == wl.spec.template.metadata.labels[x]}) == count(svc.spec.selector)
+wl_connected_to_service(wl, svc) if {
+	count({x | svc.spec.selector[x] == wl.spec.template.metadata.labels[x]}) == count(svc.spec.selector)
 }
 
-svc_connected_to_virtualservice(svc, virtualservice) = result {
-    host := virtualservice.spec.http[i].route[j].destination.host
-    svc.metadata.name == host
-    result := [sprintf("spec.http[%d].routes[%d].destination.host", [i,j])]
+svc_connected_to_virtualservice(svc, virtualservice) := result if {
+	host := virtualservice.spec.http[i].route[j].destination.host
+	svc.metadata.name == host
+	result := [sprintf("spec.http[%d].routes[%d].destination.host", [i, j])]
 }
 
-get_fqsn(ns, dest_host) = fqsn {
-    # verify that this name is without the namespace
-    count(split(".", dest_host)) == 1
-    fqsn := sprintf("%v.%v.svc.cluster.local", [dest_host, ns])
+get_fqsn(ns, dest_host) := fqsn if {
+	# verify that this name is without the namespace
+	count(split(".", dest_host)) == 1
+	fqsn := sprintf("%v.%v.svc.cluster.local", [dest_host, ns])
 }
 
-get_fqsn(ns, dest_host) = fqsn {
-    count(split(".", dest_host)) == 2
-    fqsn := sprintf("%v.svc.cluster.local", [dest_host])
+get_fqsn(ns, dest_host) := fqsn if {
+	count(split(".", dest_host)) == 2
+	fqsn := sprintf("%v.svc.cluster.local", [dest_host])
 }
 
-get_fqsn(ns, dest_host) = fqsn {
-    count(split(".", dest_host)) == 4
-    fqsn := dest_host
+get_fqsn(ns, dest_host) := fqsn if {
+	count(split(".", dest_host)) == 4
+	fqsn := dest_host
 }
-
-
 
 # get_volume - get resource spec paths for {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-get_pod_spec(resources) := result {
-	resources_kinds := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+get_pod_spec(resources) := result if {
+	resources_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	resources_kinds[resources.kind]
 	result = {"spec": resources.spec.template, "start_of_path": "spec.template."}
 }
 
 # get_volume - get resource spec paths for "Pod"
-get_pod_spec(resources) := result {
+get_pod_spec(resources) := result if {
 	resources.kind == "Pod"
 	result = {"spec": resources, "start_of_path": ""}
 }
 
 # get_volume - get resource spec paths for "CronJob"
-get_pod_spec(resources) := result {
+get_pod_spec(resources) := result if {
 	resources.kind == "CronJob"
 	result = {"spec": resources.spec.jobTemplate.spec.template.spec, "start_of_path": "spec.jobTemplate.spec.template.spec."}
 }

--- a/rules/exposure-to-internet-via-istio-ingress/raw.rego
+++ b/rules/exposure-to-internet-via-istio-ingress/raw.rego
@@ -1,8 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
 	virtualservice := input[_]
 	virtualservice.kind == "VirtualService"
 
@@ -34,11 +36,11 @@ deny contains msga if {
 	connected_service.kind == "Service"
 	fqsn := get_fqsn(get_namespace(virtualservice), virtualservice.spec.http[i].route[j].destination.host)
 	target_ns := split(fqsn, ".")[1]
-	target_name := split(fqsn, ".")[0]
 
 	# Check if the service is in the same namespace as the VirtualService
 	get_namespace(connected_service) == target_ns
 
+    target_name := split(fqsn, ".")[0]
 	# Check if the service is the target of the VirtualService
 	connected_service.metadata.name == target_name
 
@@ -47,7 +49,6 @@ deny contains msga if {
 	# Check if the service is connected to a workload
 	wl := input[_]
 	is_same_namespace(connected_service, wl)
-	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
 	spec_template_spec_patterns[wl.kind]
 	pod := get_pod_spec(wl).spec
 	wl_connected_to_service(pod, connected_service)
@@ -95,9 +96,10 @@ is_gateway_public(gateway, inputs) := svc if {
 	is_exposed_service(inputs[i])
 	svc := inputs[i]
 }
-
+ 
 get_namespace(obj) := namespace if {
 	obj.metadata
+	# regal ignore:redundant-existence-check
 	obj.metadata.namespace
 	namespace := obj.metadata.namespace
 }
@@ -107,18 +109,14 @@ get_namespace(obj) := namespace if {
 	namespace := "default"
 }
 
-get_vs_gw_ns(vs_ns, vs_gw_name) := {"name": name, "namespace": ns} if {
-	# Check if there is a / in the gateway name
+get_vs_gw_ns(vs_ns, vs_gw_name) := result if {
 	count(split(vs_gw_name, "/")) == 2
-	ns := split(vs_gw_name, "/")[0]
-	name := split(vs_gw_name, "/")[1]
+	parts := split(vs_gw_name, "/")
+	result := {"name": parts[1], "namespace": parts[0]}
 }
 
-get_vs_gw_ns(vs_ns, vs_gw_name) := {"name": name, "namespace": ns} if {
-	# Check if there is no / in the gateway name
+get_vs_gw_ns(vs_ns, vs_gw_name) := {"name": vs_gw_name, "namespace": vs_ns} if {
 	count(split(vs_gw_name, "/")) == 1
-	ns := vs_ns
-	name := vs_gw_name
 }
 
 is_same_namespace(obj1, obj2) if {
@@ -177,9 +175,8 @@ get_fqsn(ns, dest_host) := fqsn if {
 	fqsn := sprintf("%v.svc.cluster.local", [dest_host])
 }
 
-get_fqsn(ns, dest_host) := fqsn if {
+get_fqsn(ns, dest_host) := dest_host if {
 	count(split(".", dest_host)) == 4
-	fqsn := dest_host
 }
 
 # get_volume - get resource spec paths for {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}

--- a/rules/exposure-to-internet/raw.rego
+++ b/rules/exposure-to-internet/raw.rego
@@ -1,20 +1,21 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 # Checks if NodePort or LoadBalancer is connected to a workload to expose something
 deny contains msga if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
+	failPath := ["spec.type"]
 	service := input[_]
 	service.kind == "Service"
 	is_exposed_service(service)
 
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
 	spec_template_spec_patterns[wl.kind]
 	is_same_namespace(wl.metadata, service.metadata)
 	pod := get_pod_spec(wl).spec
 	wl_connected_to_service(pod, service)
-	failPath := ["spec.type"]
 	msga := {
 		"alertMessage": sprintf("workload '%v' is exposed through service '%v'", [wl.metadata.name, service.metadata.name]),
 		"packagename": "armo_builtins",
@@ -32,6 +33,7 @@ deny contains msga if {
 
 # Checks if Ingress is connected to a service and a workload to expose something
 deny contains msga if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
 	ingress := input[_]
 	ingress.kind == "Ingress"
 
@@ -46,7 +48,6 @@ deny contains msga if {
 	not is_exposed_service(svc)
 
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
 	spec_template_spec_patterns[wl.kind]
 	is_same_namespace(wl.metadata, svc.metadata)
 	wl_connected_to_service(wl, svc)

--- a/rules/exposure-to-internet/raw.rego
+++ b/rules/exposure-to-internet/raw.rego
@@ -1,152 +1,143 @@
 package armo_builtins
 
-# Checks if NodePort or LoadBalancer is connected to a workload to expose something
-deny[msga] {
-    service := input[_]
-    service.kind == "Service"
-    is_exposed_service(service)
+import rego.v1
 
-    wl := input[_]
-    spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
-    spec_template_spec_patterns[wl.kind]
-    is_same_namespace(wl.metadata, service.metadata)
-    pod := get_pod_spec(wl)["spec"]
-    wl_connected_to_service(pod, service)
-    failPath := ["spec.type"]
-    msga := {
-        "alertMessage": sprintf("workload '%v' is exposed through service '%v'", [wl.metadata.name, service.metadata.name]),
-        "packagename": "armo_builtins",
-        "alertScore": 7,
-        "fixPaths": [],
-        "failedPaths": [],
-        "alertObject": {
-            "k8sApiObjects": [wl]
-        },
-        "relatedObjects": [{
-            "object": service,
-		    "reviewPaths": failPath,
-            "failedPaths": failPath,
-        }]
-    }
+# Checks if NodePort or LoadBalancer is connected to a workload to expose something
+deny contains msga if {
+	service := input[_]
+	service.kind == "Service"
+	is_exposed_service(service)
+
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
+	spec_template_spec_patterns[wl.kind]
+	is_same_namespace(wl.metadata, service.metadata)
+	pod := get_pod_spec(wl).spec
+	wl_connected_to_service(pod, service)
+	failPath := ["spec.type"]
+	msga := {
+		"alertMessage": sprintf("workload '%v' is exposed through service '%v'", [wl.metadata.name, service.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"fixPaths": [],
+		"failedPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
+		"relatedObjects": [{
+			"object": service,
+			"reviewPaths": failPath,
+			"failedPaths": failPath,
+		}],
+	}
 }
 
 # Checks if Ingress is connected to a service and a workload to expose something
-deny[msga] {
-    ingress := input[_]
-    ingress.kind == "Ingress"
+deny contains msga if {
+	ingress := input[_]
+	ingress.kind == "Ingress"
 
-    svc := input[_]
-    svc.kind == "Service"
+	svc := input[_]
+	svc.kind == "Service"
 
-    # Make sure that they belong to the same namespace
-    svc.metadata.namespace == ingress.metadata.namespace
+	# Make sure that they belong to the same namespace
+	svc.metadata.namespace == ingress.metadata.namespace
 
-    # avoid duplicate alerts
-    # if service is already exposed through NodePort or LoadBalancer workload will fail on that
-    not is_exposed_service(svc)
+	# avoid duplicate alerts
+	# if service is already exposed through NodePort or LoadBalancer workload will fail on that
+	not is_exposed_service(svc)
 
-    wl := input[_]
-    spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
-    spec_template_spec_patterns[wl.kind]
-    is_same_namespace(wl.metadata, svc.metadata)
-    wl_connected_to_service(wl, svc)
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
+	spec_template_spec_patterns[wl.kind]
+	is_same_namespace(wl.metadata, svc.metadata)
+	wl_connected_to_service(wl, svc)
 
-    result := svc_connected_to_ingress(svc, ingress)
+	result := svc_connected_to_ingress(svc, ingress)
 
-    msga := {
-        "alertMessage": sprintf("workload '%v' is exposed through ingress '%v'", [wl.metadata.name, ingress.metadata.name]),
-        "packagename": "armo_builtins",
-        "failedPaths": [],
-        "fixPaths": [],
-        "alertScore": 7,
-        "alertObject": {
-            "k8sApiObjects": [wl]
-        },
-        "relatedObjects": [
-		{
-	            "object": ingress,
-		    "reviewPaths": result,
-	            "failedPaths": result,
-	        },
-		{
-	            "object": svc,
-		}
-        ]
-    }
+	msga := {
+		"alertMessage": sprintf("workload '%v' is exposed through ingress '%v'", [wl.metadata.name, ingress.metadata.name]),
+		"packagename": "armo_builtins",
+		"failedPaths": [],
+		"fixPaths": [],
+		"alertScore": 7,
+		"alertObject": {"k8sApiObjects": [wl]},
+		"relatedObjects": [
+			{
+				"object": ingress,
+				"reviewPaths": result,
+				"failedPaths": result,
+			},
+			{"object": svc},
+		],
+	}
 }
 
 # ====================================================================================
 
-is_exposed_service(svc) {
-    svc.spec.type == "NodePort"
+is_exposed_service(svc) if {
+	svc.spec.type == "NodePort"
 }
 
-is_exposed_service(svc) {
-    svc.spec.type == "LoadBalancer"
+is_exposed_service(svc) if {
+	svc.spec.type == "LoadBalancer"
 }
 
-
-wl_connected_to_service(wl, svc) {
-    count({x | svc.spec.selector[x] == wl.metadata.labels[x]}) == count(svc.spec.selector)
+wl_connected_to_service(wl, svc) if {
+	count({x | svc.spec.selector[x] == wl.metadata.labels[x]}) == count(svc.spec.selector)
 }
 
-wl_connected_to_service(wl, svc) {
-    wl.spec.selector.matchLabels == svc.spec.selector
+wl_connected_to_service(wl, svc) if {
+	wl.spec.selector.matchLabels == svc.spec.selector
 }
 
-wl_connected_to_service(wl, svc) {
-    count({x | svc.spec.selector[x] == wl.spec.template.metadata.labels[x]}) == count(svc.spec.selector)
+wl_connected_to_service(wl, svc) if {
+	count({x | svc.spec.selector[x] == wl.spec.template.metadata.labels[x]}) == count(svc.spec.selector)
 }
 
 # check if service is connected to ingress
-svc_connected_to_ingress(svc, ingress) = result {
-    result := [path |
-        rule := ingress.spec.rules[i]
-        paths := rule.http.paths[j]
-        svc.metadata.name == paths.backend.service.name
-        path := sprintf("spec.rules[%d].http.paths[%d].backend.service.name", [i,j])
-    ]
-    count(result) > 0
+svc_connected_to_ingress(svc, ingress) := result if {
+	result := [path |
+		rule := ingress.spec.rules[i]
+		paths := rule.http.paths[j]
+		svc.metadata.name == paths.backend.service.name
+		path := sprintf("spec.rules[%d].http.paths[%d].backend.service.name", [i, j])
+	]
+	count(result) > 0
 }
 
-
-
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	metadata1.namespace == metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	not metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata2.namespace
 	metadata1.namespace == "default"
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	metadata2.namespace == "default"
 }
 
-
-
 # get_volume - get resource spec paths for {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-get_pod_spec(resources) := result {
-	resources_kinds := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+get_pod_spec(resources) := result if {
+	resources_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	resources_kinds[resources.kind]
 	result = {"spec": resources.spec.template, "start_of_path": "spec.template."}
 }
 
 # get_volume - get resource spec paths for "Pod"
-get_pod_spec(resources) := result {
+get_pod_spec(resources) := result if {
 	resources.kind == "Pod"
 	result = {"spec": resources, "start_of_path": ""}
 }
 
 # get_volume - get resource spec paths for "CronJob"
-get_pod_spec(resources) := result {
+get_pod_spec(resources) := result if {
 	resources.kind == "CronJob"
 	result = {"spec": resources.spec.jobTemplate.spec.template.spec, "start_of_path": "spec.jobTemplate.spec.template.spec."}
 }

--- a/rules/external-secret-storage/raw.rego
+++ b/rules/external-secret-storage/raw.rego
@@ -1,10 +1,11 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 # Encryption config is not using a recommended provider for KMS
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_control_plane_info(obj)
 	config_file := obj.data.APIServerInfo.encryptionProviderConfigFile
 	config_file_content = decode_config_file(base64.decode(config_file.content))

--- a/rules/has-image-signature/raw.rego
+++ b/rules/has-image-signature/raw.rego
@@ -1,71 +1,64 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
 
-    pod := input[_]
-    pod.kind == "Pod"
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 	container := pod.spec.containers[i]
 
-    not cosign.has_signature(container.image)
+	not cosign.has_signature(container.image)
 
-    failedPath := sprintf("spec.containers[%v].image", [format_int(i, 10)])
+	failedPath := sprintf("spec.containers[%v].image", [format_int(i, 10)])
 
 	msga := {
-		"alertMessage": sprintf("image: %v is not signed", [ container.image]),
+		"alertMessage": sprintf("image: %v is not signed", [container.image]),
 		"alertScore": 7,
 		"fixPaths": [],
 		"reviewPaths": [failedPath],
 		"failedPaths": [failedPath],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		},
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-deny[msga] {
-    wl := input[_]
-	wl_kinds := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	wl_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	wl_kinds[wl.kind]
-    container := wl.spec.template.spec.containers[i]
+	container := wl.spec.template.spec.containers[i]
 
-    not cosign.has_signature(container.image)
+	not cosign.has_signature(container.image)
 
 	failedPath := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])
 
-
-    msga := {
-		"alertMessage": sprintf("image: %v is not signed", [ container.image]),
+	msga := {
+		"alertMessage": sprintf("image: %v is not signed", [container.image]),
 		"alertScore": 7,
 		"fixPaths": [],
 		"reviewPaths": [failedPath],
 		"failedPaths": [failedPath],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		},
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 
-    not cosign.has_signature(container.image)
+	not cosign.has_signature(container.image)
 
 	failedPath := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].image", [format_int(i, 10)])
 
-    msga := {
-		"alertMessage": sprintf("image: %v is not signed", [ container.image]),
+	msga := {
+		"alertMessage": sprintf("image: %v is not signed", [container.image]),
 		"alertScore": 7,
 		"fixPaths": [],
 		"reviewPaths": [failedPath],
 		"failedPaths": [failedPath],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		},
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }

--- a/rules/has-image-signature/raw.rego
+++ b/rules/has-image-signature/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -23,8 +24,8 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
 	wl_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	wl_kinds[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 

--- a/rules/horizontalpodautoscaler-in-default-namespace/raw.rego
+++ b/rules/horizontalpodautoscaler-in-default-namespace/raw.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -12,30 +14,26 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
-
+} else := []

--- a/rules/horizontalpodautoscaler-in-default-namespace/raw.rego
+++ b/rules/horizontalpodautoscaler-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/host-ipc-privileges/raw.rego
+++ b/rules/host-ipc-privileges/raw.rego
@@ -1,10 +1,11 @@
 package armo_builtins
 
+import rego.v1
 
 # Fails if pod has hostIPC enabled
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 	is_host_ipc(pod.spec)
 	path := "spec.hostIPC"
 	msga := {
@@ -14,56 +15,47 @@ deny[msga] {
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-
 # Fails if workload has hostIPC enabled
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	is_host_ipc(wl.spec.template.spec)
 	path := "spec.template.spec.hostIPC"
-    msga := {
-	"alertMessage": sprintf("%v: %v has a pod with hostIPC enabled", [wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("%v: %v has a pod with hostIPC enabled", [wl.kind, wl.metadata.name]),
 		"alertScore": 9,
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
 # Fails if cronjob has hostIPC enabled
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	is_host_ipc(wl.spec.jobTemplate.spec.template.spec)
 	path := "spec.jobTemplate.spec.template.spec.hostIPC"
-    msga := {
-	"alertMessage": sprintf("CronJob: %v has a pod with hostIPC enabled", [wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("CronJob: %v has a pod with hostIPC enabled", [wl.metadata.name]),
 		"alertScore": 9,
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Check that hostIPC is set to false. Default is false. Only in pod spec
 
-
-is_host_ipc(podspec){
-     podspec.hostIPC == true
+is_host_ipc(podspec) if {
+	podspec.hostIPC == true
 }

--- a/rules/host-ipc-privileges/raw.rego
+++ b/rules/host-ipc-privileges/raw.rego
@@ -1,13 +1,14 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 # Fails if pod has hostIPC enabled
 deny contains msga if {
+	path := "spec.hostIPC"
 	pod := input[_]
 	pod.kind == "Pod"
 	is_host_ipc(pod.spec)
-	path := "spec.hostIPC"
 	msga := {
 		"alertMessage": sprintf("Pod: %v has hostIPC enabled", [pod.metadata.name]),
 		"packagename": "armo_builtins",
@@ -21,11 +22,11 @@ deny contains msga if {
 
 # Fails if workload has hostIPC enabled
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	path := "spec.template.spec.hostIPC"
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	is_host_ipc(wl.spec.template.spec)
-	path := "spec.template.spec.hostIPC"
 	msga := {
 		"alertMessage": sprintf("%v: %v has a pod with hostIPC enabled", [wl.kind, wl.metadata.name]),
 		"alertScore": 9,
@@ -39,10 +40,10 @@ deny contains msga if {
 
 # Fails if cronjob has hostIPC enabled
 deny contains msga if {
+	path := "spec.jobTemplate.spec.template.spec.hostIPC"
 	wl := input[_]
 	wl.kind == "CronJob"
 	is_host_ipc(wl.spec.jobTemplate.spec.template.spec)
-	path := "spec.jobTemplate.spec.template.spec.hostIPC"
 	msga := {
 		"alertMessage": sprintf("CronJob: %v has a pod with hostIPC enabled", [wl.metadata.name]),
 		"alertScore": 9,

--- a/rules/host-network-access/raw.rego
+++ b/rules/host-network-access/raw.rego
@@ -1,64 +1,60 @@
 package armo_builtins
 
+import rego.v1
+
 # Fails if pod has hostNetwork enabled
-deny[msga] {
-    pods := [ pod | pod = input[_] ; pod.kind == "Pod"]
-    pod := pods[_]
+deny contains msga if {
+	pods := [pod | pod = input[_]; pod.kind == "Pod"]
+	pod := pods[_]
 
 	is_host_network(pod.spec)
 	path := "spec.hostNetwork"
-    msga := {
-	"alertMessage": sprintf("Pod: %v is connected to the host network", [pod.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("Pod: %v is connected to the host network", [pod.metadata.name]),
 		"alertScore": 9,
 		"deletePaths": [path],
 		"failedPaths": [path],
-		"fixPaths":[],
+		"fixPaths": [],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # Fails if workload has hostNetwork enabled
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	is_host_network(wl.spec.template.spec)
 	path := "spec.template.spec.hostNetwork"
-    msga := {
-	"alertMessage": sprintf("%v: %v has a pod connected to the host network", [wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("%v: %v has a pod connected to the host network", [wl.kind, wl.metadata.name]),
 		"alertScore": 9,
 		"deletePaths": [path],
 		"failedPaths": [path],
-		"fixPaths":[],
+		"fixPaths": [],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if cronjob has hostNetwork enabled
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	is_host_network(wl.spec.jobTemplate.spec.template.spec)
 	path := "spec.jobTemplate.spec.template.spec.hostNetwork"
-    msga := {
-	"alertMessage": sprintf("CronJob: %v has a pod connected to the host network", [wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("CronJob: %v has a pod connected to the host network", [wl.metadata.name]),
 		"alertScore": 9,
 		"deletePaths": [path],
 		"failedPaths": [path],
-		"fixPaths":[],
+		"fixPaths": [],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-is_host_network(podspec) {
-    podspec.hostNetwork == true
+is_host_network(podspec) if {
+	podspec.hostNetwork == true
 }

--- a/rules/host-network-access/raw.rego
+++ b/rules/host-network-access/raw.rego
@@ -1,14 +1,15 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 # Fails if pod has hostNetwork enabled
 deny contains msga if {
+	path := "spec.hostNetwork"
 	pods := [pod | pod = input[_]; pod.kind == "Pod"]
 	pod := pods[_]
 
 	is_host_network(pod.spec)
-	path := "spec.hostNetwork"
 	msga := {
 		"alertMessage": sprintf("Pod: %v is connected to the host network", [pod.metadata.name]),
 		"alertScore": 9,
@@ -22,11 +23,11 @@ deny contains msga if {
 
 # Fails if workload has hostNetwork enabled
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	path := "spec.template.spec.hostNetwork"
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	is_host_network(wl.spec.template.spec)
-	path := "spec.template.spec.hostNetwork"
 	msga := {
 		"alertMessage": sprintf("%v: %v has a pod connected to the host network", [wl.kind, wl.metadata.name]),
 		"alertScore": 9,
@@ -40,10 +41,10 @@ deny contains msga if {
 
 # Fails if cronjob has hostNetwork enabled
 deny contains msga if {
+	path := "spec.jobTemplate.spec.template.spec.hostNetwork"
 	wl := input[_]
 	wl.kind == "CronJob"
 	is_host_network(wl.spec.jobTemplate.spec.template.spec)
-	path := "spec.jobTemplate.spec.template.spec.hostNetwork"
 	msga := {
 		"alertMessage": sprintf("CronJob: %v has a pod connected to the host network", [wl.metadata.name]),
 		"alertScore": 9,

--- a/rules/host-pid-ipc-privileges/raw.rego
+++ b/rules/host-pid-ipc-privileges/raw.rego
@@ -1,10 +1,11 @@
 package armo_builtins
 
+import rego.v1
 
 # Fails if pod has hostPID enabled
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 	is_host_pid(pod.spec)
 	path := "spec.hostPID"
 	msga := {
@@ -14,16 +15,14 @@ deny[msga] {
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # Fails if pod has hostIPC enabled
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 	is_host_ipc(pod.spec)
 	path := "spec.hostIPC"
 	msga := {
@@ -33,98 +32,84 @@ deny[msga] {
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
-
 
 # Fails if workload has hostPID enabled
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	is_host_pid(wl.spec.template.spec)
 	path := "spec.template.spec.hostPID"
-    msga := {
-	"alertMessage": sprintf("%v: %v has a pod with hostPID enabled", [wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("%v: %v has a pod with hostPID enabled", [wl.kind, wl.metadata.name]),
 		"alertScore": 9,
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
 # Fails if workload has hostIPC enabled
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	is_host_ipc(wl.spec.template.spec)
 	path := "spec.template.spec.hostIPC"
-    msga := {
-	"alertMessage": sprintf("%v: %v has a pod with hostIPC enabled", [wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("%v: %v has a pod with hostIPC enabled", [wl.kind, wl.metadata.name]),
 		"alertScore": 9,
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if cronjob has hostPID enabled
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	is_host_pid(wl.spec.jobTemplate.spec.template.spec)
 	path := "spec.jobTemplate.spec.template.spec.hostPID"
-    msga := {
-	"alertMessage": sprintf("CronJob: %v has a pod with hostPID enabled", [wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("CronJob: %v has a pod with hostPID enabled", [wl.metadata.name]),
 		"alertScore": 9,
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
 # Fails if cronjob has hostIPC enabled
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	is_host_ipc(wl.spec.jobTemplate.spec.template.spec)
 	path := "spec.jobTemplate.spec.template.spec.hostIPC"
-    msga := {
-	"alertMessage": sprintf("CronJob: %v has a pod with hostIPC enabled", [wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("CronJob: %v has a pod with hostIPC enabled", [wl.metadata.name]),
 		"alertScore": 9,
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Check that hostPID and hostIPC are set to false. Default is false. Only in pod spec
 
-
-is_host_pid(podspec){
-    podspec.hostPID == true
+is_host_pid(podspec) if {
+	podspec.hostPID == true
 }
 
-is_host_ipc(podspec){
-     podspec.hostIPC == true
+is_host_ipc(podspec) if {
+	podspec.hostIPC == true
 }

--- a/rules/host-pid-ipc-privileges/raw.rego
+++ b/rules/host-pid-ipc-privileges/raw.rego
@@ -1,13 +1,14 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 # Fails if pod has hostPID enabled
 deny contains msga if {
+	path := "spec.hostPID"
 	pod := input[_]
 	pod.kind == "Pod"
 	is_host_pid(pod.spec)
-	path := "spec.hostPID"
 	msga := {
 		"alertMessage": sprintf("Pod: %v has hostPID enabled", [pod.metadata.name]),
 		"packagename": "armo_builtins",
@@ -21,10 +22,10 @@ deny contains msga if {
 
 # Fails if pod has hostIPC enabled
 deny contains msga if {
+	path := "spec.hostIPC"
 	pod := input[_]
 	pod.kind == "Pod"
 	is_host_ipc(pod.spec)
-	path := "spec.hostIPC"
 	msga := {
 		"alertMessage": sprintf("Pod: %v has hostIPC enabled", [pod.metadata.name]),
 		"packagename": "armo_builtins",
@@ -38,10 +39,10 @@ deny contains msga if {
 
 # Fails if workload has hostPID enabled
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
-	is_host_pid(wl.spec.template.spec)
 	path := "spec.template.spec.hostPID"
+	wl := input[_]
+	is_host_pid(wl.spec.template.spec)
 	msga := {
 		"alertMessage": sprintf("%v: %v has a pod with hostPID enabled", [wl.kind, wl.metadata.name]),
 		"alertScore": 9,
@@ -55,10 +56,10 @@ deny contains msga if {
 
 # Fails if workload has hostIPC enabled
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
-	is_host_ipc(wl.spec.template.spec)
 	path := "spec.template.spec.hostIPC"
+	wl := input[_]
+	is_host_ipc(wl.spec.template.spec)
 	msga := {
 		"alertMessage": sprintf("%v: %v has a pod with hostIPC enabled", [wl.kind, wl.metadata.name]),
 		"alertScore": 9,
@@ -72,10 +73,10 @@ deny contains msga if {
 
 # Fails if cronjob has hostPID enabled
 deny contains msga if {
+	path := "spec.jobTemplate.spec.template.spec.hostPID"
 	wl := input[_]
 	wl.kind == "CronJob"
 	is_host_pid(wl.spec.jobTemplate.spec.template.spec)
-	path := "spec.jobTemplate.spec.template.spec.hostPID"
 	msga := {
 		"alertMessage": sprintf("CronJob: %v has a pod with hostPID enabled", [wl.metadata.name]),
 		"alertScore": 9,
@@ -89,10 +90,10 @@ deny contains msga if {
 
 # Fails if cronjob has hostIPC enabled
 deny contains msga if {
+	path := "spec.jobTemplate.spec.template.spec.hostIPC"
 	wl := input[_]
 	wl.kind == "CronJob"
 	is_host_ipc(wl.spec.jobTemplate.spec.template.spec)
-	path := "spec.jobTemplate.spec.template.spec.hostIPC"
 	msga := {
 		"alertMessage": sprintf("CronJob: %v has a pod with hostIPC enabled", [wl.metadata.name]),
 		"alertScore": 9,

--- a/rules/host-pid-privileges/raw.rego
+++ b/rules/host-pid-privileges/raw.rego
@@ -1,10 +1,11 @@
 package armo_builtins
 
+import rego.v1
 
 # Fails if pod has hostPID enabled
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 	is_host_pid(pod.spec)
 	path := "spec.hostPID"
 	msga := {
@@ -14,58 +15,47 @@ deny[msga] {
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-
 # Fails if workload has hostPID enabled
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	is_host_pid(wl.spec.template.spec)
 	path := "spec.template.spec.hostPID"
-    msga := {
-	"alertMessage": sprintf("%v: %v has a pod with hostPID enabled", [wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("%v: %v has a pod with hostPID enabled", [wl.kind, wl.metadata.name]),
 		"alertScore": 9,
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
 # Fails if cronjob has hostPID enabled
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	is_host_pid(wl.spec.jobTemplate.spec.template.spec)
 	path := "spec.jobTemplate.spec.template.spec.hostPID"
-    msga := {
-	"alertMessage": sprintf("CronJob: %v has a pod with hostPID enabled", [wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("CronJob: %v has a pod with hostPID enabled", [wl.metadata.name]),
 		"alertScore": 9,
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
-
 # Check that hostPID and are set to false. Default is false. Only in pod spec
 
-
-is_host_pid(podspec){
-    podspec.hostPID == true
+is_host_pid(podspec) if {
+	podspec.hostPID == true
 }

--- a/rules/host-pid-privileges/raw.rego
+++ b/rules/host-pid-privileges/raw.rego
@@ -1,13 +1,14 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 # Fails if pod has hostPID enabled
 deny contains msga if {
+	path := "spec.hostPID"
 	pod := input[_]
 	pod.kind == "Pod"
 	is_host_pid(pod.spec)
-	path := "spec.hostPID"
 	msga := {
 		"alertMessage": sprintf("Pod: %v has hostPID enabled", [pod.metadata.name]),
 		"packagename": "armo_builtins",
@@ -21,11 +22,11 @@ deny contains msga if {
 
 # Fails if workload has hostPID enabled
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	path := "spec.template.spec.hostPID"
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	is_host_pid(wl.spec.template.spec)
-	path := "spec.template.spec.hostPID"
 	msga := {
 		"alertMessage": sprintf("%v: %v has a pod with hostPID enabled", [wl.kind, wl.metadata.name]),
 		"alertScore": 9,
@@ -39,10 +40,10 @@ deny contains msga if {
 
 # Fails if cronjob has hostPID enabled
 deny contains msga if {
+	path := "spec.jobTemplate.spec.template.spec.hostPID"
 	wl := input[_]
 	wl.kind == "CronJob"
 	is_host_pid(wl.spec.jobTemplate.spec.template.spec)
-	path := "spec.jobTemplate.spec.template.spec.hostPID"
 	msga := {
 		"alertMessage": sprintf("CronJob: %v has a pod with hostPID enabled", [wl.metadata.name]),
 		"alertScore": 9,

--- a/rules/if-proxy-kubeconfig-file-exists-ensure-ownership-is-set-to-root-root/raw.rego
+++ b/rules/if-proxy-kubeconfig-file-exists-ensure-ownership-is-set-to-root-root/raw.rego
@@ -1,10 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
-
 import data.cautils
+import rego.v1
 
-deny[msg] {
+deny contains msg if {
 	# Filter out irrelevent resources
 	obj = input[_]
 	is_kubproxy_info(obj)
@@ -45,17 +44,16 @@ deny[msg] {
 	}
 }
 
-
-is_kubproxy_info(obj) {
+is_kubproxy_info(obj) if {
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 	obj.kind == "KubeProxyInfo"
 }
 
-allowed_ownership(ownership, user, group) {
+allowed_ownership(ownership, user, group) if {
 	ownership.error # Do not fail if ownership is not found
 }
 
-allowed_ownership(ownership, user, group) {
+allowed_ownership(ownership, user, group) if {
 	ownership.username == user
 	ownership.groupname == group
 }

--- a/rules/if-proxy-kubeconfig-file-exists-ensure-ownership-is-set-to-root-root/raw.rego
+++ b/rules/if-proxy-kubeconfig-file-exists-ensure-ownership-is-set-to-root-root/raw.rego
@@ -1,19 +1,21 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "kubeConfigFile"]
+	allowed_user := "root"
+	allowed_group := "root"
+
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_kubproxy_info(obj)
 
-	file_obj_path := ["data", "kubeConfigFile"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual ownership check
-	allowed_user := "root"
-	allowed_group := "root"
 	not allowed_ownership(file.ownership, allowed_user, allowed_group)
 
 	# Build the message

--- a/rules/if-proxy-kubeconfig-file-exists-ensure-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/if-proxy-kubeconfig-file-exists-ensure-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,10 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
-
 import data.cautils
+import rego.v1
 
-deny[msg] {
+deny contains msg if {
 	# Filter out irrelevent resources
 	obj = input[_]
 	is_kubproxy_info(obj)
@@ -37,7 +36,7 @@ deny[msg] {
 	}
 }
 
-is_kubproxy_info(obj) {
+is_kubproxy_info(obj) if {
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 	obj.kind == "KubeProxyInfo"
 }

--- a/rules/if-proxy-kubeconfig-file-exists-ensure-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/if-proxy-kubeconfig-file-exists-ensure-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,18 +1,20 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "kubeConfigFile"]
+	allowed_perms := 384 # == 0o600
+
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_kubproxy_info(obj)
 
-	file_obj_path := ["data", "kubeConfigFile"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual permissions test
-	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 
 	# Build the message

--- a/rules/if-the-kubelet-config.yaml-configuration-file-is-being-used-validate-permissions-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/if-the-kubelet-config.yaml-configuration-file-is-being-used-validate-permissions-set-to-600-or-more-restrictive/raw.rego
@@ -1,18 +1,20 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "configFile"]
+	allowed_perms := 384 # == 0o600
+
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_kubelet_info(obj)
 
-	file_obj_path := ["data", "configFile"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual permissions test
-	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 
 	# Build the message

--- a/rules/if-the-kubelet-config.yaml-configuration-file-is-being-used-validate-permissions-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/if-the-kubelet-config.yaml-configuration-file-is-being-used-validate-permissions-set-to-600-or-more-restrictive/raw.rego
@@ -1,10 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
-
 import data.cautils
+import rego.v1
 
-deny[msg] {
+deny contains msg if {
 	# Filter out irrelevent resources
 	obj = input[_]
 	is_kubelet_info(obj)
@@ -37,7 +36,7 @@ deny[msg] {
 	}
 }
 
-is_kubelet_info(obj) {
+is_kubelet_info(obj) if {
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 	obj.kind == "KubeletInfo"
 }

--- a/rules/image-pull-policy-is-not-set-to-always/raw.rego
+++ b/rules/image-pull-policy-is-not-set-to-always/raw.rego
@@ -1,11 +1,12 @@
 package armo_builtins
 
+import rego.v1
 
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 	container := pod.spec.containers[i]
-    is_bad_container(container)
+	is_bad_container(container)
 	paths = [sprintf("spec.containers[%v].image", [format_int(i, 10)]), sprintf("spec.containers[%v].imagePullPolicy", [format_int(i, 10)])]
 	msga := {
 		"alertMessage": sprintf("container: %v in pod: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, pod.metadata.name]),
@@ -13,97 +14,90 @@ deny[msga] {
 		"alertScore": 2,
 		"reviewPaths": paths,
 		"failedPaths": paths,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	paths = [sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)]), sprintf("spec.template.spec.containers[%v].imagePullPolicy", [format_int(i, 10)])]
-    is_bad_container(container)
+	is_bad_container(container)
 	msga := {
 		"alertMessage": sprintf("container: %v in %v: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 2,
 		"reviewPaths": paths,
 		"failedPaths": paths,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-deny[msga] {
-    wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
 	paths = [sprintf("spec.jobTemplate.spec.template.spec.containers[%v].image", [format_int(i, 10)]), sprintf("spec.jobTemplate.spec.template.spec.containers[%v].imagePullPolicy", [format_int(i, 10)])]
-    is_bad_container(container)
+	is_bad_container(container)
 	msga := {
 		"alertMessage": sprintf("container: %v in cronjob: %v  has 'latest' tag on image but imagePullPolicy is not set to 'Always'", [container.name, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 2,
 		"reviewPaths": paths,
 		"failedPaths": paths,
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # image tag is latest
-is_bad_container(container){
-    reg := ":[\\w][\\w.-]{0,127}(\/)?"
-    version := regex.find_all_string_submatch_n(reg, container.image, -1)
-    v := version[_]
-    img := v[_]
-    img == ":latest"
-    not_image_pull_policy(container)
+is_bad_container(container) if {
+	reg := ":[\\w][\\w.-]{0,127}(\/)?"
+	version := regex.find_all_string_submatch_n(reg, container.image, -1)
+	v := version[_]
+	img := v[_]
+	img == ":latest"
+	not_image_pull_policy(container)
 }
 
 # No image tag or digest (== latest)
-is_bad_container(container){
-    not is_tag_image(container.image)
-    not_image_pull_policy(container)
+is_bad_container(container) if {
+	not is_tag_image(container.image)
+	not_image_pull_policy(container)
 }
 
 # image tag is only letters (== latest)
-is_bad_container(container){
-    is_tag_image_only_letters(container.image)
-    not_image_pull_policy(container)
+is_bad_container(container) if {
+	is_tag_image_only_letters(container.image)
+	not_image_pull_policy(container)
 }
 
-not_image_pull_policy(container) {
-     container.imagePullPolicy == "Never"
+not_image_pull_policy(container) if {
+	container.imagePullPolicy == "Never"
 }
 
-
-not_image_pull_policy(container) {
-     container.imagePullPolicy == "IfNotPresent"
+not_image_pull_policy(container) if {
+	container.imagePullPolicy == "IfNotPresent"
 }
 
-is_tag_image(image) {
-    reg := ":[\\w][\\w.-]{0,127}(\/)?"
-    version := regex.find_all_string_submatch_n(reg, image, -1)
-    v := version[_]
-    img := v[_]
-    not endswith(img, "/")
+is_tag_image(image) if {
+	reg := ":[\\w][\\w.-]{0,127}(\/)?"
+	version := regex.find_all_string_submatch_n(reg, image, -1)
+	v := version[_]
+	img := v[_]
+	not endswith(img, "/")
 }
 
 # The image has a tag, and contains only letters
-is_tag_image_only_letters(image) {
-    reg := ":[\\w][\\w.-]{0,127}(\/)?"
-    version := regex.find_all_string_submatch_n(reg, image, -1)
-    v := version[_]
-    img := v[_]
+is_tag_image_only_letters(image) if {
+	reg := ":[\\w][\\w.-]{0,127}(\/)?"
+	version := regex.find_all_string_submatch_n(reg, image, -1)
+	v := version[_]
+	img := v[_]
 	reg1 := "^:[a-zA-Z]{1,127}$"
-	re_match(reg1, img)
+	regex.match(reg1, img)
 }

--- a/rules/image-pull-policy-is-not-set-to-always/raw.rego
+++ b/rules/image-pull-policy-is-not-set-to-always/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -20,8 +21,8 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	paths = [sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)]), sprintf("spec.template.spec.containers[%v].imagePullPolicy", [format_int(i, 10)])]
@@ -56,12 +57,12 @@ deny contains msga if {
 
 # image tag is latest
 is_bad_container(container) if {
+	not_image_pull_policy(container)
 	reg := ":[\\w][\\w.-]{0,127}(\/)?"
 	version := regex.find_all_string_submatch_n(reg, container.image, -1)
 	v := version[_]
 	img := v[_]
 	img == ":latest"
-	not_image_pull_policy(container)
 }
 
 # No image tag or digest (== latest)
@@ -94,10 +95,10 @@ is_tag_image(image) if {
 
 # The image has a tag, and contains only letters
 is_tag_image_only_letters(image) if {
+	reg1 := "^:[a-zA-Z]{1,127}$"
 	reg := ":[\\w][\\w.-]{0,127}(\/)?"
 	version := regex.find_all_string_submatch_n(reg, image, -1)
 	v := version[_]
 	img := v[_]
-	reg1 := "^:[a-zA-Z]{1,127}$"
 	regex.match(reg1, img)
 }

--- a/rules/immutable-container-filesystem/raw.rego
+++ b/rules/immutable-container-filesystem/raw.rego
@@ -1,13 +1,14 @@
 package armo_builtins
 
+import rego.v1
 
 # Fails if pods has container with mutable filesystem
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 	container := pod.spec.containers[i]
 	start_of_path := "spec."
-    is_mutable_filesystem(container)
+	is_mutable_filesystem(container)
 	fixPath = {"path": sprintf("%vcontainers[%d].securityContext.readOnlyRootFilesystem", [start_of_path, i]), "value": "true"}
 	msga := {
 		"alertMessage": sprintf("container: %v in pod: %v  has  mutable filesystem", [container.name, pod.metadata.name]),
@@ -15,20 +16,18 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [fixPath],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-# Fails if workload has  container with mutable filesystem 
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+# Fails if workload has  container with mutable filesystem
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
+	container := wl.spec.template.spec.containers[i]
 	start_of_path := "spec.template.spec."
-    is_mutable_filesystem(container)
+	is_mutable_filesystem(container)
 	fixPath = {"path": sprintf("%vcontainers[%d].securityContext.readOnlyRootFilesystem", [start_of_path, i]), "value": "true"}
 	msga := {
 		"alertMessage": sprintf("container :%v in %v: %v has  mutable filesystem", [container.name, wl.kind, wl.metadata.name]),
@@ -36,15 +35,12 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [fixPath],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
-# Fails if cronjob has  container with mutable filesystem 
-deny[msga] {
+# Fails if cronjob has  container with mutable filesystem
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
@@ -58,18 +54,16 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [fixPath],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Default of readOnlyRootFilesystem is false. This field is only in container spec and not pod spec
-is_mutable_filesystem(container) {
+is_mutable_filesystem(container) if {
 	container.securityContext.readOnlyRootFilesystem == false
 }
 
-is_mutable_filesystem(container) {
+is_mutable_filesystem(container) if {
 	not container.securityContext.readOnlyRootFilesystem == false
-    not container.securityContext.readOnlyRootFilesystem == true
+	not container.securityContext.readOnlyRootFilesystem == true
 }

--- a/rules/immutable-container-filesystem/raw.rego
+++ b/rules/immutable-container-filesystem/raw.rego
@@ -1,13 +1,14 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 # Fails if pods has container with mutable filesystem
 deny contains msga if {
+	start_of_path := "spec."
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
-	start_of_path := "spec."
 	is_mutable_filesystem(container)
 	fixPath = {"path": sprintf("%vcontainers[%d].securityContext.readOnlyRootFilesystem", [start_of_path, i]), "value": "true"}
 	msga := {
@@ -22,11 +23,11 @@ deny contains msga if {
 
 # Fails if workload has  container with mutable filesystem
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	start_of_path := "spec.template.spec."
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
-	start_of_path := "spec.template.spec."
 	is_mutable_filesystem(container)
 	fixPath = {"path": sprintf("%vcontainers[%d].securityContext.readOnlyRootFilesystem", [start_of_path, i]), "value": "true"}
 	msga := {
@@ -41,10 +42,10 @@ deny contains msga if {
 
 # Fails if cronjob has  container with mutable filesystem
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	is_mutable_filesystem(container)
 	fixPath = {"path": sprintf("%vcontainers[%d].securityContext.readOnlyRootFilesystem", [start_of_path, i]), "value": "true"}
 

--- a/rules/ingress-and-egress-blocked/raw.rego
+++ b/rules/ingress-and-egress-blocked/raw.rego
@@ -1,29 +1,31 @@
 package armo_builtins
 
+import rego.v1
+
 # Helper to identify all network policy types
-is_network_policy(obj) {
+is_network_policy(obj) if {
 	obj.kind == "NetworkPolicy"
 }
 
-is_network_policy(obj) {
+is_network_policy(obj) if {
 	obj.kind == "CiliumNetworkPolicy"
 }
 
-is_network_policy(obj) {
+is_network_policy(obj) if {
 	obj.kind == "CiliumClusterwideNetworkPolicy"
 }
 
 # Returns the list of CiliumNetworkPolicySpec entries, unifying the
 # `spec:` (single) and `specs:` (list) forms documented for CNP/CCNP CRDs.
 # Either field may be present; both is also legal in Cilium.
-cilium_policy_specs(policy) = specs {
+cilium_policy_specs(policy) := specs if {
 	from_spec := [s | s := policy.spec]
 	from_specs := object.get(policy, "specs", [])
 	specs := array.concat(from_spec, from_specs)
 }
 
 # For pods
-deny[msga] {
+deny contains msga if {
 	pods := [pod | pod = input[_]; pod.kind == "Pod"]
 	networkpolicies := [networkpolicie | networkpolicie = input[_]; is_network_policy(networkpolicie)]
 	pod := pods[_]
@@ -38,14 +40,12 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod],
-		},
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # For pods
-deny[msga] {
+deny contains msga if {
 	pods := [pod | pod = input[_]; pod.kind == "Pod"]
 	networkpolicies := [networkpolicie | networkpolicie = input[_]; is_network_policy(networkpolicie)]
 	pod := pods[_]
@@ -58,14 +58,12 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod],
-		},
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # For workloads
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
@@ -81,14 +79,12 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl],
-		},
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # For workloads
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
@@ -102,14 +98,12 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl],
-		},
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # For Cronjobs
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	networkpolicies := [networkpolicie | networkpolicie = input[_]; is_network_policy(networkpolicie)]
@@ -124,14 +118,12 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl],
-		},
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # For Cronjobs
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	networkpolicies := [networkpolicie | networkpolicie = input[_]; is_network_policy(networkpolicie)]
@@ -144,27 +136,25 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl],
-		},
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	metadata1.namespace == metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	not metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata2.namespace
 	metadata1.namespace == "default"
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	metadata2.namespace == "default"
 }
@@ -172,7 +162,7 @@ is_same_namespace(metadata1, metadata2) {
 # --- Cilium endpointSelector match (shared across pod/workload/cronjob) ---
 
 # matchLabels with keys: every key on the selector must equal the corresponding label.
-cilium_endpoint_selector_matches(spec, labels) {
+cilium_endpoint_selector_matches(spec, labels) if {
 	count(spec.endpointSelector.matchLabels) > 0
 	count({x | spec.endpointSelector.matchLabels[x] == labels[x]}) == count(spec.endpointSelector.matchLabels)
 }
@@ -180,7 +170,7 @@ cilium_endpoint_selector_matches(spec, labels) {
 # Selects-all: covers `endpointSelector: {}` and `endpointSelector: { matchLabels: {} }`.
 # A non-empty matchExpressions makes the selector selective, NOT match-all
 # (per Kubernetes LabelSelector: matchLabels AND matchExpressions must both match).
-cilium_endpoint_selector_matches(spec, _) {
+cilium_endpoint_selector_matches(spec, _) if {
 	count(object.get(spec.endpointSelector, "matchLabels", {})) == 0
 	count(object.get(spec.endpointSelector, "matchExpressions", [])) == 0
 }
@@ -188,7 +178,7 @@ cilium_endpoint_selector_matches(spec, _) {
 # --- Pod connection checks ---
 
 # Standard NetworkPolicy with podSelector (with labels)
-pod_connected_to_network_policy(pod, networkpolicie) {
+pod_connected_to_network_policy(pod, networkpolicie) if {
 	networkpolicie.kind == "NetworkPolicy"
 	is_same_namespace(networkpolicie.metadata, pod.metadata)
 	count(networkpolicie.spec.podSelector) > 0
@@ -196,14 +186,14 @@ pod_connected_to_network_policy(pod, networkpolicie) {
 }
 
 # Standard NetworkPolicy with empty podSelector (selects all pods in namespace)
-pod_connected_to_network_policy(pod, networkpolicie) {
+pod_connected_to_network_policy(pod, networkpolicie) if {
 	networkpolicie.kind == "NetworkPolicy"
 	is_same_namespace(networkpolicie.metadata, pod.metadata)
 	count(networkpolicie.spec.podSelector) == 0
 }
 
 # CiliumNetworkPolicy: any spec (singular `spec:` or any entry of `specs:`) matches the pod
-pod_connected_to_network_policy(pod, networkpolicie) {
+pod_connected_to_network_policy(pod, networkpolicie) if {
 	networkpolicie.kind == "CiliumNetworkPolicy"
 	is_same_namespace(networkpolicie.metadata, pod.metadata)
 	spec := cilium_policy_specs(networkpolicie)[_]
@@ -211,7 +201,7 @@ pod_connected_to_network_policy(pod, networkpolicie) {
 }
 
 # CiliumClusterwideNetworkPolicy: same, no namespace check
-pod_connected_to_network_policy(pod, networkpolicie) {
+pod_connected_to_network_policy(pod, networkpolicie) if {
 	networkpolicie.kind == "CiliumClusterwideNetworkPolicy"
 	spec := cilium_policy_specs(networkpolicie)[_]
 	cilium_endpoint_selector_matches(spec, object.get(pod.metadata, "labels", {}))
@@ -220,14 +210,14 @@ pod_connected_to_network_policy(pod, networkpolicie) {
 # --- Workload connection checks ---
 
 # Standard NetworkPolicy with empty podSelector
-wlConnectedToNetworkPolicy(wl, networkpolicie) {
+wlConnectedToNetworkPolicy(wl, networkpolicie) if {
 	networkpolicie.kind == "NetworkPolicy"
 	is_same_namespace(wl.metadata, networkpolicie.metadata)
 	count(networkpolicie.spec.podSelector) == 0
 }
 
 # Standard NetworkPolicy with podSelector (with labels)
-wlConnectedToNetworkPolicy(wl, networkpolicie) {
+wlConnectedToNetworkPolicy(wl, networkpolicie) if {
 	networkpolicie.kind == "NetworkPolicy"
 	is_same_namespace(wl.metadata, networkpolicie.metadata)
 	count(networkpolicie.spec.podSelector) > 0
@@ -235,7 +225,7 @@ wlConnectedToNetworkPolicy(wl, networkpolicie) {
 }
 
 # CiliumNetworkPolicy
-wlConnectedToNetworkPolicy(wl, networkpolicie) {
+wlConnectedToNetworkPolicy(wl, networkpolicie) if {
 	networkpolicie.kind == "CiliumNetworkPolicy"
 	is_same_namespace(wl.metadata, networkpolicie.metadata)
 	spec := cilium_policy_specs(networkpolicie)[_]
@@ -243,7 +233,7 @@ wlConnectedToNetworkPolicy(wl, networkpolicie) {
 }
 
 # CiliumClusterwideNetworkPolicy
-wlConnectedToNetworkPolicy(wl, networkpolicie) {
+wlConnectedToNetworkPolicy(wl, networkpolicie) if {
 	networkpolicie.kind == "CiliumClusterwideNetworkPolicy"
 	spec := cilium_policy_specs(networkpolicie)[_]
 	cilium_endpoint_selector_matches(spec, object.get(wl.spec.template.metadata, "labels", {}))
@@ -252,14 +242,14 @@ wlConnectedToNetworkPolicy(wl, networkpolicie) {
 # --- CronJob connection checks ---
 
 # Standard NetworkPolicy with empty podSelector
-cronjob_connected_to_network_policy(cj, networkpolicie) {
+cronjob_connected_to_network_policy(cj, networkpolicie) if {
 	networkpolicie.kind == "NetworkPolicy"
 	is_same_namespace(cj.metadata, networkpolicie.metadata)
 	count(networkpolicie.spec.podSelector) == 0
 }
 
 # Standard NetworkPolicy with podSelector (with labels)
-cronjob_connected_to_network_policy(cj, networkpolicie) {
+cronjob_connected_to_network_policy(cj, networkpolicie) if {
 	networkpolicie.kind == "NetworkPolicy"
 	is_same_namespace(cj.metadata, networkpolicie.metadata)
 	count(networkpolicie.spec.podSelector) > 0
@@ -267,7 +257,7 @@ cronjob_connected_to_network_policy(cj, networkpolicie) {
 }
 
 # CiliumNetworkPolicy
-cronjob_connected_to_network_policy(cj, networkpolicie) {
+cronjob_connected_to_network_policy(cj, networkpolicie) if {
 	networkpolicie.kind == "CiliumNetworkPolicy"
 	is_same_namespace(cj.metadata, networkpolicie.metadata)
 	spec := cilium_policy_specs(networkpolicie)[_]
@@ -275,7 +265,7 @@ cronjob_connected_to_network_policy(cj, networkpolicie) {
 }
 
 # CiliumClusterwideNetworkPolicy
-cronjob_connected_to_network_policy(cj, networkpolicie) {
+cronjob_connected_to_network_policy(cj, networkpolicie) if {
 	networkpolicie.kind == "CiliumClusterwideNetworkPolicy"
 	spec := cilium_policy_specs(networkpolicie)[_]
 	cilium_endpoint_selector_matches(spec, object.get(cj.spec.jobTemplate.spec.template.metadata, "labels", {}))
@@ -284,43 +274,43 @@ cronjob_connected_to_network_policy(cj, networkpolicie) {
 # --- Ingress/Egress policy checks ---
 
 # Standard NetworkPolicy: check policyTypes
-is_ingerss_egress_policy(networkpolicie) {
+is_ingerss_egress_policy(networkpolicie) if {
 	networkpolicie.kind == "NetworkPolicy"
 	list_contains(networkpolicie.spec.policyTypes, "Ingress")
 }
 
-is_ingerss_egress_policy(networkpolicie) {
+is_ingerss_egress_policy(networkpolicie) if {
 	networkpolicie.kind == "NetworkPolicy"
 	list_contains(networkpolicie.spec.policyTypes, "Egress")
 }
 
 # CiliumNetworkPolicy / CCNP: presence of `ingress`/`egress` on any spec entry
 # determines direction (CNP/CCNP have no `policyTypes`).
-is_ingerss_egress_policy(networkpolicie) {
+is_ingerss_egress_policy(networkpolicie) if {
 	networkpolicie.kind == "CiliumNetworkPolicy"
 	spec := cilium_policy_specs(networkpolicie)[_]
 	spec.ingress
 }
 
-is_ingerss_egress_policy(networkpolicie) {
+is_ingerss_egress_policy(networkpolicie) if {
 	networkpolicie.kind == "CiliumNetworkPolicy"
 	spec := cilium_policy_specs(networkpolicie)[_]
 	spec.egress
 }
 
-is_ingerss_egress_policy(networkpolicie) {
+is_ingerss_egress_policy(networkpolicie) if {
 	networkpolicie.kind == "CiliumClusterwideNetworkPolicy"
 	spec := cilium_policy_specs(networkpolicie)[_]
 	spec.ingress
 }
 
-is_ingerss_egress_policy(networkpolicie) {
+is_ingerss_egress_policy(networkpolicie) if {
 	networkpolicie.kind == "CiliumClusterwideNetworkPolicy"
 	spec := cilium_policy_specs(networkpolicie)[_]
 	spec.egress
 }
 
-list_contains(list, element) {
+list_contains(list, element) if {
 	some i
 	list[i] == element
 }

--- a/rules/ingress-and-egress-blocked/raw.rego
+++ b/rules/ingress-and-egress-blocked/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -64,8 +65,8 @@ deny contains msga if {
 
 # For workloads
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	networkpolicies := [networkpolicie | networkpolicie = input[_]; is_network_policy(networkpolicie)]
 	network_policies_connected_to_pod := [networkpolicie | networkpolicie = networkpolicies[_]; wlConnectedToNetworkPolicy(wl, networkpolicie)]
@@ -85,8 +86,8 @@ deny contains msga if {
 
 # For workloads
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	networkpolicies := [networkpolicie | networkpolicie = input[_]; is_network_policy(networkpolicie)]
 	network_policies_connected_to_pod := [networkpolicie | networkpolicie = networkpolicies[_]; wlConnectedToNetworkPolicy(wl, networkpolicie)]

--- a/rules/ingress-in-default-namespace/raw.rego
+++ b/rules/ingress-in-default-namespace/raw.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -12,30 +14,26 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
-
+} else := []

--- a/rules/ingress-in-default-namespace/raw.rego
+++ b/rules/ingress-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/ingress-no-tls/raw.rego
+++ b/rules/ingress-no-tls/raw.rego
@@ -1,7 +1,9 @@
 package armo_builtins
 
+import rego.v1
+
 # Checks if Ingress is connected to a service and a workload to expose something
-deny[msga] {
+deny contains msga if {
 	ingress := input[_]
 	ingress.kind == "Ingress"
 
@@ -13,10 +15,10 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"failedPaths": [],
 		"fixPaths": [{
-        "path": "spec.tls",
-        "value": "<your-tls-definition>"
-        }],
+			"path": "spec.tls",
+			"value": "<your-tls-definition>",
+		}],
 		"alertScore": 7,
-		"alertObject": {"k8sApiObjects": [ingress]}
+		"alertObject": {"k8sApiObjects": [ingress]},
 	}
 }

--- a/rules/ingress-no-tls/raw.rego
+++ b/rules/ingress-no-tls/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/insecure-capabilities/raw.rego
+++ b/rules/insecure-capabilities/raw.rego
@@ -1,13 +1,15 @@
 package armo_builtins
 
+import rego.v1
+
 import data.cautils
 
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 	container := pod.spec.containers[i]
 	start_of_path := "spec."
-    result := is_dangerous_capabilities(container, start_of_path, i)
+	result := is_dangerous_capabilities(container, start_of_path, i)
 	msga := {
 		"alertMessage": sprintf("container: %v in pod: %v  have dangerous capabilities", [container.name, pod.metadata.name]),
 		"packagename": "armo_builtins",
@@ -15,19 +17,17 @@ deny[msga] {
 		"deletePaths": result,
 		"failedPaths": result,
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	start_of_path := "spec.template.spec."
-    result := is_dangerous_capabilities(container, start_of_path, i)
+	result := is_dangerous_capabilities(container, start_of_path, i)
 	msga := {
 		"alertMessage": sprintf("container: %v in workload: %v  have dangerous capabilities", [container.name, wl.metadata.name]),
 		"packagename": "armo_builtins",
@@ -35,18 +35,16 @@ deny[msga] {
 		"deletePaths": result,
 		"failedPaths": result,
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-deny[msga] {
-    wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
 	start_of_path := "spec.jobTemplate.spec.template.spec."
-    result := is_dangerous_capabilities(container, start_of_path, i)
+	result := is_dangerous_capabilities(container, start_of_path, i)
 	msga := {
 		"alertMessage": sprintf("container: %v in cronjob: %v  have dangerous capabilities", [container.name, wl.metadata.name]),
 		"packagename": "armo_builtins",
@@ -54,15 +52,13 @@ deny[msga] {
 		"deletePaths": result,
 		"failedPaths": result,
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-is_dangerous_capabilities(container, start_of_path, i) = path {
+is_dangerous_capabilities(container, start_of_path, i) := path if {
 	# see default-config-inputs.json for list values
-    insecureCapabilities := data.postureControlInputs.insecureCapabilities
+	insecureCapabilities := data.postureControlInputs.insecureCapabilities
 	path = [sprintf("%vcontainers[%v].securityContext.capabilities.add[%v]", [start_of_path, format_int(i, 10), format_int(k, 10)]) | capability = container.securityContext.capabilities.add[k]; cautils.list_contains(insecureCapabilities, capability)]
 	count(path) > 0
 }

--- a/rules/insecure-capabilities/raw.rego
+++ b/rules/insecure-capabilities/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -5,10 +6,10 @@ import rego.v1
 import data.cautils
 
 deny contains msga if {
+	start_of_path := "spec."
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
-	start_of_path := "spec."
 	result := is_dangerous_capabilities(container, start_of_path, i)
 	msga := {
 		"alertMessage": sprintf("container: %v in pod: %v  have dangerous capabilities", [container.name, pod.metadata.name]),
@@ -22,11 +23,11 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	start_of_path := "spec.template.spec."
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
-	start_of_path := "spec.template.spec."
 	result := is_dangerous_capabilities(container, start_of_path, i)
 	msga := {
 		"alertMessage": sprintf("container: %v in workload: %v  have dangerous capabilities", [container.name, wl.metadata.name]),
@@ -40,10 +41,10 @@ deny contains msga if {
 }
 
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	result := is_dangerous_capabilities(container, start_of_path, i)
 	msga := {
 		"alertMessage": sprintf("container: %v in cronjob: %v  have dangerous capabilities", [container.name, wl.metadata.name]),

--- a/rules/insecure-port-flag/filter.rego
+++ b/rules/insecure-port-flag/filter.rego
@@ -1,20 +1,20 @@
 package armo_builtins
 
+import rego.v1
+
 import data.cautils
 
 # Fails if pod has insecure-port flag enabled
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 	contains(pod.metadata.name, "kube-apiserver")
-    container := pod.spec.containers[_]
+	container := pod.spec.containers[_]
 	msga := {
 		"alertMessage": sprintf("The API server container: %v has insecure-port flag enabled", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }

--- a/rules/insecure-port-flag/filter.rego
+++ b/rules/insecure-port-flag/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/insecure-port-flag/raw.rego
+++ b/rules/insecure-port-flag/raw.rego
@@ -1,28 +1,28 @@
 package armo_builtins
 
+import rego.v1
+
 import data.cautils
 
 # Fails if pod has insecure-port flag enabled
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 	contains(pod.metadata.name, "kube-apiserver")
-    container := pod.spec.containers[i]
+	container := pod.spec.containers[i]
 	path = is_insecure_port_flag(container, i)
 	msga := {
-		"alertMessage": sprintf("The API server container: %v has insecure-port flag enabled", [ container.name]),
+		"alertMessage": sprintf("The API server container: %v has insecure-port flag enabled", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-is_insecure_port_flag(container, i) = path {
+is_insecure_port_flag(container, i) := path if {
 	command := container.command[j]
 	contains(command, "--insecure-port=1")
 	path := sprintf("spec.containers[%v].command[%v]", [format_int(i, 10), format_int(j, 10)])

--- a/rules/insecure-port-flag/raw.rego
+++ b/rules/insecure-port-flag/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/instance-metadata-api-access/raw.rego
+++ b/rules/instance-metadata-api-access/raw.rego
@@ -1,12 +1,12 @@
 package armo_builtins
 
+import rego.v1
 
-deny[msg] {
+deny contains msg if {
 	obj = input[_]
 	is_cloud_provider_info(obj)
 
 	obj.data.providerMetaDataAPIAccess == true
-
 
 	msg := {
 		"alertMessage": sprintf("Node '%s' has access to Instance Metadata Services of cloud provider.", [obj.metadata.name]),
@@ -14,17 +14,12 @@ deny[msg] {
 		"alertScore": 1,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"externalObjects": obj
-		},
-		"packagename": "armo_builtins"
+		"alertObject": {"externalObjects": obj},
+		"packagename": "armo_builtins",
 	}
-
 }
 
-
-
-is_cloud_provider_info(obj) {
+is_cloud_provider_info(obj) if {
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 	obj.kind == "cloudProviderInfo"
 }

--- a/rules/instance-metadata-api-access/raw.rego
+++ b/rules/instance-metadata-api-access/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_cloud_provider_info(obj)
 
 	obj.data.providerMetaDataAPIAccess == true

--- a/rules/internal-networking/filter.rego
+++ b/rules/internal-networking/filter.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
+import rego.v1
+
 # input: network policies + namespaces
 # apiversion: networking.k8s.io/v1
 # returns all namespaces
 
-deny[msga] {
+deny contains msga if {
 	namespaces := [namespace | namespace = input[_]; namespace.kind == "Namespace"]
 	namespace := namespaces[_]
 
@@ -13,8 +15,6 @@ deny[msga] {
 		"alertScore": 9,
 		"packagename": "armo_builtins",
 		"failedPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }

--- a/rules/internal-networking/filter.rego
+++ b/rules/internal-networking/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/internal-networking/raw.rego
+++ b/rules/internal-networking/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -12,11 +13,11 @@ deny contains msga if {
 	# Collect namespaces from all namespaced policies (NP + CNP)
 	policy_names := [policy.metadata.namespace | policy = input[_]; is_network_policy_namespaced(policy)]
 
-	# Collect clusterwide policies that legitimately protect all namespaces
-	qualifying_ccnps := [policy | policy = input[_]; is_ccnp_cluster_wide_coverage(policy)]
-
 	# Fail if: no namespaced policy in this namespace AND no qualifying CCNPs exist
 	not list_contains(policy_names, namespace.metadata.name)
+	
+	# Collect clusterwide policies that legitimately protect all namespaces
+	qualifying_ccnps := [policy | policy = input[_]; is_ccnp_cluster_wide_coverage(policy)]
 	count(qualifying_ccnps) == 0
 
 	msga := {

--- a/rules/internal-networking/raw.rego
+++ b/rules/internal-networking/raw.rego
@@ -1,9 +1,11 @@
 package armo_builtins
 
+import rego.v1
+
 # input: network policies (NetworkPolicy, CiliumNetworkPolicy, CiliumClusterwideNetworkPolicy)
 # fails if no network policies are defined in a certain namespace
 
-deny[msga] {
+deny contains msga if {
 	namespaces := [namespace | namespace = input[_]; namespace.kind == "Namespace"]
 	namespace := namespaces[_]
 
@@ -23,24 +25,22 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [namespace],
-		},
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }
 
-is_network_policy_namespaced(policy) {
+is_network_policy_namespaced(policy) if {
 	policy.kind == "NetworkPolicy"
 }
 
-is_network_policy_namespaced(policy) {
+is_network_policy_namespaced(policy) if {
 	policy.kind == "CiliumNetworkPolicy"
 }
 
 # Returns the list of CiliumNetworkPolicySpec entries, unifying the
 # `spec:` (single) and `specs:` (list) forms documented for CNP/CCNP CRDs.
 # Either field may be present; both is also legal in Cilium.
-cilium_policy_specs(policy) = specs {
+cilium_policy_specs(policy) := specs if {
 	from_spec := [s | s := policy.spec]
 	from_specs := object.get(policy, "specs", [])
 	specs := array.concat(from_spec, from_specs)
@@ -52,7 +52,7 @@ cilium_policy_specs(policy) = specs {
 # 3. Has at least ingress or egress rules defined
 # (enableDefaultDeny, endpointSelector, ingress, egress are all per-CiliumNetworkPolicySpec.)
 
-is_ccnp_cluster_wide_coverage(policy) {
+is_ccnp_cluster_wide_coverage(policy) if {
 	policy.kind == "CiliumClusterwideNetworkPolicy"
 	spec := cilium_policy_specs(policy)[_]
 	ccnp_spec_selects_all_endpoints(spec)
@@ -62,26 +62,26 @@ is_ccnp_cluster_wide_coverage(policy) {
 
 # Covers both `endpointSelector: {}` and `endpointSelector: { matchLabels: {} }`
 # (and tolerates an empty `matchExpressions: []`).
-ccnp_spec_selects_all_endpoints(spec) {
+ccnp_spec_selects_all_endpoints(spec) if {
 	count(object.get(spec.endpointSelector, "matchLabels", {})) == 0
 	count(object.get(spec.endpointSelector, "matchExpressions", [])) == 0
 }
 
 # enableDefaultDeny explicitly disables both directions on this spec
-ccnp_spec_default_deny_disabled(spec) {
+ccnp_spec_default_deny_disabled(spec) if {
 	spec.enableDefaultDeny.ingress == false
 	spec.enableDefaultDeny.egress == false
 }
 
-ccnp_spec_has_ingress_or_egress(spec) {
+ccnp_spec_has_ingress_or_egress(spec) if {
 	spec.ingress
 }
 
-ccnp_spec_has_ingress_or_egress(spec) {
+ccnp_spec_has_ingress_or_egress(spec) if {
 	spec.egress
 }
 
-list_contains(list, element) {
+list_contains(list, element) if {
 	some i
 	list[i] == element
 }

--- a/rules/k8s-audit-logs-enabled-cloud/raw.rego
+++ b/rules/k8s-audit-logs-enabled-cloud/raw.rego
@@ -1,11 +1,10 @@
 package armo_builtins
 
-import future.keywords.every
-import future.keywords.in
+import rego.v1
 
 # =============================== GKE ===============================
 # Check if audit logs is enabled for GKE
-deny[msga] {
+deny contains msga if {
 	cluster_config := input[_]
 	cluster_config.apiVersion == "container.googleapis.com/v1"
 	cluster_config.kind == "ClusterDescribe"
@@ -29,18 +28,18 @@ deny[msga] {
 	}
 }
 
-is_logging_disabled(cluster_config) {
+is_logging_disabled(cluster_config) if {
 	not cluster_config.logging_config.component_config.enable_components
 }
 
-is_logging_disabled(cluster_config) {
+is_logging_disabled(cluster_config) if {
 	cluster_config.logging_config.component_config.enable_components
 	count(cluster_config.logging_config.component_config.enable_components) == 0
 }
 
 # =============================== EKS ===============================
 # Check if audit logs is enabled for EKS
-deny[msga] {
+deny contains msga if {
 	cluster_config := input[_]
 	cluster_config.apiVersion == "eks.amazonaws.com/v1"
 	cluster_config.kind == "ClusterDescribe"
@@ -68,13 +67,13 @@ deny[msga] {
 	}
 }
 
-all_auditlogs_enabled(logSetups, types) {
+all_auditlogs_enabled(logSetups, types) if {
 	every type in types {
 		auditlogs_enabled(logSetups, type)
 	}
 }
 
-auditlogs_enabled(logSetups, type) {
+auditlogs_enabled(logSetups, type) if {
 	logSetup := logSetups[_]
 	logSetup.Enabled == true
 	type in logSetup.Types

--- a/rules/k8s-audit-logs-enabled-cloud/raw.rego
+++ b/rules/k8s-audit-logs-enabled-cloud/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -28,18 +29,10 @@ deny contains msga if {
 	}
 }
 
-is_logging_disabled(cluster_config) if {
-	not cluster_config.logging_config.component_config.enable_components
-}
-
-is_logging_disabled(cluster_config) if {
-	cluster_config.logging_config.component_config.enable_components
-	count(cluster_config.logging_config.component_config.enable_components) == 0
-}
-
 # =============================== EKS ===============================
 # Check if audit logs is enabled for EKS
 deny contains msga if {
+	logging_types := {"api", "audit", "authenticator", "controllerManager", "scheduler"}
 	cluster_config := input[_]
 	cluster_config.apiVersion == "eks.amazonaws.com/v1"
 	cluster_config.kind == "ClusterDescribe"
@@ -49,7 +42,6 @@ deny contains msga if {
 	# logSetup is an object representing the enabled or disabled Kubernetes control plane logs for your cluster.
 	# types - available cluster control plane log types
 	# https://docs.aws.amazon.com/eks/latest/APIReference/API_LogSetup.html
-	logging_types := {"api", "audit", "authenticator", "controllerManager", "scheduler"}
 	logSetups = config.Cluster.Logging.ClusterLogging
 	not all_auditlogs_enabled(logSetups, logging_types)
 
@@ -65,6 +57,15 @@ deny contains msga if {
 			"externalObjects": cluster_config,
 		},
 	}
+}
+
+is_logging_disabled(cluster_config) if {
+	not cluster_config.logging_config.component_config.enable_components
+}
+
+is_logging_disabled(cluster_config) if {
+	cluster_config.logging_config.component_config.enable_components
+	count(cluster_config.logging_config.component_config.enable_components) == 0
 }
 
 all_auditlogs_enabled(logSetups, types) if {

--- a/rules/k8s-audit-logs-enabled-native-cis/filter.rego
+++ b/rules/k8s-audit-logs-enabled-native-cis/filter.rego
@@ -1,12 +1,14 @@
 package armo_builtins
 
-deny[msg] {
+import rego.v1
+
+deny contains msg if {
 	obj = input[_]
 	is_api_server(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }
 
-is_api_server(obj) {
+is_api_server(obj) if {
 	obj.apiVersion == "v1"
 	obj.kind == "Pod"
 	obj.metadata.namespace == "kube-system"

--- a/rules/k8s-audit-logs-enabled-native-cis/filter.rego
+++ b/rules/k8s-audit-logs-enabled-native-cis/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/k8s-audit-logs-enabled-native-cis/raw.rego
+++ b/rules/k8s-audit-logs-enabled-native-cis/raw.rego
@@ -1,7 +1,9 @@
 package armo_builtins
 
+import rego.v1
+
 # CIS 3.2.1 https://workbench.cisecurity.org/sections/1126657/recommendations/1838582
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_api_server(obj)
 	cmd := obj.spec.containers[0].command
@@ -20,7 +22,7 @@ deny[msga] {
 	}
 }
 
-is_api_server(obj) {
+is_api_server(obj) if {
 	obj.apiVersion == "v1"
 	obj.kind == "Pod"
 	obj.metadata.namespace == "kube-system"

--- a/rules/k8s-audit-logs-enabled-native-cis/raw.rego
+++ b/rules/k8s-audit-logs-enabled-native-cis/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/k8s-audit-logs-enabled-native/raw.rego
+++ b/rules/k8s-audit-logs-enabled-native/raw.rego
@@ -1,15 +1,16 @@
 package armo_builtins
 
+import rego.v1
+
 import data.cautils
 
 # Check if audit logs is  enabled for native k8s
-deny[msga] {
+deny contains msga if {
 	apiserverpod := input[_]
-    cmd := apiserverpod.spec.containers[0].command
-	audit_policy :=  [ command |command := cmd[_] ; contains(command, "--audit-policy-file=")]
-    count(audit_policy) < 1
+	cmd := apiserverpod.spec.containers[0].command
+	audit_policy := [command | command := cmd[_]; contains(command, "--audit-policy-file=")]
+	count(audit_policy) < 1
 	path := "spec.containers[0].command"
-
 
 	msga := {
 		"alertMessage": "audit logs is not enabled",
@@ -18,9 +19,6 @@ deny[msga] {
 		"reviewPaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [apiserverpod],
-
-		}
+		"alertObject": {"k8sApiObjects": [apiserverpod]},
 	}
 }

--- a/rules/k8s-audit-logs-enabled-native/raw.rego
+++ b/rules/k8s-audit-logs-enabled-native/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -6,11 +7,11 @@ import data.cautils
 
 # Check if audit logs is  enabled for native k8s
 deny contains msga if {
+	path := "spec.containers[0].command"
 	apiserverpod := input[_]
 	cmd := apiserverpod.spec.containers[0].command
 	audit_policy := [command | command := cmd[_]; contains(command, "--audit-policy-file=")]
 	count(audit_policy) < 1
-	path := "spec.containers[0].command"
 
 	msga := {
 		"alertMessage": "audit logs is not enabled",

--- a/rules/k8s-common-labels-usage/raw.rego
+++ b/rules/k8s-common-labels-usage/raw.rego
@@ -1,118 +1,108 @@
 package armo_builtins
+
+import rego.v1
+
 # Deny mutating action unless user is in group owning the resource
 
-
-
-deny[msga] {
-
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	fixPath := no_K8s_label_or_no_K8s_label_usage(pod, "")
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("in the following pod the kubernetes common labels are not defined: %v", [pod.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 1,
 		"failedPaths": [],
 		"fixPaths": fixPath,
-         "alertObject": {
-			"k8sApiObjects": [pod]
-		}
-     }
+		"alertObject": {"k8sApiObjects": [pod]},
+	}
 }
 
-
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	podSpec := wl.spec.template
 	beggining_of_pod_path := "spec.template."
 	fixPath := no_K8s_label_usage(wl, podSpec, beggining_of_pod_path)
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("%v: %v the kubernetes common labels are is not defined:", [wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 1,
 		"failedPaths": [],
 		"fixPaths": fixPath,
-         "alertObject": {
-			"k8sApiObjects": [wl]
-		}
-     }
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
 }
 
 # handles cronjob
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	podSpec := wl.spec.jobTemplate.spec.template
 	beggining_of_pod_path := "spec.jobTemplate.spec.template."
 	fixPath := no_K8s_label_usage(wl, podSpec, beggining_of_pod_path)
 
-
-    msga := {
+	msga := {
 		"alertMessage": sprintf("the following cronjobs the kubernetes common labels are not defined: %v", [wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 1,
 		"failedPaths": [],
 		"fixPaths": fixPath,
-         "alertObject": {
-			"k8sApiObjects": [wl]
-		}
-     }
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
 }
 
-
-
 # There is no label-usage in WL and also for his Pod
-no_K8s_label_usage(wl, podSpec, beggining_of_pod_path) = path{
+no_K8s_label_usage(wl, podSpec, beggining_of_pod_path) := path if {
 	path1 := no_K8s_label_or_no_K8s_label_usage(wl, "")
 	path2 := no_K8s_label_or_no_K8s_label_usage(podSpec, beggining_of_pod_path)
 	path = array.concat(path1, path2)
 }
 
 # There is label-usage for WL but not for his Pod
-no_K8s_label_usage(wl, podSpec, beggining_of_pod_path) = path{
+no_K8s_label_usage(wl, podSpec, beggining_of_pod_path) := path if {
 	not no_K8s_label_or_no_K8s_label_usage(wl, "")
 	path := no_K8s_label_or_no_K8s_label_usage(podSpec, beggining_of_pod_path)
 }
 
 # There is no label-usage for WL but there is for his Pod
-no_K8s_label_usage(wl, podSpec, beggining_of_pod_path) = path{
+no_K8s_label_usage(wl, podSpec, beggining_of_pod_path) := path if {
 	not no_K8s_label_or_no_K8s_label_usage(podSpec, beggining_of_pod_path)
 	path := no_K8s_label_or_no_K8s_label_usage(wl, "")
 }
 
-no_K8s_label_or_no_K8s_label_usage(wl, start_of_path) = path{
+no_K8s_label_or_no_K8s_label_usage(wl, start_of_path) := path if {
 	not wl.metadata.labels
 	label_key := get_label_key("")
 	path = [{"path": sprintf("%vmetadata.labels[%v]", [start_of_path, label_key]), "value": "YOUR_VALUE"}]
 }
 
-no_K8s_label_or_no_K8s_label_usage(wl, start_of_path) = path{
+no_K8s_label_or_no_K8s_label_usage(wl, start_of_path) := path if {
 	metadata := wl.metadata
 	not metadata.labels
 	label_key := get_label_key("")
 	path = [{"path": sprintf("%vmetadata.labels[%v]", [start_of_path, label_key]), "value": "YOUR_VALUE"}]
 }
 
-no_K8s_label_or_no_K8s_label_usage(wl, start_of_path) = path{
+no_K8s_label_or_no_K8s_label_usage(wl, start_of_path) := path if {
 	labels := wl.metadata.labels
 	not all_kubernetes_labels(labels)
 	label_key := get_label_key("")
 	path = [{"path": sprintf("%vmetadata.labels[%v]", [start_of_path, label_key]), "value": "YOUR_VALUE"}]
 }
 
-all_kubernetes_labels(labels){
+all_kubernetes_labels(labels) if {
 	recommended_labels := data.postureControlInputs.k8sRecommendedLabels
 	recommended_label := recommended_labels[_]
 	labels[recommended_label]
 }
 
 # get_label_key accepts a parameter so it's not considered a rule
-get_label_key(unused_param) = key {
+get_label_key(unused_param) := key if {
 	recommended_labels := data.postureControlInputs.k8sRecommendedLabels
-    count(recommended_labels) > 0
-    key := recommended_labels[0]
-} else = "YOUR_LABEL"
+	count(recommended_labels) > 0
+	key := recommended_labels[0]
+} else := "YOUR_LABEL"

--- a/rules/k8s-common-labels-usage/raw.rego
+++ b/rules/k8s-common-labels-usage/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -20,11 +21,11 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	beggining_of_pod_path := "spec.template."
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	podSpec := wl.spec.template
-	beggining_of_pod_path := "spec.template."
 	fixPath := no_K8s_label_usage(wl, podSpec, beggining_of_pod_path)
 
 	msga := {
@@ -38,11 +39,11 @@ deny contains msga if {
 }
 
 # handles cronjob
-deny contains msga if {
+deny contains msga if {	
+	beggining_of_pod_path := "spec.jobTemplate.spec.template."
 	wl := input[_]
 	wl.kind == "CronJob"
 	podSpec := wl.spec.jobTemplate.spec.template
-	beggining_of_pod_path := "spec.jobTemplate.spec.template."
 	fixPath := no_K8s_label_usage(wl, podSpec, beggining_of_pod_path)
 
 	msga := {

--- a/rules/kubelet-authorization-mode-alwaysAllow/raw.rego
+++ b/rules/kubelet-authorization-mode-alwaysAllow/raw.rego
@@ -1,11 +1,11 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # CIS 4.2.2 https://workbench.cisecurity.org/sections/1126668/recommendations/1838640
 
 # has cli
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -28,7 +28,7 @@ deny[msga] {
 }
 
 # has config
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -58,7 +58,7 @@ deny[msga] {
 }
 
 # has no config and cli
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -80,7 +80,7 @@ deny[msga] {
 }
 
 ## Host sensor failed to get config file content
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -101,12 +101,12 @@ deny[msga] {
 		"alertObject": {"externalObjects": {
 			"apiVersion": obj.apiVersion,
 			"kind": obj.kind,
-			"data": obj.data
-		}}
+			"data": obj.data,
+		}},
 	}
 }
 
-is_kubelet_info(obj) {
+is_kubelet_info(obj) if {
 	obj.kind == "KubeletInfo"
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 }

--- a/rules/kubelet-authorization-mode-alwaysAllow/raw.rego
+++ b/rules/kubelet-authorization-mode-alwaysAllow/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -6,7 +7,7 @@ import rego.v1
 
 # has cli
 deny contains msga if {
-	obj := input[_]
+	some obj in input
 	is_kubelet_info(obj)
 
 	command := obj.data.cmdLine

--- a/rules/kubelet-event-qps/raw.rego
+++ b/rules/kubelet-event-qps/raw.rego
@@ -1,11 +1,11 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # CIS 4.2.9 https://workbench.cisecurity.org/sections/1126668/recommendations/1838656
 
 # if --event-qps is present rule should pass
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -36,7 +36,7 @@ deny[msga] {
 }
 
 ## Host sensor failed to get config file content
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -63,7 +63,7 @@ deny[msga] {
 	}
 }
 
-is_kubelet_info(obj) {
+is_kubelet_info(obj) if {
 	obj.kind == "KubeletInfo"
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 }

--- a/rules/kubelet-event-qps/raw.rego
+++ b/rules/kubelet-event-qps/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -6,7 +7,7 @@ import rego.v1
 
 # if --event-qps is present rule should pass
 deny contains msga if {
-	obj := input[_]
+	some obj in input
 	is_kubelet_info(obj)
 
 	command := obj.data.cmdLine


### PR DESCRIPTION
## Overview
this PR migrates the sixth batch of Rego rules to OPA v1 syntax.

## Additional Information

This batch cover rules from `rules/exec-into-container-v1` through `rules/kubelet-event-qps`

- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized policy modules to Rego v1 rule syntax across the suite for improved language compatibility and maintainability.
  * Migration preserves existing detection logic, alert messages, payload structures, and suggested fix paths — no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->