### PR TITLE
fix: migrate rego rules batch-7 to OPA v1

### DIFF
--- a/rules/kubelet-hostname-override/raw.rego
+++ b/rules/kubelet-hostname-override/raw.rego
@@ -1,10 +1,10 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # CIS 4.2.8 https://workbench.cisecurity.org/sections/1126668/recommendations/1838654
 
-deny[msga] {
+deny contains msga if {
 	kubelet_info := input[_]
 	kubelet_info.kind == "KubeletInfo"
 	kubelet_info.apiVersion == "hostdata.kubescape.cloud/v1beta0"

--- a/rules/kubelet-hostname-override/raw.rego
+++ b/rules/kubelet-hostname-override/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/kubelet-ip-tables/raw.rego
+++ b/rules/kubelet-ip-tables/raw.rego
@@ -1,10 +1,10 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # CIS 4.2.7 https://workbench.cisecurity.org/sections/1126668/recommendations/1838651
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -26,7 +26,7 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -56,7 +56,7 @@ deny[msga] {
 }
 
 ## Host sensor failed to get config file content
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -82,7 +82,7 @@ deny[msga] {
 	}
 }
 
-is_kubelet_info(obj) {
+is_kubelet_info(obj) if {
 	obj.kind == "KubeletInfo"
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 }

--- a/rules/kubelet-ip-tables/raw.rego
+++ b/rules/kubelet-ip-tables/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -5,7 +6,7 @@ import rego.v1
 # CIS 4.2.7 https://workbench.cisecurity.org/sections/1126668/recommendations/1838651
 
 deny contains msga if {
-	obj := input[_]
+	some obj in input
 	is_kubelet_info(obj)
 
 	command := obj.data.cmdLine

--- a/rules/kubelet-protect-kernel-defaults/raw.rego
+++ b/rules/kubelet-protect-kernel-defaults/raw.rego
@@ -1,10 +1,10 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # CIS 4.2.6 https://workbench.cisecurity.org/sections/1126668/recommendations/1838648
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -26,7 +26,7 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -55,7 +55,7 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -78,7 +78,7 @@ deny[msga] {
 }
 
 ## Host sensor failed to get config file content
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -104,7 +104,7 @@ deny[msga] {
 	}
 }
 
-is_kubelet_info(obj) {
+is_kubelet_info(obj) if {
 	obj.kind == "KubeletInfo"
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 }

--- a/rules/kubelet-protect-kernel-defaults/raw.rego
+++ b/rules/kubelet-protect-kernel-defaults/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -5,7 +6,7 @@ import rego.v1
 # CIS 4.2.6 https://workbench.cisecurity.org/sections/1126668/recommendations/1838648
 
 deny contains msga if {
-	obj := input[_]
+	some obj in input
 	is_kubelet_info(obj)
 
 	command := obj.data.cmdLine

--- a/rules/kubelet-rotate-certificates/raw.rego
+++ b/rules/kubelet-rotate-certificates/raw.rego
@@ -1,10 +1,10 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # CIS 4.2.11 https://workbench.cisecurity.org/sections/1126668/recommendations/1838658
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -26,7 +26,7 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -56,7 +56,7 @@ deny[msga] {
 }
 
 ## Host sensor failed to get config file content
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -82,7 +82,7 @@ deny[msga] {
 	}
 }
 
-is_kubelet_info(obj) {
+is_kubelet_info(obj) if {
 	obj.kind == "KubeletInfo"
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 }

--- a/rules/kubelet-rotate-certificates/raw.rego
+++ b/rules/kubelet-rotate-certificates/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -5,7 +6,7 @@ import rego.v1
 # CIS 4.2.11 https://workbench.cisecurity.org/sections/1126668/recommendations/1838658
 
 deny contains msga if {
-	obj := input[_]
+	some obj in input
 	is_kubelet_info(obj)
 
 	command := obj.data.cmdLine

--- a/rules/kubelet-rotate-kubelet-server-certificate/raw.rego
+++ b/rules/kubelet-rotate-kubelet-server-certificate/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	kubelet_info := input[_]
 	kubelet_info.kind == "KubeletInfo"
 	kubelet_info.apiVersion == "hostdata.kubescape.cloud/v1beta0"
@@ -26,17 +26,17 @@ deny[msga] {
 }
 
 ## Inner rules
-should_skip_check(kubelet_info) {
+should_skip_check(kubelet_info) if {
 	command := kubelet_info.data.cmdLine
 	contains(command, "--rotate-server-certificates")
 }
 
-should_skip_check(kubelet_info) {
+should_skip_check(kubelet_info) if {
 	yamlConfigContent := yaml.unmarshal(base64.decode(kubelet_info.data.configFile.content))
 	yamlConfigContent.serverTLSBootstrap == true
 }
 
-is_RotateKubeletServerCertificate_enabled_via_cli(command) {
+is_RotateKubeletServerCertificate_enabled_via_cli(command) if {
 	contains(command, "--feature-gates=")
 	args := regex.split(` +`, command)
 	some i

--- a/rules/kubelet-rotate-kubelet-server-certificate/raw.rego
+++ b/rules/kubelet-rotate-kubelet-server-certificate/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/kubelet-set-pod-limit/raw.rego
+++ b/rules/kubelet-set-pod-limit/raw.rego
@@ -1,10 +1,10 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # CIS 4.2.13 https://workbench.cisecurity.org/sections/2633393/recommendations/4262020
 
-deny[msga] {
+deny contains msga if {
 	kubelet_info := input[_]
 	kubelet_info.kind == "KubeletInfo"
 	kubelet_info.apiVersion == "hostdata.kubescape.cloud/v1beta0"

--- a/rules/kubelet-set-pod-limit/raw.rego
+++ b/rules/kubelet-set-pod-limit/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/kubelet-streaming-connection-idle-timeout/raw.rego
+++ b/rules/kubelet-streaming-connection-idle-timeout/raw.rego
@@ -1,10 +1,10 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # CIS 4.2.5 https://workbench.cisecurity.org/sections/1126668/recommendations/1838646
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -22,11 +22,11 @@ deny[msga] {
 		"failedPaths": [],
 		"fixPaths": [],
 		"packagename": "armo_builtins",
-		"alertObject": external_obj
+		"alertObject": external_obj,
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -51,12 +51,12 @@ deny[msga] {
 			"kind": obj.kind,
 			"metadata": obj.metadata,
 			"data": {"configFile": {"content": decodedConfigContent}},
-		}}
+		}},
 	}
 }
 
 ## Host sensor failed to get config file content
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -77,12 +77,12 @@ deny[msga] {
 		"alertObject": {"externalObjects": {
 			"apiVersion": obj.apiVersion,
 			"kind": obj.kind,
-			"data": obj.data
-		}}
+			"data": obj.data,
+		}},
 	}
 }
 
-is_kubelet_info(obj) {
+is_kubelet_info(obj) if {
 	obj.kind == "KubeletInfo"
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 }

--- a/rules/kubelet-streaming-connection-idle-timeout/raw.rego
+++ b/rules/kubelet-streaming-connection-idle-timeout/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -5,7 +6,7 @@ import rego.v1
 # CIS 4.2.5 https://workbench.cisecurity.org/sections/1126668/recommendations/1838646
 
 deny contains msga if {
-	obj := input[_]
+	some obj in input
 	is_kubelet_info(obj)
 
 	command := obj.data.cmdLine

--- a/rules/kubelet-strong-cryptography-ciphers/raw.rego
+++ b/rules/kubelet-strong-cryptography-ciphers/raw.rego
@@ -1,10 +1,10 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # CIS 4.2.13 https://workbench.cisecurity.org/sections/1126668/recommendations/1838663
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -27,7 +27,7 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -58,7 +58,7 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -80,7 +80,7 @@ deny[msga] {
 	}
 }
 
-has_strong_cipher_set_via_cli(command) {
+has_strong_cipher_set_via_cli(command) if {
 	contains(command, "--tls-cipher-suites=")
 
 	strong_cliphers := [
@@ -98,7 +98,7 @@ has_strong_cipher_set_via_cli(command) {
 	contains(command, sprintf("%v%v", ["--tls-cipher-suites=", strong_cliphers[i]]))
 }
 
-is_value_in_strong_cliphers_set(value) {
+is_value_in_strong_cliphers_set(value) if {
 	strong_cliphers := [
 		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -114,7 +114,7 @@ is_value_in_strong_cliphers_set(value) {
 	strong_cliphers[x] == value
 }
 
-is_kubelet_info(obj) {
+is_kubelet_info(obj) if {
 	obj.kind == "KubeletInfo"
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 }

--- a/rules/kubelet-strong-cryptography-ciphers/raw.rego
+++ b/rules/kubelet-strong-cryptography-ciphers/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -5,7 +6,7 @@ import rego.v1
 # CIS 4.2.13 https://workbench.cisecurity.org/sections/1126668/recommendations/1838663
 
 deny contains msga if {
-	obj := input[_]
+	some obj in input
 	is_kubelet_info(obj)
 
 	command := obj.data.cmdLine

--- a/rules/label-usage-for-resources/raw.rego
+++ b/rules/label-usage-for-resources/raw.rego
@@ -1,116 +1,108 @@
 package armo_builtins
+
+import rego.v1
+
 # Deny mutating action unless user is in group owning the resource
 
-
-
-deny[msga] {
-
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	fixPath := no_label_or_no_label_usage(pod, "")
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("in the following pods a certain set of labels is not defined: %v", [pod.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 2,
 		"failedPaths": [],
 		"fixPaths": fixPath,
-         "alertObject": {
-			"k8sApiObjects": [pod]
-		}
-     }
+		"alertObject": {"k8sApiObjects": [pod]},
+	}
 }
 
-
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	podSpec := wl.spec.template
 	beggining_of_pod_path := "spec.template."
 	fixPath := no_label_usage(wl, podSpec, beggining_of_pod_path)
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("%v: %v a certain set of labels is not defined:", [wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 2,
 		"failedPaths": [],
 		"fixPaths": fixPath,
-         "alertObject": {
-			"k8sApiObjects": [wl]
-		}
-     }
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
 }
 
 # handles cronjob
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	podSpec := wl.spec.jobTemplate.spec.template
 	beggining_of_pod_path := "spec.jobTemplate.spec.template."
 	fixPath := no_label_usage(wl, podSpec, beggining_of_pod_path)
 
-
-    msga := {
+	msga := {
 		"alertMessage": sprintf("the following cronjobs a certain set of labels is not defined: %v", [wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 2,
 		"failedPaths": [],
 		"fixPaths": fixPath,
-         "alertObject": {
-			"k8sApiObjects": [wl]
-		}
-     }
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
 }
 
 # There is no label-usage in WL and also for his Pod
-no_label_usage(wl, podSpec, beggining_of_pod_path) = path{
+no_label_usage(wl, podSpec, beggining_of_pod_path) := path if {
 	path1 := no_label_or_no_label_usage(wl, "")
 	path2 := no_label_or_no_label_usage(podSpec, beggining_of_pod_path)
 	path = array.concat(path1, path2)
 }
 
 # There is label-usage for WL but not for his Pod
-no_label_usage(wl, podSpec, beggining_of_pod_path) = path{
+no_label_usage(wl, podSpec, beggining_of_pod_path) := path if {
 	not no_label_or_no_label_usage(wl, "")
 	path := no_label_or_no_label_usage(podSpec, beggining_of_pod_path)
 }
 
 # There is no label-usage for WL but there is for his Pod
-no_label_usage(wl, podSpec, beggining_of_pod_path) = path{
+no_label_usage(wl, podSpec, beggining_of_pod_path) := path if {
 	not no_label_or_no_label_usage(podSpec, beggining_of_pod_path)
 	path := no_label_or_no_label_usage(wl, "")
 }
 
-no_label_or_no_label_usage(wl, start_of_path) = path{
+no_label_or_no_label_usage(wl, start_of_path) := path if {
 	not wl.metadata
 	label_key := get_label_key("")
 	path = [{"path": sprintf("%vmetadata.labels[%v]", [start_of_path, label_key]), "value": "YOUR_VALUE"}]
 }
 
-no_label_or_no_label_usage(wl, start_of_path) = path{
+no_label_or_no_label_usage(wl, start_of_path) := path if {
 	metadata := wl.metadata
 	not metadata.labels
 	label_key := get_label_key("")
 	path = [{"path": sprintf("%vmetadata.labels[%v]", [start_of_path, label_key]), "value": "YOUR_VALUE"}]
 }
 
-no_label_or_no_label_usage(wl, start_of_path) = path{
+no_label_or_no_label_usage(wl, start_of_path) := path if {
 	labels := wl.metadata.labels
 	not is_desired_label(labels)
 	label_key := get_label_key("")
 	path = [{"path": sprintf("%vmetadata.labels[%v]", [start_of_path, label_key]), "value": "YOUR_VALUE"}]
 }
 
-is_desired_label(labels) {
+is_desired_label(labels) if {
 	recommended_labels := data.postureControlInputs.recommendedLabels
 	recommended_label := recommended_labels[_]
 	labels[recommended_label]
 }
 
 # get_label_key accepts a parameter so it's not considered a rule
-get_label_key(unused_param) = key {
+get_label_key(unused_param) := key if {
 	recommended_labels := data.postureControlInputs.recommendedLabels
-    count(recommended_labels) > 0
-    key := recommended_labels[0]
-} else = "YOUR_LABEL"
+	count(recommended_labels) > 0
+	key := recommended_labels[0]
+} else := "YOUR_LABEL"

--- a/rules/label-usage-for-resources/raw.rego
+++ b/rules/label-usage-for-resources/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -20,11 +21,11 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	beggining_of_pod_path := "spec.template."
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	podSpec := wl.spec.template
-	beggining_of_pod_path := "spec.template."
 	fixPath := no_label_usage(wl, podSpec, beggining_of_pod_path)
 
 	msga := {
@@ -39,10 +40,10 @@ deny contains msga if {
 
 # handles cronjob
 deny contains msga if {
+	beggining_of_pod_path := "spec.jobTemplate.spec.template."
 	wl := input[_]
 	wl.kind == "CronJob"
 	podSpec := wl.spec.jobTemplate.spec.template
-	beggining_of_pod_path := "spec.jobTemplate.spec.template."
 	fixPath := no_label_usage(wl, podSpec, beggining_of_pod_path)
 
 	msga := {

--- a/rules/lease-in-default-namespace/raw.rego
+++ b/rules/lease-in-default-namespace/raw.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -12,30 +14,26 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
-
+} else := []

--- a/rules/lease-in-default-namespace/raw.rego
+++ b/rules/lease-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/linux-hardening/raw.rego
+++ b/rules/linux-hardening/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/linux-hardening/raw.rego
+++ b/rules/linux-hardening/raw.rego
@@ -1,9 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
-# Fails if pod does not define linux security hardening 
-deny[msga] {
+# Fails if pod does not define linux security hardening
+deny contains msga if {
 	obj := input[_]
 	fix_paths := is_unsafe_obj(obj)
 	count(fix_paths) > 0
@@ -20,18 +20,18 @@ deny[msga] {
 	}
 }
 
-is_unsafe_obj(obj) := fix_paths {
+is_unsafe_obj(obj) := fix_paths if {
 	obj.kind == "Pod"
 	fix_paths := are_unsafe_specs(obj, ["spec"])
-} else := fix_paths {
+} else := fix_paths if {
 	obj.kind == "CronJob"
 	fix_paths := are_unsafe_specs(obj, ["spec", "jobTemplate", "spec", "template", "spec"])
-} else := fix_paths {
+} else := fix_paths if {
 	obj.kind in ["Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"]
 	fix_paths := are_unsafe_specs(obj, ["spec", "template", "spec"])
 }
 
-are_unsafe_specs(obj, specs_path) := paths {
+are_unsafe_specs(obj, specs_path) := paths if {
 	# spec
 	specs := object.get(obj, specs_path, null)
 	specs != null
@@ -74,7 +74,7 @@ are_unsafe_specs(obj, specs_path) := paths {
 
 # A container is unsafe if it has no seccomp profile defined
 # at either pod level or container level
-is_unsafe_container(pod_spec, container) {
+is_unsafe_container(pod_spec, container) if {
 	not pod_spec.securityContext.seccompProfile
 	not container.securityContext.seccompProfile
 }

--- a/rules/list-all-mutating-webhooks/raw.rego
+++ b/rules/list-all-mutating-webhooks/raw.rego
@@ -1,18 +1,17 @@
 package armo_builtins
 
+import rego.v1
 
-deny [msga] {
-    mutatingwebhooks := [mutatingwebhook | mutatingwebhook = input[_]; mutatingwebhook.kind == "MutatingWebhookConfiguration"]
-    mutatingwebhook := mutatingwebhooks[_]
+deny contains msga if {
+	mutatingwebhooks := [mutatingwebhook | mutatingwebhook = input[_]; mutatingwebhook.kind == "MutatingWebhookConfiguration"]
+	mutatingwebhook := mutatingwebhooks[_]
 
-    	msga := {
+	msga := {
 		"alertMessage": sprintf("The following mutating webhook configuration should be checked %v.", [mutatingwebhook.metadata.name]),
 		"alertScore": 6,
 		"failedPaths": [],
 		"fixPaths": [],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [mutatingwebhook]
-		}
+		"alertObject": {"k8sApiObjects": [mutatingwebhook]},
 	}
 }

--- a/rules/list-all-mutating-webhooks/raw.rego
+++ b/rules/list-all-mutating-webhooks/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/list-all-namespaces/raw.rego
+++ b/rules/list-all-namespaces/raw.rego
@@ -1,7 +1,9 @@
 package armo_builtins
 
+import rego.v1
+
 # returns all namespace objects in cluster
-deny[msga] {
+deny contains msga if {
 	namespace = input[_]
 	namespace.kind == "Namespace"
 
@@ -11,8 +13,6 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }

--- a/rules/list-all-namespaces/raw.rego
+++ b/rules/list-all-namespaces/raw.rego
@@ -1,10 +1,11 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 # returns all namespace objects in cluster
 deny contains msga if {
-	namespace = input[_]
+    some namespace in input
 	namespace.kind == "Namespace"
 
 	msga := {

--- a/rules/list-all-validating-webhooks/raw.rego
+++ b/rules/list-all-validating-webhooks/raw.rego
@@ -1,18 +1,17 @@
 package armo_builtins
 
+import rego.v1
 
-deny [msga] {
-    admissionwebhooks := [admissionwebhook | admissionwebhook = input[_]; admissionwebhook.kind == "ValidatingWebhookConfiguration"]
-    admissionwebhook := admissionwebhooks[_]
+deny contains msga if {
+	admissionwebhooks := [admissionwebhook | admissionwebhook = input[_]; admissionwebhook.kind == "ValidatingWebhookConfiguration"]
+	admissionwebhook := admissionwebhooks[_]
 
-    	msga := {
+	msga := {
 		"alertMessage": sprintf("The following validating webhook configuration should be checked %v.", [admissionwebhook.metadata.name]),
 		"alertScore": 6,
 		"packagename": "armo_builtins",
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [admissionwebhook]
-		}
+		"alertObject": {"k8sApiObjects": [admissionwebhook]},
 	}
 }

--- a/rules/list-all-validating-webhooks/raw.rego
+++ b/rules/list-all-validating-webhooks/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/list-role-definitions-in-acr/raw.rego
+++ b/rules/list-role-definitions-in-acr/raw.rego
@@ -1,7 +1,9 @@
 package armo_builtins
 
+import rego.v1
+
 # return ListEntitiesForPolicies resource in azure
-deny[msg] {
+deny contains msg if {
 	resources := input[_]
 	resources.kind == "ListEntitiesForPolicies"
 	resources.apiVersion == "management.azure.com/v1"
@@ -13,8 +15,6 @@ deny[msg] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"externalObjects": resources
-		}
+		"alertObject": {"externalObjects": resources},
 	}
 }

--- a/rules/list-role-definitions-in-acr/raw.rego
+++ b/rules/list-role-definitions-in-acr/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/mismatching-selector/raw.rego
+++ b/rules/mismatching-selector/raw.rego
@@ -1,8 +1,6 @@
 package armo_builtins
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 deny contains msga if {
 	wl := input[_]
@@ -18,76 +16,74 @@ deny contains msga if {
 		"failedPaths": [failed_path],
 		"fixPaths": [],
 		"alertScore": 3,
-		"alertObject": {
-			"k8sApiObjects": [wl],
-		},
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-workload_selector(wl) = selector if {
+workload_selector(wl) := selector if {
 	wl.kind in {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	selector := object.get(wl.spec, "selector", {})
 }
 
-workload_selector(wl) = selector if {
+workload_selector(wl) := selector if {
 	wl.kind == "ReplicationController"
 	selector := {"matchLabels": object.get(wl.spec, "selector", {})}
 }
 
-workload_selector(wl) = selector if {
+workload_selector(wl) := selector if {
 	wl.kind == "CronJob"
 	selector := object.get(cronjob_spec(wl), "selector", {})
 }
 
-workload_template_labels(wl) = labels if {
+workload_template_labels(wl) := labels if {
 	wl.kind in {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "ReplicationController"}
 	labels := object.get(workload_template_metadata(wl), "labels", {})
 }
 
-workload_template_labels(wl) = labels if {
+workload_template_labels(wl) := labels if {
 	wl.kind == "CronJob"
 	labels := object.get(cronjob_template_metadata(wl), "labels", {})
 }
 
-workload_template_metadata(wl) = metadata if {
+workload_template_metadata(wl) := metadata if {
 	spec := object.get(wl, "spec", {})
 	template := object.get(spec, "template", {})
 	metadata := object.get(template, "metadata", {})
 }
 
-cronjob_spec(wl) = spec if {
+cronjob_spec(wl) := spec if {
 	wl_spec := object.get(wl, "spec", {})
 	job_template := object.get(wl_spec, "jobTemplate", {})
 	spec := object.get(job_template, "spec", {})
 }
 
-cronjob_template_metadata(wl) = metadata if {
+cronjob_template_metadata(wl) := metadata if {
 	spec := cronjob_spec(wl)
 	template := object.get(spec, "template", {})
 	metadata := object.get(template, "metadata", {})
 }
 
-selector_match_labels_path(wl) = "spec.selector.matchLabels" if {
+selector_match_labels_path(wl) := "spec.selector.matchLabels" if {
 	wl.kind in {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 }
 
-selector_match_labels_path(wl) = "spec.selector" if {
+selector_match_labels_path(wl) := "spec.selector" if {
 	wl.kind == "ReplicationController"
 }
 
-selector_match_labels_path(wl) = "spec.jobTemplate.spec.selector.matchLabels" if {
+selector_match_labels_path(wl) := "spec.jobTemplate.spec.selector.matchLabels" if {
 	wl.kind == "CronJob"
 }
 
-selector_match_expressions_path(wl) = "spec.selector.matchExpressions" if {
+selector_match_expressions_path(wl) := "spec.selector.matchExpressions" if {
 	wl.kind in {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 }
 
-selector_match_expressions_path(wl) = "spec.jobTemplate.spec.selector.matchExpressions" if {
+selector_match_expressions_path(wl) := "spec.jobTemplate.spec.selector.matchExpressions" if {
 	wl.kind == "CronJob"
 }
 
-selector_match_expressions_path(wl) = "spec.selector" if {
+selector_match_expressions_path(wl) := "spec.selector" if {
 	wl.kind == "ReplicationController"
 }
 
@@ -141,11 +137,11 @@ expression_matches(expression, labels) if {
 	not labels[expression.key]
 }
 
-selector_failed_path(selector, labels, match_labels_path, _) = match_labels_path if {
+selector_failed_path(selector, labels, match_labels_path, _) := match_labels_path if {
 	match_labels_mismatch(object.get(selector, "matchLabels", {}), labels)
 }
 
-selector_failed_path(selector, labels, _, match_expressions_path) = match_expressions_path if {
+selector_failed_path(selector, labels, _, match_expressions_path) := match_expressions_path if {
 	not match_labels_mismatch(object.get(selector, "matchLabels", {}), labels)
 	match_expressions_mismatch(object.get(selector, "matchExpressions", []), labels)
 }

--- a/rules/mismatching-selector/raw.rego
+++ b/rules/mismatching-selector/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/naked-pods/raw.rego
+++ b/rules/naked-pods/raw.rego
@@ -1,9 +1,10 @@
 package armo_builtins
 
+import rego.v1
 
 # Fails if workload is Pod
-deny[msga] {
-    pod := input[_]
+deny contains msga if {
+	pod := input[_]
 	pod.kind == "Pod"
 	not pod.metadata.ownerReferences
 	msga := {
@@ -12,10 +13,6 @@ deny[msga] {
 		"alertScore": 3,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
-
-

--- a/rules/naked-pods/raw.rego
+++ b/rules/naked-pods/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/namespace-without-service-account/filter.rego
+++ b/rules/namespace-without-service-account/filter.rego
@@ -1,19 +1,18 @@
 package armo_builtins
 
+import rego.v1
 
 # Fails if namespace does not have service accounts (not incluiding default)
-deny[msga] {
+deny contains msga if {
 	namespace := input[_]
 	namespace.kind == "Namespace"
-	
+
 	msga := {
 		"alertMessage": sprintf("Namespace: %v does not have any service accounts besides 'default'", [namespace.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }

--- a/rules/namespace-without-service-account/filter.rego
+++ b/rules/namespace-without-service-account/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/namespace-without-service-account/raw.rego
+++ b/rules/namespace-without-service-account/raw.rego
@@ -1,11 +1,12 @@
 package armo_builtins
 
+import rego.v1
 
 # Fails if namespace does not have service accounts (not incluiding default)
-deny[msga] {
+deny contains msga if {
 	namespace := input[_]
 	namespace.kind == "Namespace"
-	serviceAccounts := [serviceaccount |  serviceaccount= input[_]; is_good_sa(serviceaccount, namespace.metadata.name)]
+	serviceAccounts := [serviceaccount | serviceaccount = input[_]; is_good_sa(serviceaccount, namespace.metadata.name)]
 	count(serviceAccounts) < 1
 	msga := {
 		"alertMessage": sprintf("Namespace: %v does not have any service accounts besides 'default'", [namespace.metadata.name]),
@@ -13,14 +14,11 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }
-	
-	
-is_good_sa(sa, namespace) { 
+
+is_good_sa(sa, namespace) if {
 	sa.kind == "ServiceAccount"
 	sa.metadata.namespace == namespace
 	sa.metadata.name != "default"

--- a/rules/namespace-without-service-account/raw.rego
+++ b/rules/namespace-without-service-account/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/non-root-containers/raw.rego
+++ b/rules/non-root-containers/raw.rego
@@ -1,11 +1,12 @@
 package armo_builtins
 
+import rego.v1
 
 ################################################################################
 # Rules
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 	container := pod.spec.containers[i]
 
 	start_of_path := "spec"
@@ -15,25 +16,22 @@ deny[msga] {
 	count(all_fixpaths) > 0
 	fixPaths := get_fixed_paths(all_fixpaths, i)
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("container: %v in pod: %v  may run as root", [container.name, pod.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
-        "fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"fixPaths": fixPaths,
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
+	container := wl.spec.template.spec.containers[i]
 
 	start_of_path := "spec.template.spec"
 	run_as_user_fixpath := evaluate_workload_run_as_user(container, wl.spec.template, start_of_path)
@@ -42,21 +40,19 @@ deny[msga] {
 	count(all_fixpaths) > 0
 	fixPaths := get_fixed_paths(all_fixpaths, i)
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("container: %v in %v: %v may run as root", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
-        "fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"fixPaths": fixPaths,
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if cronjob has a container configured to run as root
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
@@ -67,85 +63,80 @@ deny[msga] {
 	all_fixpaths := array.concat(run_as_user_fixpath, run_as_group_fixpath)
 	count(all_fixpaths) > 0
 	fixPaths := get_fixed_paths(all_fixpaths, i)
-	
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("container: %v in %v: %v  may run as root", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
-        "fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"fixPaths": fixPaths,
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
-get_fixed_paths(all_fixpaths, i) = [{"path":replace(all_fixpaths[0].path,"container_ndx",format_int(i,10)), "value":all_fixpaths[0].value}, {"path":replace(all_fixpaths[1].path,"container_ndx",format_int(i,10)), "value":all_fixpaths[1].value}]{
+get_fixed_paths(all_fixpaths, i) := [{"path": replace(all_fixpaths[0].path, "container_ndx", format_int(i, 10)), "value": all_fixpaths[0].value}, {"path": replace(all_fixpaths[1].path, "container_ndx", format_int(i, 10)), "value": all_fixpaths[1].value}] if {
 	count(all_fixpaths) == 2
-} else = [{"path":replace(all_fixpaths[0].path,"container_ndx",format_int(i,10)), "value":all_fixpaths[0].value}] 
+} else := [{"path": replace(all_fixpaths[0].path, "container_ndx", format_int(i, 10)), "value": all_fixpaths[0].value}]
 
 #################################################################################
-# Workload evaluation 
+# Workload evaluation
 
 # if runAsUser is set to 0 and runAsNonRoot is set to false/ not set - suggest to set runAsUser to 1000
 # if runAsUser is not set and runAsNonRoot is set to false/ not set - suggest to set runAsNonRoot to true
 # all checks are both on the pod and the container level
-evaluate_workload_run_as_user(container, pod, start_of_path) = fixPath {
+evaluate_workload_run_as_user(container, pod, start_of_path) := fixPath if {
 	runAsNonRootValue := get_run_as_non_root_value(container, pod, start_of_path)
 	runAsNonRootValue.value == false
-	
+
 	runAsUserValue := get_run_as_user_value(container, pod, start_of_path)
 	runAsUserValue.value == 0
 
 	alertInfo := choose_first_if_defined(runAsUserValue, runAsNonRootValue)
 	fixPath := alertInfo.fixPath
-} else = [] 
-
+} else := []
 
 # if runAsGroup is set to 0/ not set - suggest to set runAsGroup to 1000
 # all checks are both on the pod and the container level
-evaluate_workload_run_as_group(container, pod, start_of_path) = fixPath {	
+evaluate_workload_run_as_group(container, pod, start_of_path) := fixPath if {
 	runAsGroupValue := get_run_as_group_value(container, pod, start_of_path)
 	runAsGroupValue.value == 0
 
 	fixPath := runAsGroupValue.fixPath
-} else = []
-
+} else := []
 
 #################################################################################
 # Value resolution functions
 
+get_run_as_non_root_value(container, pod, start_of_path) := runAsNonRoot if {
+	runAsNonRoot := {"value": container.securityContext.runAsNonRoot, "fixPath": [{"path": sprintf("%v.containers[container_ndx].securityContext.runAsNonRoot", [start_of_path]), "value": "true"}], "defined": true}
+} else := runAsNonRoot if {
+	runAsNonRoot := {"value": pod.spec.securityContext.runAsNonRoot, "fixPath": [{"path": sprintf("%v.containers[container_ndx].securityContext.runAsNonRoot", [start_of_path]), "value": "true"}], "defined": true}
+} else := {"value": false, "fixPath": [{"path": sprintf("%v.containers[container_ndx].securityContext.runAsNonRoot", [start_of_path]), "value": "true"}], "defined": false}
 
-get_run_as_non_root_value(container, pod, start_of_path) = runAsNonRoot {
-    runAsNonRoot := {"value" : container.securityContext.runAsNonRoot, "fixPath": [{"path": sprintf("%v.containers[container_ndx].securityContext.runAsNonRoot", [start_of_path]), "value":"true"}], "defined" : true}
-} else = runAsNonRoot {
-    runAsNonRoot := {"value" : pod.spec.securityContext.runAsNonRoot, "fixPath": [{"path": sprintf("%v.containers[container_ndx].securityContext.runAsNonRoot", [start_of_path]), "value":"true"}], "defined" : true}
-}  else = {"value" : false, "fixPath": [{"path":  sprintf("%v.containers[container_ndx].securityContext.runAsNonRoot", [start_of_path]) , "value":"true"}], "defined" : false}
-
-get_run_as_user_value(container, pod, start_of_path) = runAsUser {
-	path := sprintf("%v.containers[container_ndx].securityContext.runAsUser", [start_of_path]) 
-    runAsUser := {"value" : container.securityContext.runAsUser, "fixPath": [{"path": path, "value": "1000"}], "defined" : true}
-} else = runAsUser {
-	path := sprintf("%v.securityContext.runAsUser", [start_of_path]) 
-    runAsUser := {"value" : pod.spec.securityContext.runAsUser, "fixPath": [{"path": path, "value": "1000"}],"defined" : true}
-} else = {"value" : 0, "fixPath": [{"path":  sprintf("%v.containers[container_ndx].securityContext.runAsNonRoot", [start_of_path]), "value":"true"}],
-	"defined" : false}
-
-get_run_as_group_value(container, pod, start_of_path) = runAsGroup {
-	path := sprintf("%v.containers[container_ndx].securityContext.runAsGroup", [start_of_path])
-    runAsGroup := {"value" : container.securityContext.runAsGroup, "fixPath": [{"path": path, "value": "1000"}],"defined" : true}
-} else = runAsGroup {
-	path := sprintf("%v.securityContext.runAsGroup", [start_of_path])
-    runAsGroup := {"value" : pod.spec.securityContext.runAsGroup, "fixPath":[{"path": path, "value": "1000"}], "defined" : true}
-} else = {"value" : 0, "fixPath": [{"path": sprintf("%v.containers[container_ndx].securityContext.runAsGroup", [start_of_path]), "value":"1000"}],
- 	"defined" : false
+get_run_as_user_value(container, pod, start_of_path) := runAsUser if {
+	path := sprintf("%v.containers[container_ndx].securityContext.runAsUser", [start_of_path])
+	runAsUser := {"value": container.securityContext.runAsUser, "fixPath": [{"path": path, "value": "1000"}], "defined": true}
+} else := runAsUser if {
+	path := sprintf("%v.securityContext.runAsUser", [start_of_path])
+	runAsUser := {"value": pod.spec.securityContext.runAsUser, "fixPath": [{"path": path, "value": "1000"}], "defined": true}
+} else := {
+	"value": 0, "fixPath": [{"path": sprintf("%v.containers[container_ndx].securityContext.runAsNonRoot", [start_of_path]), "value": "true"}],
+	"defined": false,
 }
 
-choose_first_if_defined(l1, l2) = c {
-    l1.defined
-    c := l1
-} else = l2
+get_run_as_group_value(container, pod, start_of_path) := runAsGroup if {
+	path := sprintf("%v.containers[container_ndx].securityContext.runAsGroup", [start_of_path])
+	runAsGroup := {"value": container.securityContext.runAsGroup, "fixPath": [{"path": path, "value": "1000"}], "defined": true}
+} else := runAsGroup if {
+	path := sprintf("%v.securityContext.runAsGroup", [start_of_path])
+	runAsGroup := {"value": pod.spec.securityContext.runAsGroup, "fixPath": [{"path": path, "value": "1000"}], "defined": true}
+} else := {
+	"value": 0, "fixPath": [{"path": sprintf("%v.containers[container_ndx].securityContext.runAsGroup", [start_of_path]), "value": "1000"}],
+	"defined": false,
+}
 
+choose_first_if_defined(l1, l2) := c if {
+	l1.defined
+	c := l1
+} else := l2

--- a/rules/non-root-containers/raw.rego
+++ b/rules/non-root-containers/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -5,11 +6,11 @@ import rego.v1
 ################################################################################
 # Rules
 deny contains msga if {
+	start_of_path := "spec"
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
 
-	start_of_path := "spec"
 	run_as_user_fixpath := evaluate_workload_run_as_user(container, pod, start_of_path)
 	run_as_group_fixpath := evaluate_workload_run_as_group(container, pod, start_of_path)
 	all_fixpaths := array.concat(run_as_user_fixpath, run_as_group_fixpath)
@@ -28,12 +29,12 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
+	start_of_path := "spec.template.spec"
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 
-	start_of_path := "spec.template.spec"
 	run_as_user_fixpath := evaluate_workload_run_as_user(container, wl.spec.template, start_of_path)
 	run_as_group_fixpath := evaluate_workload_run_as_group(container, wl.spec.template, start_of_path)
 	all_fixpaths := array.concat(run_as_user_fixpath, run_as_group_fixpath)
@@ -53,11 +54,11 @@ deny contains msga if {
 
 # Fails if cronjob has a container configured to run as root
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec"
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 
-	start_of_path := "spec.jobTemplate.spec.template.spec"
 	run_as_user_fixpath := evaluate_workload_run_as_user(container, wl.spec.jobTemplate.spec.template, start_of_path)
 	run_as_group_fixpath := evaluate_workload_run_as_group(container, wl.spec.jobTemplate.spec.template, start_of_path)
 	all_fixpaths := array.concat(run_as_user_fixpath, run_as_group_fixpath)
@@ -136,7 +137,6 @@ get_run_as_group_value(container, pod, start_of_path) := runAsGroup if {
 	"defined": false,
 }
 
-choose_first_if_defined(l1, l2) := c if {
+choose_first_if_defined(l1, l2) := l1 if {
 	l1.defined
-	c := l1
 } else := l2

--- a/rules/outdated-k8s-version/raw.rego
+++ b/rules/outdated-k8s-version/raw.rego
@@ -1,25 +1,24 @@
 package armo_builtins
 
-import future.keywords.every
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	node := input[_]
 	node.kind == "Node"
 	current_version := node.status.nodeInfo.kubeletVersion
-    has_outdated_version(current_version)
+	has_outdated_version(current_version)
 	path := "status.nodeInfo.kubeletVersion"
 	msga := {
-			"alertMessage": sprintf("Your kubelet version: %s, in node: %s is outdated", [current_version, node.metadata.name]),
-			"reviewPaths": [path],
-			"alertObject": {"k8SApiObjects": [node]},
+		"alertMessage": sprintf("Your kubelet version: %s, in node: %s is outdated", [current_version, node.metadata.name]),
+		"reviewPaths": [path],
+		"alertObject": {"k8SApiObjects": [node]},
 	}
 }
 
-
-has_outdated_version(version)  {
+has_outdated_version(version) if {
 	# the `supported_k8s_versions` is validated in the validations script against "https://api.github.com/repos/kubernetes/kubernetes/releases"
-    supported_k8s_versions := ["v1.36", "v1.35", "v1.34"]
-	every v in supported_k8s_versions{
+	supported_k8s_versions := ["v1.36", "v1.35", "v1.34"]
+	every v in supported_k8s_versions {
 		not startswith(version, v)
 	}
 }

--- a/rules/outdated-k8s-version/raw.rego
+++ b/rules/outdated-k8s-version/raw.rego
@@ -1,13 +1,14 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	path := "status.nodeInfo.kubeletVersion"
 	node := input[_]
 	node.kind == "Node"
 	current_version := node.status.nodeInfo.kubeletVersion
 	has_outdated_version(current_version)
-	path := "status.nodeInfo.kubeletVersion"
 	msga := {
 		"alertMessage": sprintf("Your kubelet version: %s, in node: %s is outdated", [current_version, node.metadata.name]),
 		"reviewPaths": [path],

--- a/rules/persistentvolumeclaim-in-default-namespace/raw.rego
+++ b/rules/persistentvolumeclaim-in-default-namespace/raw.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -12,30 +14,26 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
-
+} else := []

--- a/rules/persistentvolumeclaim-in-default-namespace/raw.rego
+++ b/rules/persistentvolumeclaim-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pod-security-admission-applied-1/filter.rego
+++ b/rules/pod-security-admission-applied-1/filter.rego
@@ -1,17 +1,17 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	namespace := input[_]
 	namespace.kind == "Namespace"
-	
+
 	msga := {
 		"alertMessage": sprintf("Namespace: %v", [namespace.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }

--- a/rules/pod-security-admission-applied-1/filter.rego
+++ b/rules/pod-security-admission-applied-1/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pod-security-admission-applied-1/raw.rego
+++ b/rules/pod-security-admission-applied-1/raw.rego
@@ -1,14 +1,14 @@
 package armo_builtins
-import future.keywords.every
+
+import rego.v1
 
 # Fails if no 3rd party security admission exists and namespace does not have relevant labels
-deny[msga] {
-    not has_external_policy_control(input)
+deny contains msga if {
+	not has_external_policy_control(input)
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not admission_policy_enabled(namespace)
 	fix_path = {"path": "metadata.labels[pod-security.kubernetes.io/enforce]", "value": "YOUR_VALUE"}
-    
 
 	msga := {
 		"alertMessage": sprintf("Namespace: %v does not enable pod security admission", [namespace.metadata.name]),
@@ -16,19 +16,17 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [fix_path],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }
 
-admission_policy_enabled(namespace){
-	some label, _ in namespace.metadata.labels 
-    startswith(label, "pod-security.kubernetes.io/enforce")
+admission_policy_enabled(namespace) if {
+	some label, _ in namespace.metadata.labels
+	startswith(label, "pod-security.kubernetes.io/enforce")
 }
 
-has_external_policy_control(inp){
-    admissionwebhook := inp[_]
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
+has_external_policy_control(inp) if {
+	admissionwebhook := inp[_]
+	admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
+	admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
 }

--- a/rules/pod-security-admission-applied-1/raw.rego
+++ b/rules/pod-security-admission-applied-1/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pod-security-admission-applied-2/filter.rego
+++ b/rules/pod-security-admission-applied-2/filter.rego
@@ -1,17 +1,17 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	namespace := input[_]
 	namespace.kind == "Namespace"
-	
+
 	msga := {
 		"alertMessage": sprintf("Namespace: %v", [namespace.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }

--- a/rules/pod-security-admission-applied-2/filter.rego
+++ b/rules/pod-security-admission-applied-2/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pod-security-admission-applied-2/raw.rego
+++ b/rules/pod-security-admission-applied-2/raw.rego
@@ -1,14 +1,14 @@
 package armo_builtins
-import future.keywords.every
+
+import rego.v1
 
 # Fails if no 3rd party security admission exists and namespace does not have relevant labels
-deny[msga] {
-    not has_external_policy_control(input)
+deny contains msga if {
+	not has_external_policy_control(input)
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not admission_policy_enabled(namespace)
 	fix_path = {"path": "metadata.labels[pod-security.kubernetes.io/enforce]", "value": "YOUR_VALUE"}
-    
 
 	msga := {
 		"alertMessage": sprintf("Namespace: %v does not enable pod security admission", [namespace.metadata.name]),
@@ -16,19 +16,17 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [fix_path],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }
 
-admission_policy_enabled(namespace){
-	some label, _ in namespace.metadata.labels 
-    startswith(label, "pod-security.kubernetes.io/enforce")
+admission_policy_enabled(namespace) if {
+	some label, _ in namespace.metadata.labels
+	startswith(label, "pod-security.kubernetes.io/enforce")
 }
 
-has_external_policy_control(inp){
-    admissionwebhook := inp[_]
-    admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
-    admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
+has_external_policy_control(inp) if {
+	admissionwebhook := inp[_]
+	admissionwebhook.kind in ["ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"]
+	admissionwebhook.webhooks[i].rules[j].scope != "Cluster"
 }

--- a/rules/pod-security-admission-applied-2/raw.rego
+++ b/rules/pod-security-admission-applied-2/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pod-security-admission-baseline-applied-1/filter.rego
+++ b/rules/pod-security-admission-baseline-applied-1/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pod-security-admission-baseline-applied-1/filter.rego
+++ b/rules/pod-security-admission-baseline-applied-1/filter.rego
@@ -1,8 +1,9 @@
 package armo_builtins
-import future.keywords.in
+
+import rego.v1
 
 # Fails if namespace does not have baseline pod security admission label
-deny[msga] {
+deny contains msga if {
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not baseline_admission_policy_enabled(namespace)
@@ -13,12 +14,10 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }
 
-baseline_admission_policy_enabled(namespace){
+baseline_admission_policy_enabled(namespace) if {
 	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] in ["baseline", "restricted"]
 }

--- a/rules/pod-security-admission-baseline-applied-1/raw.rego
+++ b/rules/pod-security-admission-baseline-applied-1/raw.rego
@@ -1,8 +1,9 @@
 package armo_builtins
-import future.keywords.in
+
+import rego.v1
 
 # Fails if namespace does not have baseline pod security admission label
-deny[msga] {
+deny contains msga if {
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not baseline_admission_policy_enabled(namespace)
@@ -14,12 +15,10 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [fix_path],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }
 
-baseline_admission_policy_enabled(namespace){
+baseline_admission_policy_enabled(namespace) if {
 	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] in ["baseline", "restricted"]
 }

--- a/rules/pod-security-admission-baseline-applied-1/raw.rego
+++ b/rules/pod-security-admission-baseline-applied-1/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pod-security-admission-baseline-applied-2/filter.rego
+++ b/rules/pod-security-admission-baseline-applied-2/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pod-security-admission-baseline-applied-2/filter.rego
+++ b/rules/pod-security-admission-baseline-applied-2/filter.rego
@@ -1,8 +1,9 @@
 package armo_builtins
-import future.keywords.in
+
+import rego.v1
 
 # Fails if namespace does not have baseline pod security admission label
-deny[msga] {
+deny contains msga if {
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not baseline_admission_policy_enabled(namespace)
@@ -13,12 +14,10 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }
 
-baseline_admission_policy_enabled(namespace){
+baseline_admission_policy_enabled(namespace) if {
 	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] in ["baseline", "restricted"]
 }

--- a/rules/pod-security-admission-baseline-applied-2/raw.rego
+++ b/rules/pod-security-admission-baseline-applied-2/raw.rego
@@ -1,8 +1,9 @@
 package armo_builtins
-import future.keywords.in
+
+import rego.v1
 
 # Fails if namespace does not have baseline pod security admission label
-deny[msga] {
+deny contains msga if {
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not baseline_admission_policy_enabled(namespace)
@@ -14,12 +15,10 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [fix_path],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }
 
-baseline_admission_policy_enabled(namespace){
+baseline_admission_policy_enabled(namespace) if {
 	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] in ["baseline", "restricted"]
 }

--- a/rules/pod-security-admission-baseline-applied-2/raw.rego
+++ b/rules/pod-security-admission-baseline-applied-2/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pod-security-admission-restricted-applied-1/filter.rego
+++ b/rules/pod-security-admission-restricted-applied-1/filter.rego
@@ -1,8 +1,9 @@
 package armo_builtins
-import future.keywords.every
+
+import rego.v1
 
 # Fails if namespace does not have restricted pod security admission label
-deny[msga] {
+deny contains msga if {
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not restricted_admission_policy_enabled(namespace)
@@ -13,12 +14,10 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }
 
-restricted_admission_policy_enabled(namespace){
+restricted_admission_policy_enabled(namespace) if {
 	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] == "restricted"
 }

--- a/rules/pod-security-admission-restricted-applied-1/filter.rego
+++ b/rules/pod-security-admission-restricted-applied-1/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pod-security-admission-restricted-applied-1/raw.rego
+++ b/rules/pod-security-admission-restricted-applied-1/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pod-security-admission-restricted-applied-1/raw.rego
+++ b/rules/pod-security-admission-restricted-applied-1/raw.rego
@@ -1,8 +1,9 @@
 package armo_builtins
-import future.keywords.every
+
+import rego.v1
 
 # Fails if namespace does not have restricted pod security admission label
-deny[msga] {
+deny contains msga if {
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not restricted_admission_policy_enabled(namespace)
@@ -14,12 +15,10 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [fix_path],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }
 
-restricted_admission_policy_enabled(namespace){
+restricted_admission_policy_enabled(namespace) if {
 	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] == "restricted"
 }

--- a/rules/pod-security-admission-restricted-applied-2/filter.rego
+++ b/rules/pod-security-admission-restricted-applied-2/filter.rego
@@ -1,8 +1,9 @@
 package armo_builtins
-import future.keywords.every
+
+import rego.v1
 
 # Fails if namespace does not have restricted pod security admission label
-deny[msga] {
+deny contains msga if {
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not restricted_admission_policy_enabled(namespace)
@@ -13,12 +14,10 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }
 
-restricted_admission_policy_enabled(namespace){
+restricted_admission_policy_enabled(namespace) if {
 	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] == "restricted"
 }

--- a/rules/pod-security-admission-restricted-applied-2/filter.rego
+++ b/rules/pod-security-admission-restricted-applied-2/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pod-security-admission-restricted-applied-2/raw.rego
+++ b/rules/pod-security-admission-restricted-applied-2/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pod-security-admission-restricted-applied-2/raw.rego
+++ b/rules/pod-security-admission-restricted-applied-2/raw.rego
@@ -1,8 +1,9 @@
 package armo_builtins
-import future.keywords.every
+
+import rego.v1
 
 # Fails if namespace does not have restricted pod security admission label
-deny[msga] {
+deny contains msga if {
 	namespace := input[_]
 	namespace.kind == "Namespace"
 	not restricted_admission_policy_enabled(namespace)
@@ -14,12 +15,10 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [fix_path],
-		"alertObject": {
-			"k8sApiObjects": [namespace]
-		}
+		"alertObject": {"k8sApiObjects": [namespace]},
 	}
 }
 
-restricted_admission_policy_enabled(namespace){
+restricted_admission_policy_enabled(namespace) if {
 	namespace.metadata.labels["pod-security.kubernetes.io/enforce"] == "restricted"
 }

--- a/rules/poddisruptionbudget-in-default-namespace/raw.rego
+++ b/rules/poddisruptionbudget-in-default-namespace/raw.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -12,30 +14,26 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
-
+} else := []

--- a/rules/poddisruptionbudget-in-default-namespace/raw.rego
+++ b/rules/poddisruptionbudget-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/pods-in-default-namespace/raw.rego
+++ b/rules/pods-in-default-namespace/raw.rego
@@ -1,10 +1,11 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "CronJob", "Pod"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	result := is_default_namespace(wl.metadata)
 	failed_path := get_failed_path(result)

--- a/rules/podtemplate-in-default-namespace/raw.rego
+++ b/rules/podtemplate-in-default-namespace/raw.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -12,30 +14,26 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
-
+} else := []

--- a/rules/podtemplate-in-default-namespace/raw.rego
+++ b/rules/podtemplate-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/psp-deny-allowed-capabilities/raw.rego
+++ b/rules/psp-deny-allowed-capabilities/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.every
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	# only fail resources if all PSPs have allowedCapabilities
 	# if even one PSP has allowedCapabilities as an empty list, then the rule will not fail
 	every psp in input {

--- a/rules/psp-deny-allowed-capabilities/raw.rego
+++ b/rules/psp-deny-allowed-capabilities/raw.rego
@@ -1,8 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	path := "spec.allowedCapabilities"
 	# only fail resources if all PSPs have allowedCapabilities
 	# if even one PSP has allowedCapabilities as an empty list, then the rule will not fail
 	every psp in input {
@@ -15,7 +17,6 @@ deny contains msga if {
 	psp.kind == "PodSecurityPolicy"
 	count(psp.spec.allowedCapabilities) > 0
 
-	path := "spec.allowedCapabilities"
 	msga := {
 		"alertMessage": sprintf("PodSecurityPolicy: '%v' has allowedCapabilities.", [psp.metadata.name]),
 		"packagename": "armo_builtins",

--- a/rules/psp-deny-allowprivilegeescalation/raw.rego
+++ b/rules/psp-deny-allowprivilegeescalation/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.every
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	# only fail resources if there all PSPs have allowPrivilegeEscalation set to true
 	# if even one PSP has allowPrivilegeEscalation set to false, then the rule will not fail
 	every psp in input {

--- a/rules/psp-deny-allowprivilegeescalation/raw.rego
+++ b/rules/psp-deny-allowprivilegeescalation/raw.rego
@@ -1,8 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	path := "spec.allowPrivilegeEscalation"
 	# only fail resources if there all PSPs have allowPrivilegeEscalation set to true
 	# if even one PSP has allowPrivilegeEscalation set to false, then the rule will not fail
 	every psp in input {
@@ -15,7 +17,6 @@ deny contains msga if {
 	psp.kind == "PodSecurityPolicy"
 	psp.spec.allowPrivilegeEscalation == true
 
-	path := "spec.allowPrivilegeEscalation"
 	msga := {
 		"alertMessage": sprintf("PodSecurityPolicy: '%v' has allowPrivilegeEscalation set as true.", [psp.metadata.name]),
 		"packagename": "armo_builtins",

--- a/rules/psp-deny-hostipc/raw.rego
+++ b/rules/psp-deny-hostipc/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.every
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	# only fail resources if there all PSPs have hostIPC set to true
 	# if even one PSP has hostIPC set to false, then the rule will not fail
 	every psp in input {

--- a/rules/psp-deny-hostipc/raw.rego
+++ b/rules/psp-deny-hostipc/raw.rego
@@ -1,8 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	path := "spec.hostIPC"
 	# only fail resources if there all PSPs have hostIPC set to true
 	# if even one PSP has hostIPC set to false, then the rule will not fail
 	every psp in input {
@@ -15,7 +17,6 @@ deny contains msga if {
 	psp.kind == "PodSecurityPolicy"
 	psp.spec.hostIPC == true
 
-	path := "spec.hostIPC"
 	msga := {
 		"alertMessage": sprintf("PodSecurityPolicy: '%v' has hostIPC set as true.", [psp.metadata.name]),
 		"packagename": "armo_builtins",

--- a/rules/psp-deny-hostnetwork/raw.rego
+++ b/rules/psp-deny-hostnetwork/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.every
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	# only fail resources if there all PSPs have hostNetwork set to true
 	# if even one PSP has hostNetwork set to false, then the rule will not fail
 	every psp in input {

--- a/rules/psp-deny-hostnetwork/raw.rego
+++ b/rules/psp-deny-hostnetwork/raw.rego
@@ -1,8 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	path := "spec.hostNetwork"
 	# only fail resources if there all PSPs have hostNetwork set to true
 	# if even one PSP has hostNetwork set to false, then the rule will not fail
 	every psp in input {
@@ -15,7 +17,6 @@ deny contains msga if {
 	psp.kind == "PodSecurityPolicy"
 	psp.spec.hostNetwork == true
 
-	path := "spec.hostNetwork"
 	msga := {
 		"alertMessage": sprintf("PodSecurityPolicy: '%v' has hostNetwork set as true.", [psp.metadata.name]),
 		"packagename": "armo_builtins",

--- a/rules/psp-deny-hostpid/raw.rego
+++ b/rules/psp-deny-hostpid/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.every
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	# only fail resources if there all PSPs have hostPID set to true
 	# if even one PSP has hostPID set to false, then the rule will not fail
 	every psp in input {

--- a/rules/psp-deny-hostpid/raw.rego
+++ b/rules/psp-deny-hostpid/raw.rego
@@ -1,8 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	path := "spec.hostPID"
 	# only fail resources if there all PSPs have hostPID set to true
 	# if even one PSP has hostPID set to false, then the rule will not fail
 	every psp in input {
@@ -15,7 +17,6 @@ deny contains msga if {
 	psp.kind == "PodSecurityPolicy"
 	psp.spec.hostPID == true
 
-	path := "spec.hostPID"
 	msga := {
 		"alertMessage": sprintf("PodSecurityPolicy: '%v' has hostPID set as true.", [psp.metadata.name]),
 		"packagename": "armo_builtins",

--- a/rules/psp-deny-privileged-container/raw.rego
+++ b/rules/psp-deny-privileged-container/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.every
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	# only fail resources if there all PSPs have privileged set to true
 	# if even one PSP has privileged set to false, then the rule will not fail
 	every psp in input {

--- a/rules/psp-deny-privileged-container/raw.rego
+++ b/rules/psp-deny-privileged-container/raw.rego
@@ -1,8 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	path := "spec.privileged"
 	# only fail resources if there all PSPs have privileged set to true
 	# if even one PSP has privileged set to false, then the rule will not fail
 	every psp in input {
@@ -15,7 +17,6 @@ deny contains msga if {
 	psp.kind == "PodSecurityPolicy"
 	psp.spec.privileged == true
 
-	path := "spec.privileged"
 	msga := {
 		"alertMessage": sprintf("PodSecurityPolicy: '%v' has privileged set as true.", [psp.metadata.name]),
 		"packagename": "armo_builtins",

--- a/rules/psp-deny-root-container/raw.rego
+++ b/rules/psp-deny-root-container/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.every
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	# only fail resources if all PSPs permit containers to run as the root user
 	# if even one PSP restricts containers to run as the root user, then the rule will not fail
 	every psp in input {
@@ -26,11 +26,11 @@ deny[msga] {
 	}
 }
 
-deny_run_as_root(runAsUser){
+deny_run_as_root(runAsUser) if {
 	runAsUser.rule == "MustRunAsNonRoot"
 }
 
-deny_run_as_root(runAsUser){
+deny_run_as_root(runAsUser) if {
 	runAsUser.rule == "MustRunAs"
 	runAsUser.ranges[_].min > 0
 }

--- a/rules/psp-deny-root-container/raw.rego
+++ b/rules/psp-deny-root-container/raw.rego
@@ -1,8 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	path := "spec.runAsUser.rule"
 	# only fail resources if all PSPs permit containers to run as the root user
 	# if even one PSP restricts containers to run as the root user, then the rule will not fail
 	every psp in input {
@@ -15,7 +17,6 @@ deny contains msga if {
 	psp.kind == "PodSecurityPolicy"
 	not deny_run_as_root(psp.spec.runAsUser)
 
-	path := "spec.runAsUser.rule"
 	msga := {
 		"alertMessage": sprintf("PodSecurityPolicy: '%v' permits containers to run as the root user.", [psp.metadata.name]),
 		"packagename": "armo_builtins",

--- a/rules/psp-enabled-cloud/raw.rego
+++ b/rules/psp-enabled-cloud/raw.rego
@@ -1,16 +1,16 @@
 package armo_builtins
 
+import rego.v1
 
 # Check if PSP is enabled for GKE
-deny[msga] {
+deny contains msga if {
 	cluster_config := input[_]
 	cluster_config.apiVersion == "container.googleapis.com/v1"
 	cluster_config.kind == "ClusterDescribe"
-    cluster_config.metadata.provider == "gke"	
+	cluster_config.metadata.provider == "gke"
 	config := cluster_config.data
-    not config.pod_security_policy_config.enabled == true
+	not config.pod_security_policy_config.enabled == true
 
-	
 	msga := {
 		"alertMessage": "pod security policy configuration is not enabled",
 		"alertScore": 3,
@@ -20,7 +20,7 @@ deny[msga] {
 		"fixCommand": "gcloud beta container clusters update <cluster_name> --enable-pod-security-policy",
 		"alertObject": {
 			"k8sApiObjects": [],
-            "externalObjects": cluster_config
-		}
+			"externalObjects": cluster_config,
+		},
 	}
 }

--- a/rules/psp-enabled-cloud/raw.rego
+++ b/rules/psp-enabled-cloud/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/psp-enabled-native/raw.rego
+++ b/rules/psp-enabled-native/raw.rego
@@ -1,15 +1,16 @@
 package armo_builtins
 
+import rego.v1
 
 # Check if psp is enabled for native k8s
-deny[msga] {
+deny contains msga if {
 	apiserverpod := input[_]
-    cmd := apiserverpod.spec.containers[0].command[j]
-    contains(cmd, "--enable-admission-plugins=")
-    output := split(cmd, "=")
-    not contains(output[1], "PodSecurityPolicy")
-	path := sprintf("spec.containers[0].command[%v]", [format_int(j, 10)])	
-	
+	cmd := apiserverpod.spec.containers[0].command[j]
+	contains(cmd, "--enable-admission-plugins=")
+	output := split(cmd, "=")
+	not contains(output[1], "PodSecurityPolicy")
+	path := sprintf("spec.containers[0].command[%v]", [format_int(j, 10)])
+
 	msga := {
 		"alertMessage": "PodSecurityPolicy is not enabled",
 		"alertScore": 9,
@@ -17,9 +18,6 @@ deny[msga] {
 		"reviewPaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [apiserverpod],
-		
-		}
+		"alertObject": {"k8sApiObjects": [apiserverpod]},
 	}
 }

--- a/rules/psp-enabled-native/raw.rego
+++ b/rules/psp-enabled-native/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1

--- a/rules/psp-required-drop-capabilities/raw.rego
+++ b/rules/psp-required-drop-capabilities/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.every
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	# only fail resources if all PSPs don't have requiredDropCapabilities
 	# if even one PSP has requiredDropCapabilities, then the rule will not fail
 	every psp in input {
@@ -15,7 +15,7 @@ deny[msga] {
 	psp.kind == "PodSecurityPolicy"
 	not has_requiredDropCapabilities(psp.spec)
 
-	fixpath := {"path":"spec.requiredDropCapabilities[0]", "value":"ALL"}
+	fixpath := {"path": "spec.requiredDropCapabilities[0]", "value": "ALL"}
 	msga := {
 		"alertMessage": sprintf("PodSecurityPolicy: '%v' doesn't have requiredDropCapabilities.", [psp.metadata.name]),
 		"packagename": "armo_builtins",
@@ -25,6 +25,6 @@ deny[msga] {
 	}
 }
 
-has_requiredDropCapabilities(spec) {
+has_requiredDropCapabilities(spec) if {
 	count(spec.requiredDropCapabilities) > 0
 }

--- a/rules/psp-required-drop-capabilities/raw.rego
+++ b/rules/psp-required-drop-capabilities/raw.rego
@@ -1,8 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	fixpath := {"path": "spec.requiredDropCapabilities[0]", "value": "ALL"}
 	# only fail resources if all PSPs don't have requiredDropCapabilities
 	# if even one PSP has requiredDropCapabilities, then the rule will not fail
 	every psp in input {
@@ -15,7 +17,6 @@ deny contains msga if {
 	psp.kind == "PodSecurityPolicy"
 	not has_requiredDropCapabilities(psp.spec)
 
-	fixpath := {"path": "spec.requiredDropCapabilities[0]", "value": "ALL"}
 	msga := {
 		"alertMessage": sprintf("PodSecurityPolicy: '%v' doesn't have requiredDropCapabilities.", [psp.metadata.name]),
 		"packagename": "armo_builtins",

--- a/rules/pv-without-encryption/raw.rego
+++ b/rules/pv-without-encryption/raw.rego
@@ -1,7 +1,9 @@
 package armo_builtins
 
+import rego.v1
+
 # Checks if Ingress is connected to a service and a workload to expose something
-deny[msga] {
+deny contains msga if {
 	pv := input[_]
 	pv.kind == "PersistentVolume"
 
@@ -19,28 +21,27 @@ deny[msga] {
 		"failedPaths": [],
 		"fixPaths": [{
 			"path": "spec.storageClassName",
-			"value": "<your encrypted storage class>"
-        }],
+			"value": "<your encrypted storage class>",
+		}],
 		"alertScore": 7,
-		"alertObject": {"k8sApiObjects": [pv]}
+		"alertObject": {"k8sApiObjects": [pv]},
 	}
 }
 
 # Storage class is encrypted - AWS
-is_storage_class_encrypted(storageclass) {
+is_storage_class_encrypted(storageclass) if {
 	storageclass.parameters.encrypted == "true"
 }
 
 # Storage class is encrypted - Azure
-is_storage_class_encrypted(storageclass) {
+is_storage_class_encrypted(storageclass) if {
 	storageclass.provisioner
-	contains(storageclass.provisioner,"azure")
+	contains(storageclass.provisioner, "azure")
 }
 
 # Storage class is encrypted - GCP
-is_storage_class_encrypted(storageclass) {
+is_storage_class_encrypted(storageclass) if {
 	# GKE encryption is enabled by default https://cloud.google.com/blog/products/containers-kubernetes/exploring-container-security-use-your-own-keys-to-protect-your-data-on-gke
 	storageclass.provisioner
-	contains(storageclass.provisioner,"csi.storage.gke.io")
+	contains(storageclass.provisioner, "csi.storage.gke.io")
 }
-

--- a/rules/pv-without-encryption/raw.rego
+++ b/rules/pv-without-encryption/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -35,13 +36,11 @@ is_storage_class_encrypted(storageclass) if {
 
 # Storage class is encrypted - Azure
 is_storage_class_encrypted(storageclass) if {
-	storageclass.provisioner
 	contains(storageclass.provisioner, "azure")
 }
 
 # Storage class is encrypted - GCP
 is_storage_class_encrypted(storageclass) if {
 	# GKE encryption is enabled by default https://cloud.google.com/blog/products/containers-kubernetes/exploring-container-security-use-your-own-keys-to-protect-your-data-on-gke
-	storageclass.provisioner
 	contains(storageclass.provisioner, "csi.storage.gke.io")
 }


### PR DESCRIPTION
## Overview
This PR migrates the seventh batch of Rego rules to OPA v1 syntax.

## Additional Information
This batch cover rules from `rules/kubelet-hostname-override` through `rules/pv-without-encryption`

- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated many policy rules to Rego v1 syntax and updated rule/head forms across security checks and alert construction.
  * Formatting of emitted alert objects was normalized in several rules.
  * No changes to detection logic, enforcement behavior, or user-facing alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->