### PR TITLE
fix: migrate rego rules batch-8 to OPA v1

### DIFF
--- a/rules/rbac-enabled-cloud/raw.rego
+++ b/rules/rbac-enabled-cloud/raw.rego
@@ -1,6 +1,8 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	cluster_config := input[_]
 	cluster_config.apiVersion == "management.azure.com/v1"
 	cluster_config.kind == "ClusterDescribe"
@@ -16,11 +18,6 @@ deny[msga] {
 		"failedPaths": ["data.properties.enableRBAC"],
 		"fixCommand": "",
 		"fixPaths": [],
-		"alertObject": {
-            		"externalObjects": cluster_config
-		}
+		"alertObject": {"externalObjects": cluster_config},
 	}
 }
-
-
-

--- a/rules/rbac-enabled-cloud/raw.rego
+++ b/rules/rbac-enabled-cloud/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1

--- a/rules/rbac-enabled-native/raw.rego
+++ b/rules/rbac-enabled-native/raw.rego
@@ -1,15 +1,16 @@
 package armo_builtins
 
+import rego.v1
 
 # Check if psp is enabled for native k8s
-deny[msga] {
+deny contains msga if {
 	apiserverpod := input[_]
-    cmd := apiserverpod.spec.containers[0].command[j]
-    contains(cmd, "--authorization-mode=")
-    output := split(cmd, "=")
-    not contains(output[1], "RBAC")
-	path := sprintf("spec.containers[0].command[%v]", [format_int(j, 10)])	
-	
+	cmd := apiserverpod.spec.containers[0].command[j]
+	contains(cmd, "--authorization-mode=")
+	output := split(cmd, "=")
+	not contains(output[1], "RBAC")
+	path := sprintf("spec.containers[0].command[%v]", [format_int(j, 10)])
+
 	msga := {
 		"alertMessage": "RBAC is not enabled",
 		"alertScore": 9,
@@ -17,8 +18,6 @@ deny[msga] {
 		"reviewPaths": [path],
 		"failedPaths": [path],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [apiserverpod],
-		}
+		"alertObject": {"k8sApiObjects": [apiserverpod]},
 	}
 }

--- a/rules/rbac-enabled-native/raw.rego
+++ b/rules/rbac-enabled-native/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1

--- a/rules/read-only-port-enabled-updated/raw.rego
+++ b/rules/read-only-port-enabled-updated/raw.rego
@@ -1,10 +1,10 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # CIS 4.2.4 https://workbench.cisecurity.org/sections/1126668/recommendations/1838645
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -25,7 +25,7 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -57,7 +57,7 @@ deny[msga] {
 }
 
 ## Host sensor failed to get config file content
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -82,7 +82,7 @@ deny[msga] {
 	}
 }
 
-is_kubelet_info(obj) {
+is_kubelet_info(obj) if {
 	obj.kind == "KubeletInfo"
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 }

--- a/rules/read-only-port-enabled-updated/raw.rego
+++ b/rules/read-only-port-enabled-updated/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
@@ -29,9 +30,8 @@ deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
-	command := obj.data.cmdLine
-
 	not contains(obj, "--read-only-port")
+	command := obj.data.cmdLine
 	contains(command, "--config")
 
 	decodedConfigContent := base64.decode(obj.data.configFile.content)
@@ -61,9 +61,8 @@ deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
-	command := obj.data.cmdLine
-
 	not contains(obj, "--read-only-port")
+	command := obj.data.cmdLine
 	contains(command, "--config")
 
 	not obj.data.configFile.content

--- a/rules/replicationcontroller-in-default-namespace/raw.rego
+++ b/rules/replicationcontroller-in-default-namespace/raw.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -12,30 +14,26 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
-
+} else := []

--- a/rules/replicationcontroller-in-default-namespace/raw.rego
+++ b/rules/replicationcontroller-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1

--- a/rules/resource-policies/raw.rego
+++ b/rules/resource-policies/raw.rego
@@ -1,106 +1,96 @@
 package armo_builtins
 
+import rego.v1
 
 # Check if container has limits
-deny[msga] {
-  	pods := [pod | pod = input[_]; pod.kind == "Pod"]
-    pod := pods[_]
+deny contains msga if {
+	pods := [pod | pod = input[_]; pod.kind == "Pod"]
+	pod := pods[_]
 	container := pod.spec.containers[i]
-	
-	
+
 	start_of_path := "spec."
 	fixPath := is_no_cpu_and_memory_limits_defined(container, start_of_path, i)
-	
 
 	msga := {
-		"alertMessage": sprintf("there are no cpu and memory  limits defined for container : %v",  [container.name]),
+		"alertMessage": sprintf("there are no cpu and memory  limits defined for container : %v", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"fixPaths": fixPath,
 		"failedPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
-
 
 # Check if container has limits - for workloads
 # If there is no limits specified in the workload, we check the namespace, since if limits are only specified for namespace
 # and not in workload, it won't be on the yaml
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
-	
-	start_of_path	:= "spec.template.spec."
+
+	start_of_path := "spec.template.spec."
 	fixPath := is_no_cpu_and_memory_limits_defined(container, start_of_path, i)
-	
-	
 
 	msga := {
-		"alertMessage": sprintf("there are no cpu and memory limits defined for container : %v",  [container.name]),
+		"alertMessage": sprintf("there are no cpu and memory limits defined for container : %v", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"fixPaths": fixPath,
 		"failedPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
-	
 }
 
 # Check if container has limits - for cronjobs
 # If there is no limits specified in the cronjob, we check the namespace, since if limits are only specified for namespace
 # and not in cronjob, it won't be on the yaml
-deny [msga] {
-    wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
-	
+
 	start_of_path := "spec.jobTemplate.spec.template.spec."
 	fixPath := is_no_cpu_and_memory_limits_defined(container, start_of_path, i)
-	
+
 	msga := {
-		"alertMessage": sprintf("there are no cpu and memory limits defined for container : %v",  [container.name]),
+		"alertMessage": sprintf("there are no cpu and memory limits defined for container : %v", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"fixPaths": fixPath,
 		"failedPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # no limits at all
-is_no_cpu_and_memory_limits_defined(container, start_of_path, i) =  fixPath {
+is_no_cpu_and_memory_limits_defined(container, start_of_path, i) := fixPath if {
 	not container.resources.limits
-	fixPath = [{"path": sprintf("%vcontainers[%v].resources.limits.cpu", [start_of_path, format_int(i, 10)]), "value":"YOUR_VALUE"}, {"path": sprintf("%vcontainers[%v].resources.limits.memory", [start_of_path, format_int(i, 10)]), "value":"YOUR_VALUE"}]
+	fixPath = [{"path": sprintf("%vcontainers[%v].resources.limits.cpu", [start_of_path, format_int(i, 10)]), "value": "YOUR_VALUE"}, {"path": sprintf("%vcontainers[%v].resources.limits.memory", [start_of_path, format_int(i, 10)]), "value": "YOUR_VALUE"}]
 }
 
 # only memory limit
-is_no_cpu_and_memory_limits_defined(container, start_of_path, i) = fixPath {
+is_no_cpu_and_memory_limits_defined(container, start_of_path, i) := fixPath if {
 	container.resources.limits
 	not container.resources.limits.cpu
 	container.resources.limits.memory
-	fixPath = [{"path": sprintf("%vcontainers[%v].resources.limits.cpu", [start_of_path, format_int(i, 10)]), "value":"YOUR_VALUE"}]
+	fixPath = [{"path": sprintf("%vcontainers[%v].resources.limits.cpu", [start_of_path, format_int(i, 10)]), "value": "YOUR_VALUE"}]
 }
 
 # only cpu limit
-is_no_cpu_and_memory_limits_defined(container, start_of_path, i) =fixPath {
+is_no_cpu_and_memory_limits_defined(container, start_of_path, i) := fixPath if {
 	container.resources.limits
 	not container.resources.limits.memory
 	container.resources.limits.cpu
-	fixPath = [{"path": sprintf("%vcontainers[%v].resources.limits.memory", [start_of_path, format_int(i, 10)]), "value":"YOUR_VALUE"}]
+	fixPath = [{"path": sprintf("%vcontainers[%v].resources.limits.memory", [start_of_path, format_int(i, 10)]), "value": "YOUR_VALUE"}]
 	failed_path = ""
 }
-# limits but without capu and memory 
-is_no_cpu_and_memory_limits_defined(container, start_of_path, i) = fixPath {
+
+# limits but without capu and memory
+is_no_cpu_and_memory_limits_defined(container, start_of_path, i) := fixPath if {
 	container.resources.limits
 	not container.resources.limits.memory
 	not container.resources.limits.cpu
-	fixPath = [{"path": sprintf("%vcontainers[%v].resources.limits.cpu", [start_of_path, format_int(i, 10)]), "value":"YOUR_VALUE"}, {"path": sprintf("%vcontainers[%v].resources.limits.memory", [start_of_path, format_int(i, 10)]), "value":"YOUR_VALUE"}]
+	fixPath = [{"path": sprintf("%vcontainers[%v].resources.limits.cpu", [start_of_path, format_int(i, 10)]), "value": "YOUR_VALUE"}, {"path": sprintf("%vcontainers[%v].resources.limits.memory", [start_of_path, format_int(i, 10)]), "value": "YOUR_VALUE"}]
 }

--- a/rules/resource-policies/raw.rego
+++ b/rules/resource-policies/raw.rego
@@ -1,14 +1,15 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 # Check if container has limits
 deny contains msga if {
+	start_of_path := "spec."
 	pods := [pod | pod = input[_]; pod.kind == "Pod"]
 	pod := pods[_]
 	container := pod.spec.containers[i]
 
-	start_of_path := "spec."
 	fixPath := is_no_cpu_and_memory_limits_defined(container, start_of_path, i)
 
 	msga := {
@@ -25,12 +26,12 @@ deny contains msga if {
 # If there is no limits specified in the workload, we check the namespace, since if limits are only specified for namespace
 # and not in workload, it won't be on the yaml
 deny contains msga if {
-	wl := input[_]
+	start_of_path := "spec.template.spec."
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 
-	start_of_path := "spec.template.spec."
 	fixPath := is_no_cpu_and_memory_limits_defined(container, start_of_path, i)
 
 	msga := {
@@ -47,11 +48,11 @@ deny contains msga if {
 # If there is no limits specified in the cronjob, we check the namespace, since if limits are only specified for namespace
 # and not in cronjob, it won't be on the yaml
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
 
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	fixPath := is_no_cpu_and_memory_limits_defined(container, start_of_path, i)
 
 	msga := {

--- a/rules/resources-cpu-limit-and-request/raw.rego
+++ b/rules/resources-cpu-limit-and-request/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
@@ -25,8 +26,8 @@ deny contains msga if {
 
 # Fails if workload does not have container with CPU requests
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	not container.resources.requests.cpu
@@ -87,8 +88,8 @@ deny contains msga if {
 
 # Fails if workload does not have container with CPU-limits
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	not container.resources.limits.cpu
@@ -130,10 +131,10 @@ deny contains msga if {
 
 # Fails if pod exceeds CPU-limit or request
 deny contains msga if {
+	path := "resources.limits.cpu"
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
-	path := "resources.limits.cpu"
 	cpu_limit := container.resources.limits.cpu
 	is_limit_exceeded_cpu(cpu_limit)
 
@@ -152,12 +153,12 @@ deny contains msga if {
 
 # Fails if workload exceeds CPU-limit or request
 deny contains msga if {
-	wl := input[_]
+	path := "resources.limits.cpu"
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 
-	path := "resources.limits.cpu"
 	cpu_limit := container.resources.limits.cpu
 	is_limit_exceeded_cpu(cpu_limit)
 
@@ -176,11 +177,11 @@ deny contains msga if {
 
 # Fails if cronjob doas exceeds CPU-limit or request
 deny contains msga if {
+	path := "resources.limits.cpu"
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 
-	path := "resources.limits.cpu"
 	cpu_limit := container.resources.limits.cpu
 	is_limit_exceeded_cpu(cpu_limit)
 
@@ -201,10 +202,10 @@ deny contains msga if {
 
 # Fails if pod exceeds CPU-limit or request
 deny contains msga if {
+	path := "resources.requests.cpu"
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
-	path := "resources.requests.cpu"
 	cpu_req := container.resources.requests.cpu
 	is_req_exceeded_cpu(cpu_req)
 
@@ -223,12 +224,12 @@ deny contains msga if {
 
 # Fails if workload exceeds CPU-limit or request
 deny contains msga if {
-	wl := input[_]
+	path := "resources.requests.cpu"
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 
-	path := "resources.requests.cpu"
 	cpu_req := container.resources.requests.cpu
 	is_req_exceeded_cpu(cpu_req)
 
@@ -247,11 +248,11 @@ deny contains msga if {
 
 # Fails if cronjob doas exceeds CPU-limit or request
 deny contains msga if {
+	path := "resources.requests.cpu"
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 
-	path := "resources.requests.cpu"
 	cpu_req := container.resources.requests.cpu
 	is_req_exceeded_cpu(cpu_req)
 
@@ -319,12 +320,11 @@ is_min_request_exceeded_cpu(cpu_req) if {
 
 # Compare two Kubernetes CPU quantities by normalizing both sides to millicores.
 # Supports the milli suffix ("m") and unitless whole/fractional cores.
-compare_max(max, given) if {
-	cpu_to_millicores(given) > cpu_to_millicores(max)
+compare_max(limit, given) if {
+	cpu_to_millicores(given) > cpu_to_millicores(limit)
 }
-
-compare_min(min, given) if {
-	cpu_to_millicores(given) < cpu_to_millicores(min)
+compare_min(threshold, given) if {
+	cpu_to_millicores(given) < cpu_to_millicores(threshold)
 }
 
 # Parse a Kubernetes CPU quantity string into millicores.

--- a/rules/resources-cpu-limit-and-request/raw.rego
+++ b/rules/resources-cpu-limit-and-request/raw.rego
@@ -1,342 +1,315 @@
 package armo_builtins
 
+import rego.v1
+
 # ==================================== no CPU requests =============================================
 # Fails if pod does not have container with CPU request
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
-    container := pod.spec.containers[i]
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.containers[i]
 	not container.resources.requests.cpu
 
 	fixPaths := [{"path": sprintf("spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
-		"alertMessage": sprintf("Container: %v does not have CPU-limit or request", [ container.name]),
+		"alertMessage": sprintf("Container: %v does not have CPU-limit or request", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # Fails if workload does not have container with CPU requests
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
-    not container.resources.requests.cpu
+	container := wl.spec.template.spec.containers[i]
+	not container.resources.requests.cpu
 
 	fixPaths := [{"path": sprintf("spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if cronjob does not have container with CPU requests
-deny[msga] {
-  	wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-    not container.resources.requests.cpu
+	not container.resources.requests.cpu
 
 	fixPaths := [{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
-    msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # ==================================== no CPU limits =============================================
 # Fails if pod does not have container with CPU-limits
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
-    container := pod.spec.containers[i]
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.containers[i]
 	not container.resources.limits.cpu
 
 	fixPaths := [{"path": sprintf("spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
-		"alertMessage": sprintf("Container: %v does not have CPU-limit or request", [ container.name]),
+		"alertMessage": sprintf("Container: %v does not have CPU-limit or request", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # Fails if workload does not have container with CPU-limits
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
-    not container.resources.limits.cpu
+	container := wl.spec.template.spec.containers[i]
+	not container.resources.limits.cpu
 
 	fixPaths := [{"path": sprintf("spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if cronjob does not have container with CPU-limits
-deny[msga] {
-  	wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-    not container.resources.limits.cpu
+	not container.resources.limits.cpu
 
 	fixPaths := [{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
-    msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
-
-
 
 # ============================================= cpu limits exceed min/max =============================================
 
 # Fails if pod exceeds CPU-limit or request
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
-    container := pod.spec.containers[i]
-	path := "resources.limits.cpu" 
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.containers[i]
+	path := "resources.limits.cpu"
 	cpu_limit := container.resources.limits.cpu
 	is_limit_exceeded_cpu(cpu_limit)
 
 	failed_paths := sprintf("spec.containers[%v].%v", [format_int(i, 10), path])
 
 	msga := {
-		"alertMessage": sprintf("Container: %v exceeds CPU-limit or request", [ container.name]),
+		"alertMessage": sprintf("Container: %v exceeds CPU-limit or request", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [failed_paths],
 		"failedPaths": [failed_paths],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # Fails if workload exceeds CPU-limit or request
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
+	container := wl.spec.template.spec.containers[i]
 
-	path := "resources.limits.cpu" 
+	path := "resources.limits.cpu"
 	cpu_limit := container.resources.limits.cpu
 	is_limit_exceeded_cpu(cpu_limit)
 
 	failed_paths := sprintf("spec.template.spec.containers[%v].%v", [format_int(i, 10), path])
 
 	msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v exceeds CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+		"alertMessage": sprintf("Container: %v in %v: %v exceeds CPU-limit or request", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [failed_paths],
 		"failedPaths": [failed_paths],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if cronjob doas exceeds CPU-limit or request
-deny[msga] {
-  	wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 
-   	path := "resources.limits.cpu" 
+	path := "resources.limits.cpu"
 	cpu_limit := container.resources.limits.cpu
 	is_limit_exceeded_cpu(cpu_limit)
 
 	failed_paths := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].%v", [format_int(i, 10), path])
 
-    msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v exceeds CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("Container: %v in %v: %v exceeds CPU-limit or request", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [failed_paths],
 		"failedPaths": [failed_paths],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # ============================================= cpu requests exceed min/max =============================================
 
 # Fails if pod exceeds CPU-limit or request
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
-    container := pod.spec.containers[i]
-	path := "resources.requests.cpu" 
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.containers[i]
+	path := "resources.requests.cpu"
 	cpu_req := container.resources.requests.cpu
 	is_req_exceeded_cpu(cpu_req)
 
 	failed_paths := sprintf("spec.containers[%v].%v", [format_int(i, 10), path])
 
 	msga := {
-		"alertMessage": sprintf("Container: %v exceeds CPU-limit or request", [ container.name]),
+		"alertMessage": sprintf("Container: %v exceeds CPU-limit or request", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [failed_paths],
 		"failedPaths": [failed_paths],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # Fails if workload exceeds CPU-limit or request
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
+	container := wl.spec.template.spec.containers[i]
 
-	path := "resources.requests.cpu" 
+	path := "resources.requests.cpu"
 	cpu_req := container.resources.requests.cpu
 	is_req_exceeded_cpu(cpu_req)
 
 	failed_paths := sprintf("spec.template.spec.containers[%v].%v", [format_int(i, 10), path])
 
 	msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v exceeds CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+		"alertMessage": sprintf("Container: %v in %v: %v exceeds CPU-limit or request", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [failed_paths],
 		"failedPaths": [failed_paths],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if cronjob doas exceeds CPU-limit or request
-deny[msga] {
-  	wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 
-	path := "resources.requests.cpu" 
+	path := "resources.requests.cpu"
 	cpu_req := container.resources.requests.cpu
 	is_req_exceeded_cpu(cpu_req)
 
 	failed_paths := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].%v", [format_int(i, 10), path])
 
-    msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v exceeds CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("Container: %v in %v: %v exceeds CPU-limit or request", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [failed_paths],
 		"failedPaths": [failed_paths],
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
 #################################################################################################################
 
-
-is_min_max_exceeded_cpu(container)  = "resources.limits.cpu" {
+is_min_max_exceeded_cpu(container) := "resources.limits.cpu" if {
 	cpu_limit := container.resources.limits.cpu
 	is_limit_exceeded_cpu(cpu_limit)
-} else = "resources.requests.cpu" {
+} else := "resources.requests.cpu" if {
 	cpu_req := container.resources.requests.cpu
 	is_req_exceeded_cpu(cpu_req)
-} else = ""
+} else := ""
 
-
-is_limit_exceeded_cpu(cpu_limit) {
+is_limit_exceeded_cpu(cpu_limit) if {
 	is_min_limit_exceeded_cpu(cpu_limit)
 }
 
-is_limit_exceeded_cpu(cpu_limit) {
+is_limit_exceeded_cpu(cpu_limit) if {
 	is_max_limit_exceeded_cpu(cpu_limit)
 }
 
-is_req_exceeded_cpu(cpu_req) {
+is_req_exceeded_cpu(cpu_req) if {
 	is_max_request_exceeded_cpu(cpu_req)
 }
 
-is_req_exceeded_cpu(cpu_req) {
+is_req_exceeded_cpu(cpu_req) if {
 	is_min_request_exceeded_cpu(cpu_req)
 }
 
-is_max_limit_exceeded_cpu(cpu_limit) {
-	cpu_limit_max :=  data.postureControlInputs.cpu_limit_max[_]
+is_max_limit_exceeded_cpu(cpu_limit) if {
+	cpu_limit_max := data.postureControlInputs.cpu_limit_max[_]
 	compare_max(cpu_limit_max, cpu_limit)
 }
 
-is_min_limit_exceeded_cpu(cpu_limit) {
-	cpu_limit_min :=  data.postureControlInputs.cpu_limit_min[_]
+is_min_limit_exceeded_cpu(cpu_limit) if {
+	cpu_limit_min := data.postureControlInputs.cpu_limit_min[_]
 	compare_min(cpu_limit_min, cpu_limit)
 }
 
-is_max_request_exceeded_cpu(cpu_req) {
-	cpu_req_max :=  data.postureControlInputs.cpu_request_max[_]
+is_max_request_exceeded_cpu(cpu_req) if {
+	cpu_req_max := data.postureControlInputs.cpu_request_max[_]
 	compare_max(cpu_req_max, cpu_req)
 }
 
-is_min_request_exceeded_cpu(cpu_req) {
+is_min_request_exceeded_cpu(cpu_req) if {
 	cpu_req_min := data.postureControlInputs.cpu_request_min[_]
 	compare_min(cpu_req_min, cpu_req)
 }
@@ -346,20 +319,20 @@ is_min_request_exceeded_cpu(cpu_req) {
 
 # Compare two Kubernetes CPU quantities by normalizing both sides to millicores.
 # Supports the milli suffix ("m") and unitless whole/fractional cores.
-compare_max(max, given) {
+compare_max(max, given) if {
 	cpu_to_millicores(given) > cpu_to_millicores(max)
 }
 
-compare_min(min, given) {
+compare_min(min, given) if {
 	cpu_to_millicores(given) < cpu_to_millicores(min)
 }
 
 # Parse a Kubernetes CPU quantity string into millicores.
 # "500m" -> 500, "1" -> 1000, "0.5" -> 500.
-cpu_to_millicores(q) = n {
+cpu_to_millicores(q) := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "m")
 	n := to_number(trim_suffix(s, "m"))
-} else = n {
+} else := n if {
 	n := to_number(q) * 1000
 }

--- a/rules/resources-cpu-limits/raw.rego
+++ b/rules/resources-cpu-limits/raw.rego
@@ -1,72 +1,65 @@
 package armo_builtins
 
+import rego.v1
 
 # ==================================== no CPU limits =============================================
 # Fails if pod does not have container with CPU-limits
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
-    container := pod.spec.containers[i]
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.containers[i]
 	not container.resources.limits.cpu
 
 	fixPaths := [{"path": sprintf("spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
-		"alertMessage": sprintf("Container: %v does not have CPU-limit or request", [ container.name]),
+		"alertMessage": sprintf("Container: %v does not have CPU-limit or request", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # Fails if workload does not have container with CPU-limits
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
-    not container.resources.limits.cpu
+	container := wl.spec.template.spec.containers[i]
+	not container.resources.limits.cpu
 
 	fixPaths := [{"path": sprintf("spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if cronjob does not have container with CPU-limits
-deny[msga] {
-  	wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-    not container.resources.limits.cpu
+	not container.resources.limits.cpu
 
 	fixPaths := [{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.limits.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
-    msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
-
-

--- a/rules/resources-cpu-limits/raw.rego
+++ b/rules/resources-cpu-limits/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
@@ -25,8 +26,8 @@ deny contains msga if {
 
 # Fails if workload does not have container with CPU-limits
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	not container.resources.limits.cpu

--- a/rules/resources-cpu-requests/raw.rego
+++ b/rules/resources-cpu-requests/raw.rego
@@ -1,69 +1,65 @@
 package armo_builtins
 
+import rego.v1
+
 # ==================================== no CPU requests =============================================
 # Fails if pod does not have container with CPU request
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
-    container := pod.spec.containers[i]
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.containers[i]
 	not container.resources.requests.cpu
 
 	fixPaths := [{"path": sprintf("spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
-		"alertMessage": sprintf("Container: %v does not have CPU-limit or request", [ container.name]),
+		"alertMessage": sprintf("Container: %v does not have CPU-limit or request", [container.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # Fails if workload does not have container with CPU requests
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
-    not container.resources.requests.cpu
+	container := wl.spec.template.spec.containers[i]
+	not container.resources.requests.cpu
 
 	fixPaths := [{"path": sprintf("spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
 	msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if cronjob does not have container with CPU requests
-deny[msga] {
-  	wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-    not container.resources.requests.cpu
+	not container.resources.requests.cpu
 
 	fixPaths := [{"path": sprintf("spec.jobTemplate.spec.template.spec.containers[%v].resources.requests.cpu", [format_int(i, 10)]), "value": "YOUR_VALUE"}]
 
-    msga := {
-		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [ container.name, wl.kind, wl.metadata.name]),
+	msga := {
+		"alertMessage": sprintf("Container: %v in %v: %v   does not have CPU-limit or request", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"reviewPaths": [],
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }

--- a/rules/resources-cpu-requests/raw.rego
+++ b/rules/resources-cpu-requests/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
@@ -25,8 +26,8 @@ deny contains msga if {
 
 # Fails if workload does not have container with CPU requests
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	not container.resources.requests.cpu

--- a/rules/resources-memory-limit-and-request/raw.rego
+++ b/rules/resources-memory-limit-and-request/raw.rego
@@ -1,8 +1,10 @@
 package armo_builtins
 
+import rego.v1
+
 #  ================================== no memory limits ==================================
 # Fails if pod does not have container with memory-limits
-deny[msga] {
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
@@ -20,7 +22,7 @@ deny[msga] {
 }
 
 # Fails if workload does not have container with memory-limits
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
@@ -39,7 +41,7 @@ deny[msga] {
 }
 
 # Fails if cronjob does not have container with memory-limits
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
@@ -58,7 +60,7 @@ deny[msga] {
 
 #  ================================== no memory requests ==================================
 # Fails if pod does not have container with memory requests
-deny[msga] {
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
@@ -76,7 +78,7 @@ deny[msga] {
 }
 
 # Fails if workload does not have container with memory requests
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
@@ -95,7 +97,7 @@ deny[msga] {
 }
 
 # Fails if cronjob does not have container with memory requests
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
@@ -112,11 +114,10 @@ deny[msga] {
 	}
 }
 
-
 # ============================================= memory requests exceed min/max =============================================
 
 # Fails if pod exceeds memory request
-deny[msga] {
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
@@ -138,7 +139,7 @@ deny[msga] {
 }
 
 # Fails if workload exceeds memory request
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
@@ -162,14 +163,14 @@ deny[msga] {
 }
 
 # Fails if cronjob exceeds memory request
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 
 	memory_req := container.resources.requests.memory
 	is_req_exceeded_memory(memory_req)
-	path := "resources.requests.memory" 
+	path := "resources.requests.memory"
 
 	failed_paths := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].%v", [format_int(i, 10), path])
 
@@ -186,8 +187,8 @@ deny[msga] {
 
 # ============================================= memory limits exceed min/max =============================================
 
-# Fails if pod exceeds memory-limit 
-deny[msga] {
+# Fails if pod exceeds memory-limit
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
@@ -208,8 +209,8 @@ deny[msga] {
 	}
 }
 
-# Fails if workload exceeds memory-limit 
-deny[msga] {
+# Fails if workload exceeds memory-limit
+deny contains msga if {
 	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
@@ -232,8 +233,8 @@ deny[msga] {
 	}
 }
 
-# Fails if cronjob exceeds memory-limit 
-deny[msga] {
+# Fails if cronjob exceeds memory-limit
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
@@ -257,118 +258,116 @@ deny[msga] {
 
 ######################################################################################################
 
-
-is_limit_exceeded_memory(memory_limit) {
+is_limit_exceeded_memory(memory_limit) if {
 	is_min_limit_exceeded_memory(memory_limit)
 }
 
-is_limit_exceeded_memory(memory_limit) {
+is_limit_exceeded_memory(memory_limit) if {
 	is_max_limit_exceeded_memory(memory_limit)
 }
 
-is_req_exceeded_memory(memory_req) {
+is_req_exceeded_memory(memory_req) if {
 	is_max_request_exceeded_memory(memory_req)
 }
 
-is_req_exceeded_memory(memory_req) {
+is_req_exceeded_memory(memory_req) if {
 	is_min_request_exceeded_memory(memory_req)
 }
 
 # helpers
 
-is_max_limit_exceeded_memory(memory_limit) {
+is_max_limit_exceeded_memory(memory_limit) if {
 	memory_limit_max := data.postureControlInputs.memory_limit_max[_]
 	compare_max(memory_limit_max, memory_limit)
 }
 
-is_min_limit_exceeded_memory(memory_limit) {
+is_min_limit_exceeded_memory(memory_limit) if {
 	memory_limit_min := data.postureControlInputs.memory_limit_min[_]
 	compare_min(memory_limit_min, memory_limit)
 }
 
-is_max_request_exceeded_memory(memory_req) {
+is_max_request_exceeded_memory(memory_req) if {
 	memory_req_max := data.postureControlInputs.memory_request_max[_]
 	compare_max(memory_req_max, memory_req)
 }
 
-is_min_request_exceeded_memory(memory_req) {
+is_min_request_exceeded_memory(memory_req) if {
 	memory_req_min := data.postureControlInputs.memory_request_min[_]
 	compare_min(memory_req_min, memory_req)
 }
-
 
 ##############
 # helpers
 
 # Compare two Kubernetes memory quantities by normalizing both sides to bytes.
 # Supports binary (Ki/Mi/Gi/Ti/Pi/Ei), decimal (k/K/M/G/T/P/E) and unitless byte counts.
-compare_max(max, given) {
+compare_max(max, given) if {
 	mem_to_bytes(given) > mem_to_bytes(max)
 }
 
-compare_min(min, given) {
+compare_min(min, given) if {
 	mem_to_bytes(given) < mem_to_bytes(min)
 }
 
 # Parse a Kubernetes memory quantity string into bytes.
 # Order matters: binary two-char suffixes are checked before single-char decimal
 # suffixes so "Mi" is not misread as "M".
-mem_to_bytes(q) = n {
+mem_to_bytes(q) := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "Ki")
 	n := to_number(trim_suffix(s, "Ki")) * 1024
-} else = n {
+} else := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "Mi")
 	n := to_number(trim_suffix(s, "Mi")) * 1048576
-} else = n {
+} else := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "Gi")
 	n := to_number(trim_suffix(s, "Gi")) * 1073741824
-} else = n {
+} else := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "Ti")
 	n := to_number(trim_suffix(s, "Ti")) * 1099511627776
-} else = n {
+} else := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "Pi")
 	n := to_number(trim_suffix(s, "Pi")) * 1125899906842624
-} else = n {
+} else := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "Ei")
 	n := to_number(trim_suffix(s, "Ei")) * 1152921504606846976
-} else = n {
+} else := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "m")
 	n := to_number(trim_suffix(s, "m")) / 1000
-} else = n {
+} else := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "k")
 	n := to_number(trim_suffix(s, "k")) * 1000
-} else = n {
+} else := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "K")
 	n := to_number(trim_suffix(s, "K")) * 1000
-} else = n {
+} else := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "M")
 	n := to_number(trim_suffix(s, "M")) * 1000000
-} else = n {
+} else := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "G")
 	n := to_number(trim_suffix(s, "G")) * 1000000000
-} else = n {
+} else := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "T")
 	n := to_number(trim_suffix(s, "T")) * 1000000000000
-} else = n {
+} else := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "P")
 	n := to_number(trim_suffix(s, "P")) * 1000000000000000
-} else = n {
+} else := n if {
 	s := sprintf("%v", [q])
 	endswith(s, "E")
 	n := to_number(trim_suffix(s, "E")) * 1000000000000000000
-} else = n {
+} else := n if {
 	n := to_number(q)
 }

--- a/rules/resources-memory-limit-and-request/raw.rego
+++ b/rules/resources-memory-limit-and-request/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
@@ -23,8 +24,8 @@ deny contains msga if {
 
 # Fails if workload does not have container with memory-limits
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	not container.resources.limits.memory
@@ -79,8 +80,8 @@ deny contains msga if {
 
 # Fails if workload does not have container with memory requests
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	not container.resources.requests.memory
@@ -118,12 +119,12 @@ deny contains msga if {
 
 # Fails if pod exceeds memory request
 deny contains msga if {
+	path := "resources.requests.memory"
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
 	memory_req := container.resources.requests.memory
 	is_req_exceeded_memory(memory_req)
-	path := "resources.requests.memory"
 
 	failed_paths := sprintf("spec.containers[%v].%v", [format_int(i, 10), path])
 
@@ -140,14 +141,14 @@ deny contains msga if {
 
 # Fails if workload exceeds memory request
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	path := "resources.requests.memory"
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 
 	memory_req := container.resources.requests.memory
 	is_req_exceeded_memory(memory_req)
-	path := "resources.requests.memory"
 
 	failed_paths := sprintf("spec.template.spec.containers[%v].%v", [format_int(i, 10), path])
 
@@ -164,13 +165,13 @@ deny contains msga if {
 
 # Fails if cronjob exceeds memory request
 deny contains msga if {
+	path := "resources.requests.memory"
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 
 	memory_req := container.resources.requests.memory
 	is_req_exceeded_memory(memory_req)
-	path := "resources.requests.memory"
 
 	failed_paths := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].%v", [format_int(i, 10), path])
 
@@ -189,12 +190,12 @@ deny contains msga if {
 
 # Fails if pod exceeds memory-limit
 deny contains msga if {
+	path := "resources.limits.memory"
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
 	memory_limit := container.resources.limits.memory
 	is_limit_exceeded_memory(memory_limit)
-	path := "resources.limits.memory"
 
 	failed_paths := sprintf("spec.containers[%v].%v", [format_int(i, 10), path])
 
@@ -211,14 +212,14 @@ deny contains msga if {
 
 # Fails if workload exceeds memory-limit
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	path := "resources.limits.memory"
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 
 	memory_limit := container.resources.limits.memory
 	is_limit_exceeded_memory(memory_limit)
-	path := "resources.limits.memory"
 
 	failed_paths := sprintf("spec.template.spec.containers[%v].%v", [format_int(i, 10), path])
 
@@ -235,13 +236,13 @@ deny contains msga if {
 
 # Fails if cronjob exceeds memory-limit
 deny contains msga if {
+	path := "resources.limits.memory"
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 
 	memory_limit := container.resources.limits.memory
 	is_limit_exceeded_memory(memory_limit)
-	path := "resources.limits.memory"
 
 	failed_paths := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].%v", [format_int(i, 10), path])
 
@@ -301,12 +302,12 @@ is_min_request_exceeded_memory(memory_req) if {
 
 # Compare two Kubernetes memory quantities by normalizing both sides to bytes.
 # Supports binary (Ki/Mi/Gi/Ti/Pi/Ei), decimal (k/K/M/G/T/P/E) and unitless byte counts.
-compare_max(max, given) if {
-	mem_to_bytes(given) > mem_to_bytes(max)
+compare_max(limit, given) if {
+	mem_to_bytes(given) > mem_to_bytes(limit)
 }
 
-compare_min(min, given) if {
-	mem_to_bytes(given) < mem_to_bytes(min)
+compare_min(threshold, given) if {
+	mem_to_bytes(given) < mem_to_bytes(threshold)
 }
 
 # Parse a Kubernetes memory quantity string into bytes.

--- a/rules/resources-memory-limits/raw.rego
+++ b/rules/resources-memory-limits/raw.rego
@@ -1,8 +1,10 @@
 package armo_builtins
 
+import rego.v1
+
 #  ================================== no memory limits ==================================
 # Fails if pod does not have container with memory-limits
-deny[msga] {
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
@@ -20,7 +22,7 @@ deny[msga] {
 }
 
 # Fails if workload does not have container with memory-limits
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
@@ -39,7 +41,7 @@ deny[msga] {
 }
 
 # Fails if cronjob does not have container with memory-limits
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]

--- a/rules/resources-memory-limits/raw.rego
+++ b/rules/resources-memory-limits/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
@@ -23,8 +24,8 @@ deny contains msga if {
 
 # Fails if workload does not have container with memory-limits
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	not container.resources.limits.memory

--- a/rules/resources-memory-requests/raw.rego
+++ b/rules/resources-memory-requests/raw.rego
@@ -1,8 +1,10 @@
 package armo_builtins
 
+import rego.v1
+
 #  ================================== no memory requests ==================================
 # Fails if pod does not have container with memory requests
-deny[msga] {
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
@@ -20,7 +22,7 @@ deny[msga] {
 }
 
 # Fails if workload does not have container with memory requests
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
@@ -39,7 +41,7 @@ deny[msga] {
 }
 
 # Fails if cronjob does not have container with memory requests
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
@@ -55,4 +57,3 @@ deny[msga] {
 		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
-

--- a/rules/resources-memory-requests/raw.rego
+++ b/rules/resources-memory-requests/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
@@ -23,8 +24,8 @@ deny contains msga if {
 
 # Fails if workload does not have container with memory requests
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	not container.resources.requests.memory

--- a/rules/resources-secret-in-default-namespace/raw.rego
+++ b/rules/resources-secret-in-default-namespace/raw.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -12,30 +14,26 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
-
+} else := []

--- a/rules/resources-secret-in-default-namespace/raw.rego
+++ b/rules/resources-secret-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1

--- a/rules/restrict-access-to-the-control-plane-endpoint/raw.rego
+++ b/rules/restrict-access-to-the-control-plane-endpoint/raw.rego
@@ -1,8 +1,9 @@
-
 package armo_builtins
 
+import rego.v1
+
 # fails in case authorizedIPRanges is not set.
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	obj.apiVersion == "management.azure.com/v1"
 	obj.kind == "ClusterDescribe"
@@ -12,20 +13,17 @@ deny[msga] {
 	not isAuthorizedIPRangesSet(config)
 
 	msga := {
-    	"alertMessage": "Parameter 'authorizedIPRanges' was not set.",
-    	"packagename": "armo_builtins",
-    	"alertScore": 7,
+		"alertMessage": "Parameter 'authorizedIPRanges' was not set.",
+		"packagename": "armo_builtins",
+		"alertScore": 7,
 		"reviewPaths": [],
-    	"failedPaths": [],
-    	"fixPaths":[],
-        "fixCommand": "az aks update -n '<name>' -g '<resource_group>' --api-server-authorized-ip-ranges '0.0.0.0/32'",
-    	"alertObject": {
-			"externalObjects": obj
-        }
-    }
-
+		"failedPaths": [],
+		"fixPaths": [],
+		"fixCommand": "az aks update -n '<name>' -g '<resource_group>' --api-server-authorized-ip-ranges '0.0.0.0/32'",
+		"alertObject": {"externalObjects": obj},
+	}
 }
 
-isAuthorizedIPRangesSet(config) {
+isAuthorizedIPRangesSet(config) if {
 	count(config.properties.apiServerAccessProfile.authorizedIPRanges) > 0
 }

--- a/rules/restrict-access-to-the-control-plane-endpoint/raw.rego
+++ b/rules/restrict-access-to-the-control-plane-endpoint/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1

--- a/rules/review-roles-with-aws-iam-authenticator/raw.rego
+++ b/rules/review-roles-with-aws-iam-authenticator/raw.rego
@@ -1,7 +1,9 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	resource.kind == "Role"
 
 	msga := {
@@ -10,8 +12,6 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [],
-		"alertObject": {
-			"externalObjects": resource
-		}
+		"alertObject": {"externalObjects": resource},
 	}
 }

--- a/rules/review-roles-with-aws-iam-authenticator/raw.rego
+++ b/rules/review-roles-with-aws-iam-authenticator/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1

--- a/rules/role-in-default-namespace/raw.rego
+++ b/rules/role-in-default-namespace/raw.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -12,30 +14,26 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
-
+} else := []

--- a/rules/role-in-default-namespace/raw.rego
+++ b/rules/role-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1

--- a/rules/rolebinding-in-default-namespace/raw.rego
+++ b/rules/rolebinding-in-default-namespace/raw.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -12,30 +14,26 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
-
+} else := []

--- a/rules/rolebinding-in-default-namespace/raw.rego
+++ b/rules/rolebinding-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1

--- a/rules/rule-access-dashboard-subject-v1/raw.rego
+++ b/rules/rule-access-dashboard-subject-v1/raw.rego
@@ -1,9 +1,11 @@
 package armo_builtins
 
+import rego.v1
+
 # input: regoResponseVectorObject
 # fails if a subject that is not dashboard service account is bound to dashboard role
 
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -14,7 +16,7 @@ deny[msga] {
 	subjectVector.name != "kubernetes-dashboard"
 
 	subject := rolebinding.subjects[k]
-    path := [sprintf("relatedObjects[%v].subjects[%v]", [format_int(j, 10), format_int(k, 10)])]
+	path := [sprintf("relatedObjects[%v].subjects[%v]", [format_int(j, 10), format_int(k, 10)])]
 	finalpath := array.concat(path, [sprintf("relatedObjects[%v].roleRef.name", [format_int(j, 10)])])
 	msga := {
 		"alertMessage": sprintf("Subject: %v-%v is bound to dashboard role/clusterrole", [subjectVector.kind, subjectVector.name]),
@@ -25,7 +27,7 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"alertObject": {
 			"k8sApiObjects": [],
-			"externalObjects": subjectVector
-		}
+			"externalObjects": subjectVector,
+		},
 	}
 }

--- a/rules/rule-access-dashboard-subject-v1/raw.rego
+++ b/rules/rule-access-dashboard-subject-v1/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1

--- a/rules/rule-access-dashboard-wl-v1/raw.rego
+++ b/rules/rule-access-dashboard-wl-v1/raw.rego
@@ -1,13 +1,15 @@
 package armo_builtins
 
-# input: 
-# apiversion: 
+import rego.v1
+
+# input:
+# apiversion:
 # fails if pod that is not dashboard is associated to dashboard service account
 
-deny[msga] {
-    pod := input[_]
-    pod.spec.serviceAccountName == "kubernetes-dashboard"
-    not startswith(pod.metadata.name, "kubernetes-dashboard")
+deny contains msga if {
+	pod := input[_]
+	pod.spec.serviceAccountName == "kubernetes-dashboard"
+	not startswith(pod.metadata.name, "kubernetes-dashboard")
 
 	msga := {
 		"alertMessage": sprintf("the following pods: %s are associated with dashboard service account", [pod.metadata.name]),
@@ -16,22 +18,20 @@ deny[msga] {
 		"fixPaths": [],
 		"deletePaths": ["spec.serviceAccountName"],
 		"failedPaths": ["spec.serviceAccountName"],
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-# input: 
-# apiversion: 
+# input:
+# apiversion:
 # fails if workload that is not dashboard is associated to dashboard service account
 
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    wl.spec.template.spec.serviceAccountName == "kubernetes-dashboard"
-    not startswith(wl.metadata.name, "kubernetes-dashboard")
+	wl.spec.template.spec.serviceAccountName == "kubernetes-dashboard"
+	not startswith(wl.metadata.name, "kubernetes-dashboard")
 
 	msga := {
 		"alertMessage": sprintf("%v: %v is associated with dashboard service account", [wl.kind, wl.metadata.name]),
@@ -40,21 +40,19 @@ deny[msga] {
 		"failedPaths": ["spec.template.spec.serviceAccountName"],
 		"alertScore": 7,
 		"fixPaths": [],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-# input: 
-# apiversion: 
+# input:
+# apiversion:
 # fails if CronJob that is not dashboard is associated to dashboard service account
 
-deny[msga] {
-    wl := input[_]
+deny contains msga if {
+	wl := input[_]
 	wl.kind == "CronJob"
-    wl.spec.jobTemplate.spec.template.spec.serviceAccountName == "kubernetes-dashboard"
-    not startswith(wl.metadata.name, "kubernetes-dashboard")
+	wl.spec.jobTemplate.spec.template.spec.serviceAccountName == "kubernetes-dashboard"
+	not startswith(wl.metadata.name, "kubernetes-dashboard")
 
 	msga := {
 		"alertMessage": sprintf("the following cronjob: %s is associated with dashboard service account", [wl.metadata.name]),
@@ -63,8 +61,6 @@ deny[msga] {
 		"fixPaths": [],
 		"deletePaths": ["spec.jobTemplate.spec.template.spec.serviceAccountName"],
 		"failedPaths": ["spec.jobTemplate.spec.template.spec.serviceAccountName"],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }

--- a/rules/rule-access-dashboard-wl-v1/raw.rego
+++ b/rules/rule-access-dashboard-wl-v1/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
@@ -27,8 +28,8 @@ deny contains msga if {
 # fails if workload that is not dashboard is associated to dashboard service account
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	wl.spec.template.spec.serviceAccountName == "kubernetes-dashboard"
 	not startswith(wl.metadata.name, "kubernetes-dashboard")

--- a/rules/rule-allow-privilege-escalation/raw.rego
+++ b/rules/rule-allow-privilege-escalation/raw.rego
@@ -1,13 +1,14 @@
 package armo_builtins
 
+import rego.v1
 
 # Fails if pod has container  that allow privilege escalation
-deny[msga] {
-    pod := input[_]
-    pod.kind == "Pod"
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 	container := pod.spec.containers[i]
 	start_of_path := "spec."
-    is_allow_privilege_escalation_container(container)
+	is_allow_privilege_escalation_container(container)
 	fixPath := get_fix_path(i, start_of_path)
 
 	msga := {
@@ -15,37 +16,31 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"fixPaths": fixPath,
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-
 # Fails if workload has a container that allow privilege escalation
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
+	container := wl.spec.template.spec.containers[i]
 	start_of_path := "spec.template.spec."
-    is_allow_privilege_escalation_container(container)
+	is_allow_privilege_escalation_container(container)
 	fixPath := get_fix_path(i, start_of_path)
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("container :%v in %v: %v  allow privilege escalation", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"fixPaths": fixPath,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
 # Fails if cronjob has a container that allow privilege escalation
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
@@ -53,49 +48,46 @@ deny[msga] {
 	is_allow_privilege_escalation_container(container)
 	fixPath := get_fix_path(i, start_of_path)
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("container :%v in %v: %v allow privilege escalation", [container.name, wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"fixPaths": fixPath,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
-
-is_allow_privilege_escalation_container(container) {
-    not container.securityContext.allowPrivilegeEscalation == false
+is_allow_privilege_escalation_container(container) if {
+	not container.securityContext.allowPrivilegeEscalation == false
 	not container.securityContext.allowPrivilegeEscalation == true
-	psps := [psp |  psp= input[_]; psp.kind == "PodSecurityPolicy"]
+	psps := [psp | psp = input[_]; psp.kind == "PodSecurityPolicy"]
 	count(psps) == 0
 }
 
-is_allow_privilege_escalation_container(container) {
-    not container.securityContext.allowPrivilegeEscalation == false
+is_allow_privilege_escalation_container(container) if {
+	not container.securityContext.allowPrivilegeEscalation == false
 	not container.securityContext.allowPrivilegeEscalation == true
-	psps := [psp |  psp= input[_]; psp.kind == "PodSecurityPolicy"]
+	psps := [psp | psp = input[_]; psp.kind == "PodSecurityPolicy"]
 	count(psps) > 0
 	psp := psps[_]
 	not psp.spec.allowPrivilegeEscalation == false
 }
 
-
-is_allow_privilege_escalation_container(container) {
-    container.securityContext.allowPrivilegeEscalation == true
-	psps := [psp |  psp= input[_]; psp.kind == "PodSecurityPolicy"]
+is_allow_privilege_escalation_container(container) if {
+	container.securityContext.allowPrivilegeEscalation == true
+	psps := [psp | psp = input[_]; psp.kind == "PodSecurityPolicy"]
 	count(psps) == 0
 }
 
-is_allow_privilege_escalation_container(container) {
-    container.securityContext.allowPrivilegeEscalation == true
-	psps := [psp |  psp= input[_]; psp.kind == "PodSecurityPolicy"]
+is_allow_privilege_escalation_container(container) if {
+	container.securityContext.allowPrivilegeEscalation == true
+	psps := [psp | psp = input[_]; psp.kind == "PodSecurityPolicy"]
 	count(psps) > 0
 	psp := psps[_]
 	not psp.spec.allowPrivilegeEscalation == false
 }
 
-get_fix_path(i, start_of_path) = [{"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, i]), "value":"false"},
-	{"path": sprintf("%vcontainers[%v].securityContext.privileged", [start_of_path, i]), "value":"false"}]
+get_fix_path(i, start_of_path) := [
+	{"path": sprintf("%vcontainers[%v].securityContext.allowPrivilegeEscalation", [start_of_path, i]), "value": "false"},
+	{"path": sprintf("%vcontainers[%v].securityContext.privileged", [start_of_path, i]), "value": "false"},
+]

--- a/rules/rule-allow-privilege-escalation/raw.rego
+++ b/rules/rule-allow-privilege-escalation/raw.rego
@@ -1,13 +1,14 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 # Fails if pod has container  that allow privilege escalation
 deny contains msga if {
+	start_of_path := "spec."
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
-	start_of_path := "spec."
 	is_allow_privilege_escalation_container(container)
 	fixPath := get_fix_path(i, start_of_path)
 
@@ -22,11 +23,11 @@ deny contains msga if {
 
 # Fails if workload has a container that allow privilege escalation
 deny contains msga if {
-	wl := input[_]
+	start_of_path := "spec.template.spec."
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
-	start_of_path := "spec.template.spec."
 	is_allow_privilege_escalation_container(container)
 	fixPath := get_fix_path(i, start_of_path)
 
@@ -41,10 +42,10 @@ deny contains msga if {
 
 # Fails if cronjob has a container that allow privilege escalation
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	is_allow_privilege_escalation_container(container)
 	fixPath := get_fix_path(i, start_of_path)
 

--- a/rules/rule-can-access-proxy-subresource/raw.rego
+++ b/rules/rule-can-access-proxy-subresource/raw.rego
@@ -1,9 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # fails if user has access to proxy subresources
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -15,10 +15,10 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-is_same_subjects(subjectVector, subject)
+	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["get", "create", "connect","*"]
+	verbs := ["get", "create", "connect", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
@@ -52,14 +52,14 @@ is_same_subjects(subjectVector, subject)
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-can-access-proxy-subresource/raw.rego
+++ b/rules/rule-can-access-proxy-subresource/raw.rego
@@ -1,9 +1,13 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 # fails if user has access to proxy subresources
 deny contains msga if {
+	verbs := ["get", "create", "connect", "*"]
+	api_groups := ["", "*"]
+	resources := ["nodes/proxy", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -18,15 +22,12 @@ deny contains msga if {
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["get", "create", "connect", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["nodes/proxy", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/rule-can-approve-cert-signing-request/raw.rego
+++ b/rules/rule-can-approve-cert-signing-request/raw.rego
@@ -1,9 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # fails if user can approve certificate signing requests
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -15,7 +15,7 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-is_same_subjects(subjectVector, subject)
+	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
 	verbs := ["update", "*"]
@@ -52,14 +52,14 @@ is_same_subjects(subjectVector, subject)
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-can-approve-cert-signing-request/raw.rego
+++ b/rules/rule-can-approve-cert-signing-request/raw.rego
@@ -1,9 +1,13 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 # fails if user can approve certificate signing requests
 deny contains msga if {
+	verbs := ["update", "*"]
+	api_groups := ["certificates.k8s.io", "*"]
+	resources := ["certificatesigningrequests/approval", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -18,15 +22,12 @@ deny contains msga if {
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["update", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["certificates.k8s.io", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["certificatesigningrequests/approval", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/rule-can-bind-escalate/raw.rego
+++ b/rules/rule-can-bind-escalate/raw.rego
@@ -1,11 +1,11 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # ================= bind ===============================
 
 # fails if user has access to bind clusterroles/roles
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -54,7 +54,7 @@ deny[msga] {
 # ================= escalate ===============================
 
 # fails if user has access to escalate roles/clusterroles
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -103,14 +103,14 @@ deny[msga] {
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-can-bind-escalate/raw.rego
+++ b/rules/rule-can-bind-escalate/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
@@ -6,6 +7,9 @@ import rego.v1
 
 # fails if user has access to bind clusterroles/roles
 deny contains msga if {
+	verbs := ["bind", "*"]
+	api_groups := ["rbac.authorization.k8s.io", "*"]
+	resources := ["clusterroles", "roles", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -18,15 +22,12 @@ deny contains msga if {
 
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["bind", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["rbac.authorization.k8s.io", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["clusterroles", "roles", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 
@@ -55,6 +56,9 @@ deny contains msga if {
 
 # fails if user has access to escalate roles/clusterroles
 deny contains msga if {
+	verbs := ["escalate", "*"]
+	api_groups := ["rbac.authorization.k8s.io", "*"]
+	resources := ["clusterroles", "roles", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -69,15 +73,12 @@ deny contains msga if {
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["escalate", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["rbac.authorization.k8s.io", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["clusterroles", "roles", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/rule-can-create-pod/raw.rego
+++ b/rules/rule-can-create-pod/raw.rego
@@ -1,9 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # fails if user has create access to pods
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -15,7 +15,7 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-is_same_subjects(subjectVector, subject)
+	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
 	verbs := ["create", "*"]
@@ -52,14 +52,14 @@ is_same_subjects(subjectVector, subject)
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-can-create-pod/raw.rego
+++ b/rules/rule-can-create-pod/raw.rego
@@ -1,9 +1,13 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 # fails if user has create access to pods
 deny contains msga if {
+	verbs := ["create", "*"]
+	api_groups := ["", "*"]
+	resources := ["pods", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -18,15 +22,12 @@ deny contains msga if {
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["create", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["pods", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/rule-can-create-pv/raw.rego
+++ b/rules/rule-can-create-pv/raw.rego
@@ -1,9 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # fails if user has create access to persistent volumes
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -15,7 +15,7 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-is_same_subjects(subjectVector, subject)
+	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
 	verbs := ["create", "*"]
@@ -52,14 +52,14 @@ is_same_subjects(subjectVector, subject)
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-can-create-pv/raw.rego
+++ b/rules/rule-can-create-pv/raw.rego
@@ -1,9 +1,13 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 # fails if user has create access to persistent volumes
 deny contains msga if {
+	verbs := ["create", "*"]
+	api_groups := ["", "*"]
+	resources := ["persistentvolumes", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -18,15 +22,12 @@ deny contains msga if {
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["create", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["persistentvolumes", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/rule-can-create-service-account-token/raw.rego
+++ b/rules/rule-can-create-service-account-token/raw.rego
@@ -1,9 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # fails if user has create access to service account tokens
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -15,7 +15,7 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-is_same_subjects(subjectVector, subject)
+	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
 	verbs := ["create", "*"]
@@ -52,14 +52,14 @@ is_same_subjects(subjectVector, subject)
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-can-create-service-account-token/raw.rego
+++ b/rules/rule-can-create-service-account-token/raw.rego
@@ -1,9 +1,13 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 # fails if user has create access to service account tokens
 deny contains msga if {
+	verbs := ["create", "*"]
+	api_groups := ["", "*"]
+	resources := ["serviceaccounts/token", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -18,15 +22,12 @@ deny contains msga if {
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["create", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["serviceaccounts/token", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/rule-can-delete-k8s-events-v1/raw.rego
+++ b/rules/rule-can-delete-k8s-events-v1/raw.rego
@@ -1,9 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # fails if user can delete events
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -15,7 +15,7 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
+	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
 	verbs := ["delete", "deletecollection", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
@@ -51,14 +51,14 @@ rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-can-delete-k8s-events-v1/raw.rego
+++ b/rules/rule-can-delete-k8s-events-v1/raw.rego
@@ -1,9 +1,13 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 # fails if user can delete events
 deny contains msga if {
+	verbs := ["delete", "deletecollection", "*"]
+	api_groups := ["", "*"]
+	resources := ["events", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -17,15 +21,12 @@ deny contains msga if {
 
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["delete", "deletecollection", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["events", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/rule-can-impersonate-users-groups-v1/raw.rego
+++ b/rules/rule-can-impersonate-users-groups-v1/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -14,7 +14,7 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-is_same_subjects(subjectVector, subject)
+	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
 	verbs := ["impersonate", "*"]
@@ -51,14 +51,14 @@ is_same_subjects(subjectVector, subject)
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-can-impersonate-users-groups-v1/raw.rego
+++ b/rules/rule-can-impersonate-users-groups-v1/raw.rego
@@ -1,8 +1,12 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	verbs := ["impersonate", "*"]
+	api_groups := ["", "*"]
+	resources := ["users", "serviceaccounts", "groups", "uids", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -17,15 +21,12 @@ deny contains msga if {
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["impersonate", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["users", "serviceaccounts", "groups", "uids", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/rule-can-list-get-secrets-v1/raw.rego
+++ b/rules/rule-can-list-get-secrets-v1/raw.rego
@@ -1,9 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
-# fails if user can list/get secrets 
-deny[msga] {
+# fails if user can list/get secrets
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -15,7 +15,7 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-is_same_subjects(subjectVector, subject)
+	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
 	verbs := ["get", "list", "watch", "*"]
@@ -52,14 +52,14 @@ is_same_subjects(subjectVector, subject)
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-can-list-get-secrets-v1/raw.rego
+++ b/rules/rule-can-list-get-secrets-v1/raw.rego
@@ -1,9 +1,13 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 # fails if user can list/get secrets
 deny contains msga if {
+	verbs := ["get", "list", "watch", "*"]
+	api_groups := ["", "*"]
+	resources := ["secrets", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -18,15 +22,12 @@ deny contains msga if {
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["get", "list", "watch", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["secrets", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/rule-can-modify-admission-webhooks/raw.rego
+++ b/rules/rule-can-modify-admission-webhooks/raw.rego
@@ -1,9 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # fails if user can modify admission webhooks
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -15,7 +15,7 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-is_same_subjects(subjectVector, subject)
+	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
 	verbs := ["create", "update", "delete", "*"]
@@ -52,14 +52,14 @@ is_same_subjects(subjectVector, subject)
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-can-modify-admission-webhooks/raw.rego
+++ b/rules/rule-can-modify-admission-webhooks/raw.rego
@@ -1,9 +1,13 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 # fails if user can modify admission webhooks
 deny contains msga if {
+	verbs := ["create", "update", "delete", "*"]
+	api_groups := ["admissionregistration.k8s.io", "*"]
+	resources := ["validatingwebhookconfigurations", "mutatingwebhookconfigurations", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -18,15 +22,12 @@ deny contains msga if {
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["create", "update", "delete", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["admissionregistration.k8s.io", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["validatingwebhookconfigurations", "mutatingwebhookconfigurations", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/rule-can-portforward-v1/raw.rego
+++ b/rules/rule-can-portforward-v1/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -13,7 +13,7 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
+	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
 	verbs := ["create", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
@@ -48,16 +48,15 @@ rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 	}
 }
 
-
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-can-portforward-v1/raw.rego
+++ b/rules/rule-can-portforward-v1/raw.rego
@@ -1,8 +1,12 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	verbs := ["create", "*"]
+	api_groups := ["", "*"]
+	resources := ["pods/portforward", "pods/*", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -15,15 +19,12 @@ deny contains msga if {
 
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["create", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["pods/portforward", "pods/*", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/rule-can-ssh-to-pod-v1/filter.rego
+++ b/rules/rule-can-ssh-to-pod-v1/filter.rego
@@ -1,92 +1,97 @@
 package armo_builtins
 
+import rego.v1
+
 # input: pod
 # apiversion: v1
 # does:	returns the external facing services of that pod
 
-deny[msga] {
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	podns := pod.metadata.namespace
 	podname := pod.metadata.name
 	labels := pod.metadata.labels
 	filtered_labels := json.remove(labels, ["pod-template-hash"])
-    path := "metadata.labels"
-	service := 	input[_]
+	path := "metadata.labels"
+	service := input[_]
 	service.kind == "Service"
 	service.metadata.namespace == podns
 	service.spec.selector == filtered_labels
 
-
-	wlvector = {"name": pod.metadata.name,
-				"namespace": pod.metadata.namespace,
-				"kind": pod.kind,
-				"relatedObjects": service}
+	wlvector = {
+		"name": pod.metadata.name,
+		"namespace": pod.metadata.namespace,
+		"kind": pod.kind,
+		"relatedObjects": service,
+	}
 	msga := {
 		"alertMessage": sprintf("pod %v/%v exposed by SSH services: %v", [podns, podname, service]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [path],
-        "alertObject": {
+		"alertObject": {
 			"k8sApiObjects": [],
-			"externalObjects": wlvector
-		}
-    }
+			"externalObjects": wlvector,
+		},
+	}
 }
 
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	labels := wl.spec.template.metadata.labels
-    path := "spec.template.metadata.labels"
-	service := 	input[_]
+	path := "spec.template.metadata.labels"
+	service := input[_]
 	service.kind == "Service"
 	service.metadata.namespace == wl.metadata.namespace
 	service.spec.selector == labels
 
-
-	wlvector = {"name": wl.metadata.name,
-				"namespace": wl.metadata.namespace,
-				"kind": wl.kind,
-				"relatedObjects": service}
+	wlvector = {
+		"name": wl.metadata.name,
+		"namespace": wl.metadata.namespace,
+		"kind": wl.kind,
+		"relatedObjects": service,
+	}
 
 	msga := {
 		"alertMessage": sprintf("%v: %v is exposed by SSH services: %v", [wl.kind, wl.metadata.name, service]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [path],
-        "alertObject": {
+		"alertObject": {
 			"k8sApiObjects": [],
-			"externalObjects": wlvector
-		}
-     }
+			"externalObjects": wlvector,
+		},
+	}
 }
 
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	labels := wl.spec.jobTemplate.spec.template.metadata.labels
-    path := "spec.jobTemplate.spec.template.metadata.labels"
-	service := 	input[_]
+	path := "spec.jobTemplate.spec.template.metadata.labels"
+	service := input[_]
 	service.kind == "Service"
 	service.metadata.namespace == wl.metadata.namespace
 	service.spec.selector == labels
 
-
-	wlvector = {"name": wl.metadata.name,
-				"namespace": wl.metadata.namespace,
-				"kind": wl.kind,
-				"relatedObjects": service}
+	wlvector = {
+		"name": wl.metadata.name,
+		"namespace": wl.metadata.namespace,
+		"kind": wl.kind,
+		"relatedObjects": service,
+	}
 
 	msga := {
 		"alertMessage": sprintf("%v: %v is exposed by SSH services: %v", [wl.kind, wl.metadata.name, service]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [path],
-        "alertObject": {
+		"alertObject": {
 			"k8sApiObjects": [],
-			"externalObjects": wlvector
-		}
-     }
+			"externalObjects": wlvector,
+		},
+	}
 }

--- a/rules/rule-can-ssh-to-pod-v1/filter.rego
+++ b/rules/rule-can-ssh-to-pod-v1/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
@@ -7,13 +8,13 @@ import rego.v1
 # does:	returns the external facing services of that pod
 
 deny contains msga if {
+	path := "metadata.labels"
 	pod := input[_]
 	pod.kind == "Pod"
 	podns := pod.metadata.namespace
 	podname := pod.metadata.name
 	labels := pod.metadata.labels
 	filtered_labels := json.remove(labels, ["pod-template-hash"])
-	path := "metadata.labels"
 	service := input[_]
 	service.kind == "Service"
 	service.metadata.namespace == podns
@@ -38,11 +39,12 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	path := "spec.template.metadata.labels"
+
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	labels := wl.spec.template.metadata.labels
-	path := "spec.template.metadata.labels"
 	service := input[_]
 	service.kind == "Service"
 	service.metadata.namespace == wl.metadata.namespace
@@ -68,10 +70,10 @@ deny contains msga if {
 }
 
 deny contains msga if {
+	path := "spec.jobTemplate.spec.template.metadata.labels"
 	wl := input[_]
 	wl.kind == "CronJob"
 	labels := wl.spec.jobTemplate.spec.template.metadata.labels
-	path := "spec.jobTemplate.spec.template.metadata.labels"
 	service := input[_]
 	service.kind == "Service"
 	service.metadata.namespace == wl.metadata.namespace

--- a/rules/rule-can-ssh-to-pod-v1/raw.rego
+++ b/rules/rule-can-ssh-to-pod-v1/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
@@ -7,13 +8,13 @@ import rego.v1
 # does:	returns the external facing services of that pod
 
 deny contains msga if {
+	path := "metadata.labels"
 	pod := input[_]
 	pod.kind == "Pod"
 	podns := pod.metadata.namespace
 	podname := pod.metadata.name
 	labels := pod.metadata.labels
 	filtered_labels := json.remove(labels, ["pod-template-hash"])
-	path := "metadata.labels"
 	service := input[_]
 	service.kind == "Service"
 	service.metadata.namespace == podns
@@ -42,11 +43,11 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	path := "spec.template.metadata.labels"
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	labels := wl.spec.template.metadata.labels
-	path := "spec.template.metadata.labels"
 	service := input[_]
 	service.kind == "Service"
 	service.metadata.namespace == wl.metadata.namespace
@@ -75,10 +76,10 @@ deny contains msga if {
 }
 
 deny contains msga if {
+	path := "spec.jobTemplate.spec.template.metadata.labels"
 	wl := input[_]
 	wl.kind == "CronJob"
 	labels := wl.spec.jobTemplate.spec.template.metadata.labels
-	path := "spec.jobTemplate.spec.template.metadata.labels"
 	service := input[_]
 	service.kind == "Service"
 	service.metadata.namespace == wl.metadata.namespace

--- a/rules/rule-can-update-configmap-v1/raw.rego
+++ b/rules/rule-can-update-configmap-v1/raw.rego
@@ -1,9 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # Fails if user can modify all configmaps
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -14,7 +14,7 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
+	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
 	verbs := ["update", "patch", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
@@ -51,7 +51,7 @@ rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 }
 
 # Fails if user  can modify the 'coredns' configmap (default for coredns)
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -62,7 +62,7 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
+	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
 	verbs := ["update", "patch", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
@@ -96,16 +96,15 @@ rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 	}
 }
 
-
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-can-update-configmap-v1/raw.rego
+++ b/rules/rule-can-update-configmap-v1/raw.rego
@@ -1,9 +1,13 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 # Fails if user can modify all configmaps
 deny contains msga if {
+	verbs := ["update", "patch", "*"]
+	api_groups := ["", "*"]
+	resources := ["configmaps", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -16,15 +20,12 @@ deny contains msga if {
 
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["update", "patch", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["configmaps", "*"]
 	not rule.resourceNames
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
@@ -52,6 +53,9 @@ deny contains msga if {
 
 # Fails if user  can modify the 'coredns' configmap (default for coredns)
 deny contains msga if {
+	verbs := ["update", "patch", "*"]
+	api_groups := ["", "*"]
+	resources := ["configmaps", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -64,15 +68,12 @@ deny contains msga if {
 
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["update", "patch", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["", "*"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["configmaps", "*"]
 	"coredns" in rule.resourceNames
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0

--- a/rules/rule-cni-enabled-aks/raw.rego
+++ b/rules/rule-cni-enabled-aks/raw.rego
@@ -1,8 +1,10 @@
 package armo_builtins
 
+import rego.v1
+
 # fails if cni is not enabled like defined in:
 # https://learn.microsoft.com/en-us/azure/aks/use-network-policies#create-an-aks-cluster-and-enable-network-policy
-deny[msga] {
+deny contains msga if {
 	cluster_describe := input[_]
 	cluster_describe.apiVersion == "management.azure.com/v1"
 	cluster_describe.kind == "ClusterDescribe"
@@ -25,17 +27,17 @@ deny[msga] {
 	}
 }
 
-cni_enabled_aks(properties) {
+cni_enabled_aks(properties) if {
 	properties.networkProfile.networkPlugin == "azure"
 	properties.networkProfile.networkPolicy == "azure"
 }
 
-cni_enabled_aks(properties) {
+cni_enabled_aks(properties) if {
 	properties.networkProfile.networkPlugin == "azure"
 	properties.networkProfile.networkPolicy == "calico"
 }
 
-cni_enabled_aks(properties) {
+cni_enabled_aks(properties) if {
 	properties.networkProfile.networkPlugin == "kubenet"
 	properties.networkProfile.networkPolicy == "calico"
 }

--- a/rules/rule-cni-enabled-aks/raw.rego
+++ b/rules/rule-cni-enabled-aks/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1

--- a/rules/rule-credentials-configmap/raw.rego
+++ b/rules/rule-credentials-configmap/raw.rego
@@ -1,14 +1,15 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 # fails if config map has keys with suspicious name
 deny contains msga if {
+	sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
 	configmap := input[_]
 	configmap.kind == "ConfigMap"
 
 	# see default-config-inputs.json for list values
-	sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
 	key_name := sensitive_key_names[_]
 	map_secret := configmap.data[map_key]
 	map_secret != ""

--- a/rules/rule-credentials-in-env-var/raw.rego
+++ b/rules/rule-credentials-in-env-var/raw.rego
@@ -1,228 +1,238 @@
-	package armo_builtins
+package armo_builtins
 
-	deny[msga] {
-		pod := input[_]
-		pod.kind == "Pod"
-		# see default-config-inputs.json for list values
-		sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
-		key_name := sensitive_key_names[_]
-		container := pod.spec.containers[i]
-		env := container.env[j]
+import rego.v1
 
-		contains(lower(env.name), lower(key_name))
-		env.value != ""
-		# check that value or key weren't allowed by user
-    	not is_allowed_value(env.value)
-    	not is_allowed_key_name(env.name)
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 
-		is_not_reference(env)
-		is_not_file_path(env.value)
+	# see default-config-inputs.json for list values
+	sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
+	key_name := sensitive_key_names[_]
+	container := pod.spec.containers[i]
+	env := container.env[j]
 
-		paths := [sprintf("spec.containers[%v].env[%v].name", [i, j]),
-				  sprintf("spec.containers[%v].env[%v].value", [i, j])]
+	contains(lower(env.name), lower(key_name))
+	env.value != ""
 
-		msga := {
-			"alertMessage": sprintf("Pod: %v has sensitive information in environment variables", [pod.metadata.name]),
-			"alertScore": 9,
-			"fixPaths": [],
-			"deletePaths": paths,
-			"failedPaths": paths,
-			"packagename": "armo_builtins",
-			"alertObject": {
-				"k8sApiObjects": [pod]
-			}
-		}
+	# check that value or key weren't allowed by user
+	not is_allowed_value(env.value)
+	not is_allowed_key_name(env.name)
+
+	is_not_reference(env)
+	is_not_file_path(env.value)
+
+	paths := [
+		sprintf("spec.containers[%v].env[%v].name", [i, j]),
+		sprintf("spec.containers[%v].env[%v].value", [i, j]),
+	]
+
+	msga := {
+		"alertMessage": sprintf("Pod: %v has sensitive information in environment variables", [pod.metadata.name]),
+		"alertScore": 9,
+		"fixPaths": [],
+		"deletePaths": paths,
+		"failedPaths": paths,
+		"packagename": "armo_builtins",
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
+}
 
-	deny[msga] {
-		wl := input[_]
-		spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-		spec_template_spec_patterns[wl.kind]
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	spec_template_spec_patterns[wl.kind]
 
-		# see default-config-inputs.json for list values
-		sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
-		key_name := sensitive_key_names[_]
-		container := wl.spec.template.spec.containers[i]
-		env := container.env[j]
+	# see default-config-inputs.json for list values
+	sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
+	key_name := sensitive_key_names[_]
+	container := wl.spec.template.spec.containers[i]
+	env := container.env[j]
 
-		contains(lower(env.name), lower(key_name))
-		env.value != ""
-		# check that value or key weren't allowed by user
-    	not is_allowed_value(env.value)
-    	not is_allowed_key_name(env.name)
+	contains(lower(env.name), lower(key_name))
+	env.value != ""
 
-		is_not_reference(env)
-		is_not_file_path(env.value)
+	# check that value or key weren't allowed by user
+	not is_allowed_value(env.value)
+	not is_allowed_key_name(env.name)
 
-		paths := [sprintf("spec.template.spec.containers[%v].env[%v].name", [i, j]),
-				sprintf("spec.template.spec.containers[%v].env[%v].value", [i, j])]
+	is_not_reference(env)
+	is_not_file_path(env.value)
 
-		msga := {
-			"alertMessage": sprintf("%v: %v has sensitive information in environment variables", [wl.kind, wl.metadata.name]),
-			"alertScore": 9,
-			"fixPaths": [],
-			"deletePaths": paths,
-			"failedPaths": paths,
-			"packagename": "armo_builtins",
-			"alertObject": {
-				"k8sApiObjects": [wl]
-			}
-		}
+	paths := [
+		sprintf("spec.template.spec.containers[%v].env[%v].name", [i, j]),
+		sprintf("spec.template.spec.containers[%v].env[%v].value", [i, j]),
+	]
+
+	msga := {
+		"alertMessage": sprintf("%v: %v has sensitive information in environment variables", [wl.kind, wl.metadata.name]),
+		"alertScore": 9,
+		"fixPaths": [],
+		"deletePaths": paths,
+		"failedPaths": paths,
+		"packagename": "armo_builtins",
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
+}
 
-	deny[msga] {
-		wl := input[_]
-		wl.kind == "CronJob"
-		# see default-config-inputs.json for list values
-		sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
-		key_name := sensitive_key_names[_]
-		container := wl.spec.jobTemplate.spec.template.spec.containers[i]
-		env := container.env[j]
+deny contains msga if {
+	wl := input[_]
+	wl.kind == "CronJob"
 
-		contains(lower(env.name), lower(key_name))
-		env.value != ""
-		# check that value or key weren't allowed by user
-    	not is_allowed_value(env.value)
-    	not is_allowed_key_name(env.name)
+	# see default-config-inputs.json for list values
+	sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
+	key_name := sensitive_key_names[_]
+	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
+	env := container.env[j]
 
-		is_not_reference(env)
-		is_not_file_path(env.value)
+	contains(lower(env.name), lower(key_name))
+	env.value != ""
 
-		paths := [sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].name", [i, j]),
-				  sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].value", [i, j])]
+	# check that value or key weren't allowed by user
+	not is_allowed_value(env.value)
+	not is_allowed_key_name(env.name)
 
-		msga := {
-			"alertMessage": sprintf("Cronjob: %v has sensitive information in environment variables", [wl.metadata.name]),
-			"alertScore": 9,
-			"fixPaths": [],
-			"deletePaths": paths,
-			"failedPaths": paths,
-			"packagename": "armo_builtins",
-			"alertObject": {
-				"k8sApiObjects": [wl]
-			}
-		}
+	is_not_reference(env)
+	is_not_file_path(env.value)
+
+	paths := [
+		sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].name", [i, j]),
+		sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].value", [i, j]),
+	]
+
+	msga := {
+		"alertMessage": sprintf("Cronjob: %v has sensitive information in environment variables", [wl.metadata.name]),
+		"alertScore": 9,
+		"fixPaths": [],
+		"deletePaths": paths,
+		"failedPaths": paths,
+		"packagename": "armo_builtins",
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
+}
 
 # check sensitive values
-deny[msga] {
-		pod := input[_]
-		pod.kind == "Pod"
-		# see default-config-inputs.json for list values
-		sensitive_values := data.postureControlInputs.sensitiveValues
-    	value := sensitive_values[_]
-		container := pod.spec.containers[i]
-		env := container.env[j]
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 
-		contains(lower(env.value), lower(value))
-		# check that value or key weren't allowed by user
-    	not is_allowed_value(env.value)
-    	not is_allowed_key_name(env.name)
+	# see default-config-inputs.json for list values
+	sensitive_values := data.postureControlInputs.sensitiveValues
+	value := sensitive_values[_]
+	container := pod.spec.containers[i]
+	env := container.env[j]
 
-		is_not_reference(env)
-		is_not_file_path(env.value)
+	contains(lower(env.value), lower(value))
 
-		paths := [sprintf("spec.containers[%v].env[%v].name", [i, j]),
-				  sprintf("spec.containers[%v].env[%v].value", [i, j])]
+	# check that value or key weren't allowed by user
+	not is_allowed_value(env.value)
+	not is_allowed_key_name(env.name)
 
-		msga := {
-			"alertMessage": sprintf("Pod: %v has sensitive information in environment variables", [pod.metadata.name]),
-			"alertScore": 9,
-			"fixPaths": [],
-			"deletePaths": paths,
-			"failedPaths": paths,
-			"packagename": "armo_builtins",
-			"alertObject": {
-				"k8sApiObjects": [pod]
-			}
-		}
+	is_not_reference(env)
+	is_not_file_path(env.value)
+
+	paths := [
+		sprintf("spec.containers[%v].env[%v].name", [i, j]),
+		sprintf("spec.containers[%v].env[%v].value", [i, j]),
+	]
+
+	msga := {
+		"alertMessage": sprintf("Pod: %v has sensitive information in environment variables", [pod.metadata.name]),
+		"alertScore": 9,
+		"fixPaths": [],
+		"deletePaths": paths,
+		"failedPaths": paths,
+		"packagename": "armo_builtins",
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
+}
 
-	deny[msga] {
-		wl := input[_]
-		spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-		spec_template_spec_patterns[wl.kind]
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	spec_template_spec_patterns[wl.kind]
 
-		# see default-config-inputs.json for list values
-		sensitive_values := data.postureControlInputs.sensitiveValues
-    	value := sensitive_values[_]
-		container := wl.spec.template.spec.containers[i]
-		env := container.env[j]
+	# see default-config-inputs.json for list values
+	sensitive_values := data.postureControlInputs.sensitiveValues
+	value := sensitive_values[_]
+	container := wl.spec.template.spec.containers[i]
+	env := container.env[j]
 
-		contains(lower(env.value), lower(value))
-		# check that value or key weren't allowed by user
-    	not is_allowed_value(env.value)
-    	not is_allowed_key_name(env.name)
+	contains(lower(env.value), lower(value))
 
-		is_not_reference(env)
-		is_not_file_path(env.value)
+	# check that value or key weren't allowed by user
+	not is_allowed_value(env.value)
+	not is_allowed_key_name(env.name)
 
-		paths := [sprintf("spec.template.spec.containers[%v].env[%v].name", [i, j]),
-				sprintf("spec.template.spec.containers[%v].env[%v].value", [i, j])]
+	is_not_reference(env)
+	is_not_file_path(env.value)
 
-		msga := {
-			"alertMessage": sprintf("%v: %v has sensitive information in environment variables", [wl.kind, wl.metadata.name]),
-			"alertScore": 9,
-			"fixPaths": [],
-			"deletePaths": paths,
-			"failedPaths": paths,
-			"packagename": "armo_builtins",
-			"alertObject": {
-				"k8sApiObjects": [wl]
-			}
-		}
+	paths := [
+		sprintf("spec.template.spec.containers[%v].env[%v].name", [i, j]),
+		sprintf("spec.template.spec.containers[%v].env[%v].value", [i, j]),
+	]
+
+	msga := {
+		"alertMessage": sprintf("%v: %v has sensitive information in environment variables", [wl.kind, wl.metadata.name]),
+		"alertScore": 9,
+		"fixPaths": [],
+		"deletePaths": paths,
+		"failedPaths": paths,
+		"packagename": "armo_builtins",
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
+}
 
-	deny[msga] {
-		wl := input[_]
-		wl.kind == "CronJob"
-		# see default-config-inputs.json for list values
-		sensitive_values := data.postureControlInputs.sensitiveValues
-    	value := sensitive_values[_]
-		container := wl.spec.jobTemplate.spec.template.spec.containers[i]
-		env := container.env[j]
+deny contains msga if {
+	wl := input[_]
+	wl.kind == "CronJob"
 
-		contains(lower(env.value), lower(value))
-		# check that value or key weren't allowed by user
-    	not is_allowed_value(env.value)
-    	not is_allowed_key_name(env.name)
+	# see default-config-inputs.json for list values
+	sensitive_values := data.postureControlInputs.sensitiveValues
+	value := sensitive_values[_]
+	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
+	env := container.env[j]
 
-		is_not_reference(env)
-		is_not_file_path(env.value)
+	contains(lower(env.value), lower(value))
 
-		paths := [sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].name", [i, j]),
-				  sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].value", [i, j])]
+	# check that value or key weren't allowed by user
+	not is_allowed_value(env.value)
+	not is_allowed_key_name(env.name)
 
-		msga := {
-			"alertMessage": sprintf("Cronjob: %v has sensitive information in environment variables", [wl.metadata.name]),
-			"alertScore": 9,
-			"fixPaths": [],
-			"deletePaths": paths,
-			"failedPaths": paths,
-			"packagename": "armo_builtins",
-			"alertObject": {
-				"k8sApiObjects": [wl]
-			}
-		}
+	is_not_reference(env)
+	is_not_file_path(env.value)
+
+	paths := [
+		sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].name", [i, j]),
+		sprintf("spec.jobTemplate.spec.template.spec.containers[%v].env[%v].value", [i, j]),
+	]
+
+	msga := {
+		"alertMessage": sprintf("Cronjob: %v has sensitive information in environment variables", [wl.metadata.name]),
+		"alertScore": 9,
+		"fixPaths": [],
+		"deletePaths": paths,
+		"failedPaths": paths,
+		"packagename": "armo_builtins",
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
+}
 
-
-is_not_reference(env)
-{
+is_not_reference(env) if {
 	not env.valueFrom.secretKeyRef
 	not env.valueFrom.configMapKeyRef
 }
 
-is_allowed_value(value) {
-    allow_val := data.postureControlInputs.sensitiveValuesAllowed[_]
-    regex.match(allow_val , value)
+is_allowed_value(value) if {
+	allow_val := data.postureControlInputs.sensitiveValuesAllowed[_]
+	regex.match(allow_val, value)
 }
 
-is_allowed_key_name(key_name) {
-    allow_key := data.postureControlInputs.sensitiveKeyNamesAllowed[_]
-    contains(lower(key_name), lower(allow_key))
+is_allowed_key_name(key_name) if {
+	allow_key := data.postureControlInputs.sensitiveKeyNamesAllowed[_]
+	contains(lower(key_name), lower(allow_key))
 }
 
-is_not_file_path(value) {
-    not startswith(value, "/")
+is_not_file_path(value) if {
+	not startswith(value, "/")
 }

--- a/rules/rule-credentials-in-env-var/raw.rego
+++ b/rules/rule-credentials-in-env-var/raw.rego
@@ -1,13 +1,14 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	sensitive_key_names := data.postureControlInputs.sensitiveKeyName
 	pod := input[_]
 	pod.kind == "Pod"
 
 	# see default-config-inputs.json for list values
-	sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
 	key_name := sensitive_key_names[_]
 	container := pod.spec.containers[i]
 	env := container.env[j]
@@ -39,12 +40,12 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 
 	# see default-config-inputs.json for list values
-	sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
 	key_name := sensitive_key_names[_]
 	container := wl.spec.template.spec.containers[i]
 	env := container.env[j]
@@ -76,11 +77,11 @@ deny contains msga if {
 }
 
 deny contains msga if {
+	sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
 	wl := input[_]
 	wl.kind == "CronJob"
 
 	# see default-config-inputs.json for list values
-	sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
 	key_name := sensitive_key_names[_]
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
 	env := container.env[j]
@@ -113,11 +114,11 @@ deny contains msga if {
 
 # check sensitive values
 deny contains msga if {
+	sensitive_values := data.postureControlInputs.sensitiveValues
 	pod := input[_]
 	pod.kind == "Pod"
 
 	# see default-config-inputs.json for list values
-	sensitive_values := data.postureControlInputs.sensitiveValues
 	value := sensitive_values[_]
 	container := pod.spec.containers[i]
 	env := container.env[j]
@@ -148,12 +149,12 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	sensitive_values := data.postureControlInputs.sensitiveValues
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 
 	# see default-config-inputs.json for list values
-	sensitive_values := data.postureControlInputs.sensitiveValues
 	value := sensitive_values[_]
 	container := wl.spec.template.spec.containers[i]
 	env := container.env[j]
@@ -184,11 +185,11 @@ deny contains msga if {
 }
 
 deny contains msga if {
+	sensitive_values := data.postureControlInputs.sensitiveValues
 	wl := input[_]
 	wl.kind == "CronJob"
 
 	# see default-config-inputs.json for list values
-	sensitive_values := data.postureControlInputs.sensitiveValues
 	value := sensitive_values[_]
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
 	env := container.env[j]

--- a/rules/rule-deny-cronjobs/raw.rego
+++ b/rules/rule-deny-cronjobs/raw.rego
@@ -1,20 +1,19 @@
 package armo_builtins
 
+import rego.v1
+
 # alert cronjobs
 
 # handles cronjob
-deny[msga] {
-
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
-    msga := {
+	msga := {
 		"alertMessage": sprintf("the following cronjobs are defined: %v", [wl.metadata.name]),
 		"alertScore": 2,
 		"failedPaths": [],
 		"fixPaths": [],
 		"packagename": "armo_builtins",
-         "alertObject": {
-			"k8sApiObjects": [wl]
-		}
-     }
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
 }

--- a/rules/rule-deny-cronjobs/raw.rego
+++ b/rules/rule-deny-cronjobs/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1

--- a/rules/rule-excessive-delete-rights-v1/raw.rego
+++ b/rules/rule-excessive-delete-rights-v1/raw.rego
@@ -1,9 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # fails if user can can delete important resources
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -14,7 +14,7 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
+	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
 	verbs := ["delete", "deletecollection", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
@@ -50,14 +50,14 @@ rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-excessive-delete-rights-v1/raw.rego
+++ b/rules/rule-excessive-delete-rights-v1/raw.rego
@@ -1,9 +1,13 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
 # fails if user can can delete important resources
 deny contains msga if {
+	verbs := ["delete", "deletecollection", "*"]
+	api_groups := ["", "*", "apps", "batch"]
+	resources := ["secrets", "pods", "services", "deployments", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs", "*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -16,15 +20,12 @@ deny contains msga if {
 
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["delete", "deletecollection", "*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["", "*", "apps", "batch"]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["secrets", "pods", "services", "deployments", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs", "*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/rule-hostile-multitenant-workloads/raw.rego
+++ b/rules/rule-hostile-multitenant-workloads/raw.rego
@@ -1,13 +1,14 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
 
+deny contains msga if {
 	msga := {
 		"alertMessage": "Please check it manually.",
 		"packagename": "armo_builtins",
 		"alertScore": 2,
 		"fixPaths": [],
 		"failedPaths": [],
-         "alertObject": {}
-    }
+		"alertObject": {},
+	}
 }

--- a/rules/rule-hostile-multitenant-workloads/raw.rego
+++ b/rules/rule-hostile-multitenant-workloads/raw.rego
@@ -1,14 +1,13 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
 
-deny contains msga if {
-	msga := {
-		"alertMessage": "Please check it manually.",
-		"packagename": "armo_builtins",
-		"alertScore": 2,
-		"fixPaths": [],
-		"failedPaths": [],
-		"alertObject": {},
-	}
+deny contains {
+	"alertMessage": "Please check it manually.",
+	"packagename": "armo_builtins",
+	"alertScore": 2,
+	"fixPaths": [],
+	"failedPaths": [],
+	"alertObject": {},
 }

--- a/rules/rule-identify-blocklisted-image-registries-v1/raw.rego
+++ b/rules/rule-identify-blocklisted-image-registries-v1/raw.rego
@@ -1,6 +1,8 @@
 package armo_builtins
 
-untrustedImageRepo[msga] {
+import rego.v1
+
+untrustedImageRepo contains msga if {
 	wl := input[_]
 	containers_path := get_containers_path(wl)
 	containers := object.get(wl, containers_path, [])
@@ -20,15 +22,14 @@ untrustedImageRepo[msga] {
 	}
 }
 
-untrusted_or_public_registries(image){
+untrusted_or_public_registries(image) if {
 	# see default-config-inputs.json for list values
 	untrusted_registries := data.postureControlInputs.untrustedRegistries
 	registry := untrusted_registries[_]
 	startswith(image, registry)
-
 }
 
-untrusted_or_public_registries(image){
+untrusted_or_public_registries(image) if {
 	# see default-config-inputs.json for list values
 	public_registries := data.postureControlInputs.publicRegistries
 	registry := public_registries[_]
@@ -36,20 +37,20 @@ untrusted_or_public_registries(image){
 }
 
 # get_containers_path - get resource containers paths for  {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-get_containers_path(resource) := result {
+get_containers_path(resource) := result if {
 	resource_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	resource_kinds[resource.kind]
 	result = ["spec", "template", "spec", "containers"]
 }
 
 # get_containers_path - get resource containers paths for "Pod"
-get_containers_path(resource) := result {
+get_containers_path(resource) := result if {
 	resource.kind == "Pod"
 	result = ["spec", "containers"]
 }
 
 # get_containers_path - get resource containers paths for  "CronJob"
-get_containers_path(resource) := result {
+get_containers_path(resource) := result if {
 	resource.kind == "CronJob"
 	result = ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
 }

--- a/rules/rule-identify-blocklisted-image-registries-v1/raw.rego
+++ b/rules/rule-identify-blocklisted-image-registries-v1/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1

--- a/rules/rule-identify-blocklisted-image-registries/raw.rego
+++ b/rules/rule-identify-blocklisted-image-registries/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch 
 package armo_builtins
 
 import rego.v1
@@ -25,8 +26,8 @@ untrustedImageRepo contains msga if {
 }
 
 untrustedImageRepo contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	path := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])


### PR DESCRIPTION
## Overview
This PR migrates the eighth batch of Rego rules to OPA v1 syntax.
## Additional Information

This batch cover rules from `rules/rbac-enabled-cloud` through `rules/rule-identify-blocklisted-image-registries-v1`
 
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized Kubernetes security policy rules to Rego v1 syntax across multiple validation rules (RBAC, resource limits, credentials, access controls, and container security). All changes are syntax updates with no functional modifications to policy logic or enforcement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->