### PR TITLE
fix: migrate rego rules batch-9 to OPA v1

### DIFF
--- a/rules/rule-identify-old-k8s-registry/filter.rego
+++ b/rules/rule-identify-old-k8s-registry/filter.rego
@@ -1,11 +1,10 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
-deny[msg] {
+deny contains msg if {
 	# find aggregated API APIServices
 	obj = input[_]
 	obj.metadata.namespace == "kube-system"
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }
-

--- a/rules/rule-identify-old-k8s-registry/filter.rego
+++ b/rules/rule-identify-old-k8s-registry/filter.rego
@@ -1,10 +1,11 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
 	# find aggregated API APIServices
-	obj = input[_]
+	some obj in input
 	obj.metadata.namespace == "kube-system"
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/rule-identify-old-k8s-registry/raw.rego
+++ b/rules/rule-identify-old-k8s-registry/raw.rego
@@ -1,6 +1,8 @@
 package armo_builtins
 
-deprecatedK8sRepo[msga] {
+import rego.v1
+
+deprecatedK8sRepo contains msga if {
 	pod := input[_]
 	pod.metadata.namespace == "kube-system"
 	k := pod.kind
@@ -8,7 +10,7 @@ deprecatedK8sRepo[msga] {
 	container := pod.spec.containers[i]
 	path := sprintf("spec.containers[%v].image", [format_int(i, 10)])
 	image := container.image
-    deprecated_registry(image)
+	deprecated_registry(image)
 
 	msga := {
 		"alertMessage": sprintf("image '%v' in container '%s' comes from the deprecated k8s.gcr.io", [image, container.name]),
@@ -17,21 +19,19 @@ deprecatedK8sRepo[msga] {
 		"fixPaths": [],
 		"reviewPaths": [path],
 		"failedPaths": [path],
-         "alertObject": {
-			"k8sApiObjects": [pod]
-		}
-    }
+		"alertObject": {"k8sApiObjects": [pod]},
+	}
 }
 
-deprecatedK8sRepo[msga] {
+deprecatedK8sRepo contains msga if {
 	wl := input[_]
 	wl.metadata.namespace == "kube-system"
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	path := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])
 	image := container.image
-    deprecated_registry(image)
+	deprecated_registry(image)
 
 	msga := {
 		"alertMessage": sprintf("image '%v' in container '%s' comes from the deprecated k8s.gcr.io", [image, container.name]),
@@ -40,20 +40,18 @@ deprecatedK8sRepo[msga] {
 		"fixPaths": [],
 		"reviewPaths": [path],
 		"failedPaths": [path],
-         "alertObject": {
-			"k8sApiObjects": [wl]
-		}
-    }
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
 }
 
-deprecatedK8sRepo[msga] {
+deprecatedK8sRepo contains msga if {
 	wl := input[_]
 	wl.metadata.namespace == "kube-system"
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
 	path := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].image", [format_int(i, 10)])
 	image := container.image
-    deprecated_registry(image)
+	deprecated_registry(image)
 
 	msga := {
 		"alertMessage": sprintf("image '%v' in container '%s' comes from the deprecated k8s.gcr.io", [image, container.name]),
@@ -62,12 +60,10 @@ deprecatedK8sRepo[msga] {
 		"fixPaths": [],
 		"reviewPaths": [path],
 		"failedPaths": [path],
-        "alertObject": {
-			"k8sApiObjects": [wl]
-		}
-    }
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
 }
 
-deprecated_registry(image){
+deprecated_registry(image) if {
 	startswith(image, "k8s.gcr.io/")
 }

--- a/rules/rule-identify-old-k8s-registry/raw.rego
+++ b/rules/rule-identify-old-k8s-registry/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -24,9 +25,9 @@ deprecatedK8sRepo contains msga if {
 }
 
 deprecatedK8sRepo contains msga if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	wl := input[_]
 	wl.metadata.namespace == "kube-system"
-	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	path := sprintf("spec.template.spec.containers[%v].image", [format_int(i, 10)])

--- a/rules/rule-list-all-cluster-admins-v1/raw.rego
+++ b/rules/rule-list-all-cluster-admins-v1/raw.rego
@@ -1,9 +1,9 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
 # returns subjects with cluster admin permissions
-deny[msga] {
+deny contains msga if {
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -14,7 +14,7 @@ deny[msga] {
 	subject := rolebinding.subjects[k]
 	is_same_subjects(subjectVector, subject)
 
-is_same_subjects(subjectVector, subject)
+	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
 	verbs := ["*"]
@@ -51,14 +51,14 @@ is_same_subjects(subjectVector, subject)
 }
 
 # for service accounts
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.namespace == subject.namespace
 }
 
 # for users/ groups
-is_same_subjects(subjectVector, subject) {
+is_same_subjects(subjectVector, subject) if {
 	subjectVector.kind == subject.kind
 	subjectVector.name == subject.name
 	subjectVector.apiGroup == subject.apiGroup

--- a/rules/rule-list-all-cluster-admins-v1/raw.rego
+++ b/rules/rule-list-all-cluster-admins-v1/raw.rego
@@ -1,9 +1,13 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
 
 # returns subjects with cluster admin permissions
 deny contains msga if {
+	verbs := ["*"]
+	api_groups := ["*", ""]
+	resources := ["*"]
 	subjectVector := input[_]
 	role := subjectVector.relatedObjects[i]
 	rolebinding := subjectVector.relatedObjects[j]
@@ -17,15 +21,12 @@ deny contains msga if {
 	is_same_subjects(subjectVector, subject)
 	rule_path := sprintf("relatedObjects[%d].rules[%d]", [i, p])
 
-	verbs := ["*"]
 	verb_path := [sprintf("%s.verbs[%d]", [rule_path, l]) | verb = rule.verbs[l]; verb in verbs]
 	count(verb_path) > 0
 
-	api_groups := ["*", ""]
 	api_groups_path := [sprintf("%s.apiGroups[%d]", [rule_path, a]) | apiGroup = rule.apiGroups[a]; apiGroup in api_groups]
 	count(api_groups_path) > 0
 
-	resources := ["*"]
 	resources_path := [sprintf("%s.resources[%d]", [rule_path, l]) | resource = rule.resources[l]; resource in resources]
 	count(resources_path) > 0
 

--- a/rules/rule-manual/raw.rego
+++ b/rules/rule-manual/raw.rego
@@ -1,17 +1,15 @@
-
 package armo_builtins
 
-deny[msga] {
+import rego.v1
 
+deny contains msga if {
 	msga := {
-    	"alertMessage": "Please check it manually.",
-    	"packagename": "armo_builtins",
-    	"alertScore": 2,
-    	"failedPaths": [],
-    	"fixPaths":[],
-        "fixCommand": "",
-    	"alertObject": {
-			"k8sObject": []
-        }
-    }
+		"alertMessage": "Please check it manually.",
+		"packagename": "armo_builtins",
+		"alertScore": 2,
+		"failedPaths": [],
+		"fixPaths": [],
+		"fixCommand": "",
+		"alertObject": {"k8sObject": []},
+	}
 }

--- a/rules/rule-manual/raw.rego
+++ b/rules/rule-manual/raw.rego
@@ -1,9 +1,9 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
 
-deny contains msga if {
-	msga := {
+deny contains {
 		"alertMessage": "Please check it manually.",
 		"packagename": "armo_builtins",
 		"alertScore": 2,
@@ -12,4 +12,3 @@ deny contains msga if {
 		"fixCommand": "",
 		"alertObject": {"k8sObject": []},
 	}
-}

--- a/rules/rule-privileged-container/raw.rego
+++ b/rules/rule-privileged-container/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -6,10 +7,10 @@ import rego.v1
 
 # privileged pods — containers
 deny contains msga if {
+	start_of_path := "spec."
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
-	start_of_path := "spec."
 	path := isPrivilegedContainer(container, i, "containers", start_of_path)
 
 	msga := {
@@ -25,10 +26,10 @@ deny contains msga if {
 
 # privileged pods — initContainers
 deny contains msga if {
+	start_of_path := "spec."
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.initContainers[i]
-	start_of_path := "spec."
 	path := isPrivilegedContainer(container, i, "initContainers", start_of_path)
 
 	msga := {
@@ -44,10 +45,10 @@ deny contains msga if {
 
 # privileged pods — ephemeralContainers
 deny contains msga if {
+	start_of_path := "spec."
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.ephemeralContainers[i]
-	start_of_path := "spec."
 	path := isPrivilegedContainer(container, i, "ephemeralContainers", start_of_path)
 
 	msga := {
@@ -63,11 +64,11 @@ deny contains msga if {
 
 # handles majority of workload resources — containers
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	start_of_path := "spec.template.spec."
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
-	start_of_path := "spec.template.spec."
 	path := isPrivilegedContainer(container, i, "containers", start_of_path)
 
 	msga := {
@@ -83,11 +84,11 @@ deny contains msga if {
 
 # handles majority of workload resources — initContainers
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	start_of_path := "spec.template.spec."
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.initContainers[i]
-	start_of_path := "spec.template.spec."
 	path := isPrivilegedContainer(container, i, "initContainers", start_of_path)
 
 	msga := {
@@ -103,11 +104,11 @@ deny contains msga if {
 
 # handles majority of workload resources — ephemeralContainers
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	start_of_path := "spec.template.spec."
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.ephemeralContainers[i]
-	start_of_path := "spec.template.spec."
 	path := isPrivilegedContainer(container, i, "ephemeralContainers", start_of_path)
 
 	msga := {
@@ -123,10 +124,10 @@ deny contains msga if {
 
 # handles cronjob — containers
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	path := isPrivilegedContainer(container, i, "containers", start_of_path)
 
 	msga := {
@@ -142,10 +143,10 @@ deny contains msga if {
 
 # handles cronjob — initContainers
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.initContainers[i]
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	path := isPrivilegedContainer(container, i, "initContainers", start_of_path)
 
 	msga := {
@@ -161,10 +162,10 @@ deny contains msga if {
 
 # handles cronjob — ephemeralContainers
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.ephemeralContainers[i]
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	path := isPrivilegedContainer(container, i, "ephemeralContainers", start_of_path)
 
 	msga := {

--- a/rules/rule-privileged-container/raw.rego
+++ b/rules/rule-privileged-container/raw.rego
@@ -1,31 +1,30 @@
 package armo_builtins
+
+import rego.v1
+
 # Deny mutating action unless user is in group owning the resource
 
-
 # privileged pods — containers
-deny[msga] {
-
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
 	start_of_path := "spec."
 	path := isPrivilegedContainer(container, i, "containers", start_of_path)
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("the following pods are defined as privileged: %v", [pod.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 3,
 		"fixPaths": [],
 		"deletePaths": path,
 		"failedPaths": path,
-         "alertObject": {
-			"k8sApiObjects": [pod]
-		}
-     }
+		"alertObject": {"k8sApiObjects": [pod]},
+	}
 }
 
 # privileged pods — initContainers
-deny[msga] {
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.initContainers[i]
@@ -39,14 +38,12 @@ deny[msga] {
 		"fixPaths": [],
 		"deletePaths": path,
 		"failedPaths": path,
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
 # privileged pods — ephemeralContainers
-deny[msga] {
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.ephemeralContainers[i]
@@ -60,39 +57,34 @@ deny[msga] {
 		"fixPaths": [],
 		"deletePaths": path,
 		"failedPaths": path,
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-
 # handles majority of workload resources — containers
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	start_of_path := "spec.template.spec."
 	path := isPrivilegedContainer(container, i, "containers", start_of_path)
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("%v: %v is defined as privileged:", [wl.kind, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 3,
 		"fixPaths": [],
 		"deletePaths": path,
 		"failedPaths": path,
-         "alertObject": {
-			"k8sApiObjects": [wl]
-		}
-     }
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
 }
 
 # handles majority of workload resources — initContainers
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.initContainers[i]
 	start_of_path := "spec.template.spec."
@@ -105,16 +97,14 @@ deny[msga] {
 		"fixPaths": [],
 		"deletePaths": path,
 		"failedPaths": path,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # handles majority of workload resources — ephemeralContainers
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.ephemeralContainers[i]
 	start_of_path := "spec.template.spec."
@@ -127,35 +117,31 @@ deny[msga] {
 		"fixPaths": [],
 		"deletePaths": path,
 		"failedPaths": path,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # handles cronjob — containers
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
 	start_of_path := "spec.jobTemplate.spec.template.spec."
 	path := isPrivilegedContainer(container, i, "containers", start_of_path)
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("the following cronjobs are defined as privileged: %v", [wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 3,
 		"fixPaths": [],
 		"deletePaths": path,
 		"failedPaths": path,
-         "alertObject": {
-			"k8sApiObjects": [wl]
-		}
-     }
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
 }
 
 # handles cronjob — initContainers
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.initContainers[i]
@@ -169,14 +155,12 @@ deny[msga] {
 		"fixPaths": [],
 		"deletePaths": path,
 		"failedPaths": path,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # handles cronjob — ephemeralContainers
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.ephemeralContainers[i]
@@ -190,22 +174,19 @@ deny[msga] {
 		"fixPaths": [],
 		"deletePaths": path,
 		"failedPaths": path,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
 # Only SYS_ADMIN capability
-isPrivilegedContainer(container, i, array_name, start_of_path) = path {
+isPrivilegedContainer(container, i, array_name, start_of_path) := path if {
 	not container.securityContext.privileged == true
 	path = [sprintf("%v%v[%v].securityContext.capabilities.add[%v]", [start_of_path, array_name, format_int(i, 10), format_int(k, 10)]) | capabilite = container.securityContext.capabilities.add[k]; capabilite == "SYS_ADMIN"]
 	count(path) > 0
 }
 
 # Only securityContext.privileged == true
-isPrivilegedContainer(container, i, array_name, start_of_path) = path {
+isPrivilegedContainer(container, i, array_name, start_of_path) := path if {
 	container.securityContext.privileged == true
 	path1 = [sprintf("%v%v[%v].securityContext.capabilities.add[%v]", [start_of_path, array_name, format_int(i, 10), format_int(k, 10)]) | capabilite = container.securityContext.capabilities.add[k]; capabilite == "SYS_ADMIN"]
 	count(path1) < 1
@@ -213,7 +194,7 @@ isPrivilegedContainer(container, i, array_name, start_of_path) = path {
 }
 
 # SYS_ADMIN capability && securityContext.privileged == true
-isPrivilegedContainer(container, i, array_name, start_of_path) = path {
+isPrivilegedContainer(container, i, array_name, start_of_path) := path if {
 	path1 = [sprintf("%v%v[%v].securityContext.capabilities.add[%v]", [start_of_path, array_name, format_int(i, 10), format_int(k, 10)]) | capabilite = container.securityContext.capabilities.add[k]; capabilite == "SYS_ADMIN"]
 	count(path1) > 0
 	container.securityContext.privileged == true

--- a/rules/rule-secrets-in-env-var/raw.rego
+++ b/rules/rule-secrets-in-env-var/raw.rego
@@ -1,6 +1,8 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 
@@ -17,15 +19,13 @@ deny[msga] {
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		}
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	env := container.env[j]
@@ -40,13 +40,11 @@ deny[msga] {
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
@@ -62,8 +60,6 @@ deny[msga] {
 		"deletePaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }

--- a/rules/rule-secrets-in-env-var/raw.rego
+++ b/rules/rule-secrets-in-env-var/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -24,8 +25,8 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 	env := container.env[j]

--- a/rules/secret-etcd-encryption-cloud/raw.rego
+++ b/rules/secret-etcd-encryption-cloud/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -92,7 +93,7 @@ is_encrypted_EKS(config) if {
 # hand the raw AWS CLI / describe-cluster JSON (cluster.encryptionConfig)
 # would otherwise always trip the C-0066 deny even with KMS actually
 # enabled (kubescape/kubescape#1959).
-is_encrypted_EKS(config) {
+is_encrypted_EKS(config) if {
 	encryption := config.cluster.encryptionConfig[_]
 	encryption.provider.keyArn != ""
 	count(encryption.resources) > 0

--- a/rules/secret-etcd-encryption-cloud/raw.rego
+++ b/rules/secret-etcd-encryption-cloud/raw.rego
@@ -1,18 +1,17 @@
 package armo_builtins
 
-import future.keywords.every
-import future.keywords.in
+import rego.v1
 
 # Check if encryption in etcd in enabled for AKS
-deny[msga] {
+deny contains msga if {
 	cluster_config := input[_]
 	cluster_config.apiVersion == "management.azure.com/v1"
 	cluster_config.kind == "ClusterDescribe"
-    cluster_config.metadata.provider == "aks"	
+	cluster_config.metadata.provider == "aks"
 	config = cluster_config.data
 
 	not isEncryptedAKS(config)
-	
+
 	msga := {
 		"alertMessage": "etcd/secret encryption is not enabled",
 		"alertScore": 3,
@@ -20,15 +19,12 @@ deny[msga] {
 		"failedPaths": [],
 		"fixPaths": [],
 		"fixCommand": "az aks nodepool add --name hostencrypt --cluster-name <myAKSCluster> --resource-group <myResourceGroup> -s Standard_DS2_v2 -l <myRegion> --enable-encryption-at-host",
-		"alertObject": {
-            "externalObjects": cluster_config
-		}
+		"alertObject": {"externalObjects": cluster_config},
 	}
 }
 
-
 # Check if encryption in etcd is enabled for EKS
-deny[msga] {
+deny contains msga if {
 	cluster_config := input[_]
 	cluster_config.apiVersion == "eks.amazonaws.com/v1"
 	cluster_config.kind == "ClusterDescribe"
@@ -46,24 +42,21 @@ deny[msga] {
 		"fixCommand": "eksctl utils enable-secrets-encryption --cluster=<cluster> --key-arn=arn:aws:kms:<cluster_region>:<account>:key/<key> --region=<region>",
 		"alertObject": {
 			"k8sApiObjects": [],
-			"externalObjects": cluster_config
-		}
+			"externalObjects": cluster_config,
+		},
 	}
 }
 
-
-
 # Check if encryption in etcd in enabled for GKE
-deny[msga] {
+deny contains msga if {
 	cluster_config := input[_]
 	cluster_config.apiVersion == "container.googleapis.com/v1"
 	cluster_config.kind == "ClusterDescribe"
-    cluster_config.metadata.provider == "gke"	
+	cluster_config.metadata.provider == "gke"
 	config := cluster_config.data
 
 	not is_encrypted_GKE(config)
-    
-	
+
 	msga := {
 		"alertMessage": "etcd/secret encryption is not enabled",
 		"alertScore": 3,
@@ -74,20 +67,20 @@ deny[msga] {
 		"fixCommand": "gcloud container clusters update <cluster_name> --region=<compute_region> --database-encryption-key=<key_project_id>/locations/<location>/keyRings/<ring_name>/cryptoKeys/<key_name> --project=<cluster_project_id>",
 		"alertObject": {
 			"k8sApiObjects": [],
-            "externalObjects": cluster_config
-		}
+			"externalObjects": cluster_config,
+		},
 	}
 }
 
-is_encrypted_GKE(config) {
-	 config.database_encryption.state == "1"
-}
-is_encrypted_GKE(config) {
-	 config.database_encryption.state == "ENCRYPTED"
+is_encrypted_GKE(config) if {
+	config.database_encryption.state == "1"
 }
 
+is_encrypted_GKE(config) if {
+	config.database_encryption.state == "ENCRYPTED"
+}
 
-is_encrypted_EKS(config) {
+is_encrypted_EKS(config) if {
 	encryption := config.Cluster.EncryptionConfig[_]
 	encryption.Provider.KeyArn != ""
 	count(encryption.Resources) > 0
@@ -105,16 +98,16 @@ is_encrypted_EKS(config) {
 	count(encryption.resources) > 0
 }
 
-isEncryptedAKS(cluster_config) {
+isEncryptedAKS(cluster_config) if {
 	profiles := cluster_config.properties.agentPoolProfiles
 	count(profiles) > 0
 	every p in profiles { p.enableEncryptionAtHost == true }
 }
 
-isEncryptedAKS(cluster_config) {
+isEncryptedAKS(cluster_config) if {
 	cluster_config.properties.securityProfile.azureKeyVaultKms.enabled == true
 }
 
-isEncryptedAKS(cluster_config) {
+isEncryptedAKS(cluster_config) if {
 	cluster_config.properties.securityProfile.kubernetesResourceObjectEncryptionProfile.infrastructureEncryption == "Enabled"
 }

--- a/rules/service-in-default-namespace/raw.rego
+++ b/rules/service-in-default-namespace/raw.rego
@@ -1,11 +1,13 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	not is_kubernetes_default_resource(resource)
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -13,36 +15,34 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
+} else := []
 
 # The kubernetes Service is auto-created by Kubernetes in the default
 # namespace for API server discovery and is excluded by the CIS benchmark
 # (CIS 5.7.4: kubescape/regolibrary#644).
-is_kubernetes_default_resource(resource) {
+is_kubernetes_default_resource(resource) if {
 	resource.kind == "Service"
 	resource.metadata.name == "kubernetes"
 	resource.metadata.namespace == "default"

--- a/rules/service-in-default-namespace/raw.rego
+++ b/rules/service-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1

--- a/rules/service-with-no-workload/raw.rego
+++ b/rules/service-with-no-workload/raw.rego
@@ -1,8 +1,8 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
-deny[msga] {
+deny contains msga if {
 	service := input[_]
 	service.kind == "Service"
 	service_type := object.get(service.spec, "type", "ClusterIP")
@@ -19,51 +19,49 @@ deny[msga] {
 		"failedPaths": ["spec.selector"],
 		"fixPaths": [],
 		"alertScore": 3,
-		"alertObject": {
-			"k8sApiObjects": [service],
-		},
+		"alertObject": {"k8sApiObjects": [service]},
 	}
 }
 
-has_matching_workload(service, all) {
+has_matching_workload(service, all) if {
 	wl := all[_]
 	is_workload(wl)
 	same_namespace(service, wl)
 	labels_match(service.spec.selector, pod_template_labels(wl))
 }
 
-is_workload(wl) {
+is_workload(wl) if {
 	workload_kinds := {"Pod", "Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "CronJob", "ReplicationController"}
 	workload_kinds[wl.kind]
 }
 
-pod_template_labels(wl) = labels {
+pod_template_labels(wl) := labels if {
 	wl.kind == "Pod"
 	labels := object.get(wl.metadata, "labels", {})
 }
 
-pod_template_labels(wl) = labels {
+pod_template_labels(wl) := labels if {
 	controller_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job", "ReplicationController"}
 	controller_kinds[wl.kind]
 	labels := object.get(wl.spec.template.metadata, "labels", {})
 }
 
-pod_template_labels(wl) = labels {
+pod_template_labels(wl) := labels if {
 	wl.kind == "CronJob"
 	labels := object.get(wl.spec.jobTemplate.spec.template.metadata, "labels", {})
 }
 
-labels_match(selector, labels) {
+labels_match(selector, labels) if {
 	count(selector) > 0
 	not selector_mismatch(selector, labels)
 }
 
-selector_mismatch(selector, labels) {
+selector_mismatch(selector, labels) if {
 	selector[k]
 	not labels[k] == selector[k]
 }
 
-same_namespace(a, b) {
+same_namespace(a, b) if {
 	service_namespace(a) == workload_namespace(b)
 }
 

--- a/rules/service-with-no-workload/raw.rego
+++ b/rules/service-with-no-workload/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -23,8 +24,8 @@ deny contains msga if {
 	}
 }
 
-has_matching_workload(service, all) if {
-	wl := all[_]
+has_matching_workload(service, workloads) if {
+	wl := workloads[_]
 	is_workload(wl)
 	same_namespace(service, wl)
 	labels_match(service.spec.selector, pod_template_labels(wl))

--- a/rules/serviceaccount-in-default-namespace/raw.rego
+++ b/rules/serviceaccount-in-default-namespace/raw.rego
@@ -1,10 +1,12 @@
 package armo_builtins
 
-deny[msga] {
-    resource := input[_]
+import rego.v1
+
+deny contains msga if {
+	resource := input[_]
 	result := is_default_namespace(resource.metadata)
 	failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	fixed_path := get_fixed_path(result)
 	msga := {
 		"alertMessage": sprintf("%v: %v is in the 'default' namespace", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
@@ -12,30 +14,26 @@ deny[msga] {
 		"reviewPaths": failed_path,
 		"failedPaths": failed_path,
 		"fixPaths": fixed_path,
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		}
+		"alertObject": {"k8sApiObjects": [resource]},
 	}
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	metadata.namespace == "default"
 	failed_path = "metadata.namespace"
-	fixPath = "" 
+	fixPath = ""
 }
 
-is_default_namespace(metadata) = [failed_path, fixPath] {
+is_default_namespace(metadata) := [failed_path, fixPath] if {
 	not metadata.namespace
 	failed_path = ""
 	fixPath = {"path": "metadata.namespace", "value": "YOUR_NAMESPACE"}
 }
 
-get_failed_path(paths) = [paths[0]] {
+get_failed_path(paths) := [paths[0]] if {
 	paths[0] != ""
-} else = []
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
+get_fixed_path(paths) := [paths[1]] if {
 	paths[1] != ""
-} else = []
-
-
+} else := []

--- a/rules/serviceaccount-in-default-namespace/raw.rego
+++ b/rules/serviceaccount-in-default-namespace/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1

--- a/rules/serviceaccount-token-mount/filter.rego
+++ b/rules/serviceaccount-token-mount/filter.rego
@@ -1,32 +1,31 @@
 package armo_builtins
 
-deny[msga] {
-    wl := input[_]
-    start_of_path := get_beginning_of_path(wl)
+import rego.v1
 
-    msga := {
-        "alertMessage": sprintf("%v: %v in the following namespace: %v mounts service account tokens by default", [wl.kind, wl.metadata.name, wl.metadata.namespace]),
-        "packagename": "armo_builtins",
-        "alertScore": 9,
-        "alertObject": {
-            "k8sApiObjects": [wl]
-        },
-    }
+deny contains msga if {
+	wl := input[_]
+	start_of_path := get_beginning_of_path(wl)
+
+	msga := {
+		"alertMessage": sprintf("%v: %v in the following namespace: %v mounts service account tokens by default", [wl.kind, wl.metadata.name, wl.metadata.namespace]),
+		"packagename": "armo_builtins",
+		"alertScore": 9,
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
 }
 
-
-get_beginning_of_path(workload) = start_of_path {
-    spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-    spec_template_spec_patterns[workload.kind]
-    start_of_path := ["spec", "template", "spec"]
+get_beginning_of_path(workload) := start_of_path if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	spec_template_spec_patterns[workload.kind]
+	start_of_path := ["spec", "template", "spec"]
 }
 
-get_beginning_of_path(workload) = start_of_path {
-    workload.kind == "Pod"
-    start_of_path := ["spec"]
+get_beginning_of_path(workload) := start_of_path if {
+	workload.kind == "Pod"
+	start_of_path := ["spec"]
 }
 
-get_beginning_of_path(workload) = start_of_path {
-    workload.kind == "CronJob"
-    start_of_path := ["spec", "jobTemplate", "spec", "template", "spec"]
+get_beginning_of_path(workload) := start_of_path if {
+	workload.kind == "CronJob"
+	start_of_path := ["spec", "jobTemplate", "spec", "template", "spec"]
 }

--- a/rules/serviceaccount-token-mount/filter.rego
+++ b/rules/serviceaccount-token-mount/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1

--- a/rules/serviceaccount-token-mount/raw.rego
+++ b/rules/serviceaccount-token-mount/raw.rego
@@ -1,133 +1,127 @@
 package armo_builtins
 
-deny[msga] {
-    wl := input[_]
-    start_of_path := get_beginning_of_path(wl)
-    spec := object.get(wl, start_of_path, [])
+import rego.v1
 
-    sa := input[_]
-    sa.kind == "ServiceAccount"
-    is_same_sa(spec, sa.metadata.name)
-    is_same_namespace(sa.metadata , wl.metadata)
-    has_service_account_binding(sa)
-    result := is_sa_auto_mounted_and_bound(spec, start_of_path, sa)
+deny contains msga if {
+	wl := input[_]
+	start_of_path := get_beginning_of_path(wl)
+	spec := object.get(wl, start_of_path, [])
 
-    failed_path := get_failed_path(result)
-    fixed_path := get_fixed_path(result)
+	sa := input[_]
+	sa.kind == "ServiceAccount"
+	is_same_sa(spec, sa.metadata.name)
+	is_same_namespace(sa.metadata, wl.metadata)
+	has_service_account_binding(sa)
+	result := is_sa_auto_mounted_and_bound(spec, start_of_path, sa)
 
-    msga := {
-        "alertMessage": sprintf("%v: %v in the following namespace: %v mounts service account tokens by default", [wl.kind, wl.metadata.name, wl.metadata.namespace]),
-        "packagename": "armo_builtins",
-        "alertScore": 9,
-        "fixPaths": fixed_path,
-        "reviewPaths": failed_path,
-        "failedPaths": failed_path,
-        "alertObject": {
-            "k8sApiObjects": [wl]
-        },
-        "relatedObjects": [{
-            "object": sa
-        }]
-    }
+	failed_path := get_failed_path(result)
+	fixed_path := get_fixed_path(result)
+
+	msga := {
+		"alertMessage": sprintf("%v: %v in the following namespace: %v mounts service account tokens by default", [wl.kind, wl.metadata.name, wl.metadata.namespace]),
+		"packagename": "armo_builtins",
+		"alertScore": 9,
+		"fixPaths": fixed_path,
+		"reviewPaths": failed_path,
+		"failedPaths": failed_path,
+		"alertObject": {"k8sApiObjects": [wl]},
+		"relatedObjects": [{"object": sa}],
+	}
 }
 
-
-get_beginning_of_path(workload) = start_of_path {
-    spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-    spec_template_spec_patterns[workload.kind]
-    start_of_path := ["spec", "template", "spec"]
+get_beginning_of_path(workload) := start_of_path if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	spec_template_spec_patterns[workload.kind]
+	start_of_path := ["spec", "template", "spec"]
 }
 
-get_beginning_of_path(workload) = start_of_path {
-    workload.kind == "Pod"
-    start_of_path := ["spec"]
+get_beginning_of_path(workload) := start_of_path if {
+	workload.kind == "Pod"
+	start_of_path := ["spec"]
 }
 
-get_beginning_of_path(workload) = start_of_path {
-    workload.kind == "CronJob"
-    start_of_path := ["spec", "jobTemplate", "spec", "template", "spec"]
+get_beginning_of_path(workload) := start_of_path if {
+	workload.kind == "CronJob"
+	start_of_path := ["spec", "jobTemplate", "spec", "template", "spec"]
 }
 
+#  -- ----     For workloads     -- ----
+is_sa_auto_mounted_and_bound(spec, start_of_path, sa) := [failed_path, fix_path] if {
+	# automountServiceAccountToken not in pod spec
+	not spec.automountServiceAccountToken == false
+	not spec.automountServiceAccountToken == true
 
- #  -- ----     For workloads     -- ----     
-is_sa_auto_mounted_and_bound(spec, start_of_path, sa) = [failed_path, fix_path]   {
-    # automountServiceAccountToken not in pod spec
-    not spec.automountServiceAccountToken == false
-    not spec.automountServiceAccountToken == true
+	not sa.automountServiceAccountToken == false
 
-    not sa.automountServiceAccountToken == false
-
-    fix_path = { "path": sprintf("%v.automountServiceAccountToken", [concat(".", start_of_path)]), "value": "false"}
-    failed_path = ""
+	fix_path = {"path": sprintf("%v.automountServiceAccountToken", [concat(".", start_of_path)]), "value": "false"}
+	failed_path = ""
 }
 
-is_sa_auto_mounted_and_bound(spec, start_of_path, sa) =  [failed_path, fix_path]  {
-    # automountServiceAccountToken set to true in pod spec
-    spec.automountServiceAccountToken == true
+is_sa_auto_mounted_and_bound(spec, start_of_path, sa) := [failed_path, fix_path] if {
+	# automountServiceAccountToken set to true in pod spec
+	spec.automountServiceAccountToken == true
 
-    failed_path = sprintf("%v.automountServiceAccountToken", [concat(".", start_of_path)])
-    fix_path = ""
+	failed_path = sprintf("%v.automountServiceAccountToken", [concat(".", start_of_path)])
+	fix_path = ""
 }
 
-get_failed_path(paths) = [paths[0]] {
-    paths[0] != ""
-} else = []
+get_failed_path(paths) := [paths[0]] if {
+	paths[0] != ""
+} else := []
 
+get_fixed_path(paths) := [paths[1]] if {
+	paths[1] != ""
+} else := []
 
-get_fixed_path(paths) = [paths[1]] {
-    paths[1] != ""
-} else = []
-
-
-is_same_sa(spec, serviceAccountName) {
-    spec.serviceAccountName == serviceAccountName
+is_same_sa(spec, serviceAccountName) if {
+	spec.serviceAccountName == serviceAccountName
 }
 
-is_same_sa(spec, serviceAccountName) {
-    not spec.serviceAccountName 
-    serviceAccountName == "default"
+is_same_sa(spec, serviceAccountName) if {
+	not spec.serviceAccountName
+	serviceAccountName == "default"
 }
 
-is_same_namespace(metadata1, metadata2) {
-    metadata1.namespace == metadata2.namespace
+is_same_namespace(metadata1, metadata2) if {
+	metadata1.namespace == metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
-    not metadata1.namespace
-    not metadata2.namespace
+is_same_namespace(metadata1, metadata2) if {
+	not metadata1.namespace
+	not metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
-    not metadata2.namespace
-    metadata1.namespace == "default"
+is_same_namespace(metadata1, metadata2) if {
+	not metadata2.namespace
+	metadata1.namespace == "default"
 }
 
-is_same_namespace(metadata1, metadata2) {
-    not metadata1.namespace
-    metadata2.namespace == "default"
+is_same_namespace(metadata1, metadata2) if {
+	not metadata1.namespace
+	metadata2.namespace == "default"
 }
 
 # checks if RoleBinding/ClusterRoleBinding has a bind with the given ServiceAccount
-has_service_account_binding(service_account) {
-    role_bindings := [role_binding | role_binding = input[_]; endswith(role_binding.kind, "Binding")]
-    role_binding := role_bindings[_]
-    role_binding.subjects[_].name == service_account.metadata.name
-    role_binding.subjects[_].namespace == service_account.metadata.namespace
-    role_binding.subjects[_].kind == "ServiceAccount"
+has_service_account_binding(service_account) if {
+	role_bindings := [role_binding | role_binding = input[_]; endswith(role_binding.kind, "Binding")]
+	role_binding := role_bindings[_]
+	role_binding.subjects[_].name == service_account.metadata.name
+	role_binding.subjects[_].namespace == service_account.metadata.namespace
+	role_binding.subjects[_].kind == "ServiceAccount"
 }
 
 # checks if RoleBinding/ClusterRoleBinding has a bind with the system:authenticated group
 # which gives access to all authenticated users, including service accounts
-has_service_account_binding(service_account) {
-    role_bindings := [role_binding | role_binding = input[_]; endswith(role_binding.kind, "Binding")]
-    role_binding := role_bindings[_]
-    role_binding.subjects[_].name == "system:authenticated"
+has_service_account_binding(service_account) if {
+	role_bindings := [role_binding | role_binding = input[_]; endswith(role_binding.kind, "Binding")]
+	role_binding := role_bindings[_]
+	role_binding.subjects[_].name == "system:authenticated"
 }
 
 # checks if RoleBinding/ClusterRoleBinding has a bind with the "system:serviceaccounts" group
 # which gives access to all service accounts
-has_service_account_binding(service_account) {
-    role_bindings := [role_binding | role_binding = input[_]; endswith(role_binding.kind, "Binding")]
-    role_binding := role_bindings[_]
-    role_binding.subjects[_].name == "system:serviceaccounts"
+has_service_account_binding(service_account) if {
+	role_bindings := [role_binding | role_binding = input[_]; endswith(role_binding.kind, "Binding")]
+	role_binding := role_bindings[_]
+	role_binding.subjects[_].name == "system:serviceaccounts"
 }

--- a/rules/serviceaccount-token-mount/raw.rego
+++ b/rules/serviceaccount-token-mount/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1

--- a/rules/set-fsgroup-value/raw.rego
+++ b/rules/set-fsgroup-value/raw.rego
@@ -1,11 +1,11 @@
 package armo_builtins
 
-import future.keywords.if
+import rego.v1
 
 ### POD ###
 
 # Fails if securityContext.fsGroup does not have a values >= 0
-deny[msga] {
+deny contains msga if {
 	# verify the object kind
 	pod := input[_]
 	pod.kind = "Pod"
@@ -29,7 +29,7 @@ deny[msga] {
 ### CRONJOB ###
 
 # Fails if securityContext.fsGroup does not have a values >= 0
-deny[msga] {
+deny contains msga if {
 	# verify the object kind
 	cj := input[_]
 	cj.kind == "CronJob"
@@ -53,7 +53,7 @@ deny[msga] {
 ### WORKLOAD ###
 
 # Fails if securityContext.fsGroup does not have a values >= 0
-deny[msga] {
+deny contains msga if {
 	# verify the object kind
 	wl := input[_]
 	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}

--- a/rules/set-fsgroup-value/raw.rego
+++ b/rules/set-fsgroup-value/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -6,14 +7,13 @@ import rego.v1
 
 # Fails if securityContext.fsGroup does not have a values >= 0
 deny contains msga if {
+	securityContextPath := "spec.securityContext"
 	# verify the object kind
 	pod := input[_]
-	pod.kind = "Pod"
+	pod.kind == "Pod"
 
 	# check securityContext has fsGroup set properly
 	not fsGroupSetProperly(pod.spec.securityContext)
-
-	securityContextPath := "spec.securityContext"
 
 	fixPaths = [{"path": sprintf("%v.fsGroup", [securityContextPath]), "value": "YOUR_VALUE"}]
 
@@ -30,14 +30,13 @@ deny contains msga if {
 
 # Fails if securityContext.fsGroup does not have a values >= 0
 deny contains msga if {
+	securityContextPath := "spec.jobTemplate.spec.template.spec.securityContext"
 	# verify the object kind
 	cj := input[_]
 	cj.kind == "CronJob"
 
 	# check securityContext has fsGroup set properly
 	not fsGroupSetProperly(cj.spec.jobTemplate.spec.template.spec.securityContext)
-
-	securityContextPath := "spec.jobTemplate.spec.template.spec.securityContext"
 
 	fixPaths = [{"path": sprintf("%v.fsGroup", [securityContextPath]), "value": "YOUR_VALUE"}]
 
@@ -54,15 +53,15 @@ deny contains msga if {
 
 # Fails if securityContext.fsGroup does not have a values >= 0
 deny contains msga if {
+	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	securityContextPath := "spec.template.spec.securityContext"
 	# verify the object kind
 	wl := input[_]
-	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	manifest_kind[wl.kind]
 
 	# check securityContext has fsGroup set properly
 	not fsGroupSetProperly(wl.spec.template.spec.securityContext)
 
-	securityContextPath := "spec.template.spec.securityContext"
 	fixPaths = [{"path": sprintf("%v.fsGroup", [securityContextPath]), "value": "YOUR_VALUE"}]
 
 	msga := {

--- a/rules/set-fsgroupchangepolicy-value/raw.rego
+++ b/rules/set-fsgroupchangepolicy-value/raw.rego
@@ -1,79 +1,72 @@
 package armo_builtins
 
-import future.keywords.if
+import rego.v1
 
 ### POD ###
 
 # Fails if securityContext.fsGroupChangePolicy does not have an allowed value
-deny[msga] {
-    # verify the object kind
-    pod := input[_]
-    pod.kind = "Pod"
-    
-    # check securityContext has fsGroupChangePolicy set
-    not fsGroupChangePolicySetProperly(pod.spec.securityContext)
+deny contains msga if {
+	# verify the object kind
+	pod := input[_]
+	pod.kind = "Pod"
 
-    msga := {
+	# check securityContext has fsGroupChangePolicy set
+	not fsGroupChangePolicySetProperly(pod.spec.securityContext)
+
+	msga := {
 		"alertMessage": sprintf("Pod: %v does not set 'securityContext.fsGroupChangePolicy' with allowed value", [pod.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [{"path": "spec.securityContext.fsGroupChangePolicy", "value": "Always"}],
-    "alertObject": {
-			"k8sApiObjects": [pod]
-		}
-    }
+		"alertObject": {"k8sApiObjects": [pod]},
+	}
 }
 
 ### WORKLOAD ###
 
 # Fails if securityContext.fsGroupChangePolicy does not have an allowed value
-deny[msga] {
-    # verify the object kind
-    wl := input[_]
-    manifest_kind := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-    manifest_kind[wl.kind]
-    
-    # check securityContext has fsGroupChangePolicy set
-    not fsGroupChangePolicySetProperly(wl.spec.template.spec.securityContext)
+deny contains msga if {
+	# verify the object kind
+	wl := input[_]
+	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	manifest_kind[wl.kind]
 
-    msga := {
+	# check securityContext has fsGroupChangePolicy set
+	not fsGroupChangePolicySetProperly(wl.spec.template.spec.securityContext)
+
+	msga := {
 		"alertMessage": sprintf("Workload: %v does not set 'securityContext.fsGroupChangePolicy' with allowed value", [wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [{"path": "spec.template.spec.securityContext.fsGroupChangePolicy", "value": "Always"}],
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
-    }
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
 }
 
 ### CRONJOB ###
 
 # Fails if securityContext.fsGroupChangePolicy does not have an allowed value
-deny[msga] {
-    # verify the object kind
-    cj := input[_]
-    cj.kind == "CronJob"
+deny contains msga if {
+	# verify the object kind
+	cj := input[_]
+	cj.kind == "CronJob"
 
-    # check securityContext has fsGroupChangePolicy set
-    not fsGroupChangePolicySetProperly(cj.spec.jobTemplate.spec.template.spec.securityContext)
+	# check securityContext has fsGroupChangePolicy set
+	not fsGroupChangePolicySetProperly(cj.spec.jobTemplate.spec.template.spec.securityContext)
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("CronJob: %v does not set 'securityContext.fsGroupChangePolicy' with allowed value", [cj.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": [{"path": "spec.jobTemplate.spec.template.spec.securityContext.fsGroupChangePolicy", "value": "Always"}],
-		"alertObject": {
-			"k8sApiObjects": [cj]
-		}
-    }
+		"alertObject": {"k8sApiObjects": [cj]},
+	}
 }
 
 # fsGroupChangePolicySetProperly checks if applied value is set as appropriate [Always|OnRootMismatch]
-fsGroupChangePolicySetProperly(securityContext) := true if {
-    regex.match(securityContext.fsGroupChangePolicy, "Always|OnRootMismatch")
+fsGroupChangePolicySetProperly(securityContext) if {
+	regex.match(securityContext.fsGroupChangePolicy, "Always|OnRootMismatch")
 } else := false
-

--- a/rules/set-fsgroupchangepolicy-value/raw.rego
+++ b/rules/set-fsgroupchangepolicy-value/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -8,7 +9,7 @@ import rego.v1
 deny contains msga if {
 	# verify the object kind
 	pod := input[_]
-	pod.kind = "Pod"
+	pod.kind == "Pod"
 
 	# check securityContext has fsGroupChangePolicy set
 	not fsGroupChangePolicySetProperly(pod.spec.securityContext)
@@ -27,9 +28,9 @@ deny contains msga if {
 
 # Fails if securityContext.fsGroupChangePolicy does not have an allowed value
 deny contains msga if {
+	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	# verify the object kind
 	wl := input[_]
-	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	manifest_kind[wl.kind]
 
 	# check securityContext has fsGroupChangePolicy set

--- a/rules/set-procmount-default/raw.rego
+++ b/rules/set-procmount-default/raw.rego
@@ -1,9 +1,9 @@
 package armo_builtins
 
-import future.keywords.if
+import rego.v1
 
 # Fails if container does not define the "procMount" parameter as "Default"
-deny[msga] {
+deny contains msga if {
 	# checks at first if we the procMountType feature gate is enabled on the api-server
 	obj := input[_]
 	is_control_plane_info(obj)
@@ -27,7 +27,7 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	# checks at first if we the procMountType feature gate is enabled on the api-server
 	obj := input[_]
 	is_control_plane_info(obj)
@@ -52,7 +52,7 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	# checks at first if we the procMountType feature gate is enabled on the api-server
 	obj := input[_]
 	is_control_plane_info(obj)

--- a/rules/set-procmount-default/raw.rego
+++ b/rules/set-procmount-default/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -11,7 +12,7 @@ deny contains msga if {
 
 	# checks if procMount paramenter has the right value in containers
 	pod := input[_]
-	pod.kind = "Pod"
+	pod.kind == "Pod"
 
 	# retrieve container list
 	container := pod.spec.containers[i]
@@ -28,6 +29,7 @@ deny contains msga if {
 }
 
 deny contains msga if {
+	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	# checks at first if we the procMountType feature gate is enabled on the api-server
 	obj := input[_]
 	is_control_plane_info(obj)
@@ -35,7 +37,6 @@ deny contains msga if {
 
 	# checks if we are managing the right workload kind
 	wl := input[_]
-	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	manifest_kind[wl.kind]
 
 	# retrieve container list
@@ -60,7 +61,7 @@ deny contains msga if {
 
 	# checks if we are managing the right workload kind
 	cj := input[_]
-	cj.kind = "CronJob"
+	cj.kind == "CronJob"
 
 	# retrieve container list
 	container := cj.spec.jobTemplate.spec.template.spec.containers[i]

--- a/rules/set-seLinuxOptions/raw.rego
+++ b/rules/set-seLinuxOptions/raw.rego
@@ -1,22 +1,22 @@
 package armo_builtins
 
+import rego.v1
 
-# Fails if pod does not define seLinuxOptions 
-deny[msga] {
-    wl := input[_]
-    wl.kind == "Pod"
-    spec := wl.spec
+# Fails if pod does not define seLinuxOptions
+deny contains msga if {
+	wl := input[_]
+	wl.kind == "Pod"
+	spec := wl.spec
 	path_to_search := ["securityContext", "seLinuxOptions"]
 	no_seLinuxOptions_in_securityContext(spec, path_to_search)
 
 	path_to_containers := ["spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
-    no_seLinuxOptions_in_securityContext(container, path_to_search)
+	no_seLinuxOptions_in_securityContext(container, path_to_search)
 
-	fix_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)]) 
+	fix_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)])
 	fixPaths := [{"path": fix_path, "value": "YOUR_VALUE"}]
-
 
 	msga := {
 		"alertMessage": sprintf("Pod: %v does not define any seLinuxOptions", [wl.metadata.name]),
@@ -24,29 +24,26 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if workload does not define seLinuxOptions
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    spec := wl.spec.template.spec
+	spec := wl.spec.template.spec
 	path_to_search := ["securityContext", "seLinuxOptions"]
 	no_seLinuxOptions_in_securityContext(spec, path_to_search)
 
 	path_to_containers := ["spec", "template", "spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
-    no_seLinuxOptions_in_securityContext(container, path_to_search)
+	no_seLinuxOptions_in_securityContext(container, path_to_search)
 
-	fix_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)]) 
+	fix_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)])
 	fixPaths := [{"path": fix_path, "value": "YOUR_VALUE"}]
-
 
 	msga := {
 		"alertMessage": sprintf("Workload: %v does not define any seLinuxOptions", [wl.metadata.name]),
@@ -54,15 +51,12 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
-# Fails if CronJob does not define seLinuxOptions 
-deny[msga] {
+# Fails if CronJob does not define seLinuxOptions
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	spec := wl.spec.jobTemplate.spec.template.spec
@@ -72,9 +66,9 @@ deny[msga] {
 	path_to_containers := ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
-    no_seLinuxOptions_in_securityContext(container, path_to_search)
+	no_seLinuxOptions_in_securityContext(container, path_to_search)
 
-	fix_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)]) 
+	fix_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)])
 	fixPaths := [{"path": fix_path, "value": "YOUR_VALUE"}]
 	msga := {
 		"alertMessage": sprintf("Cronjob: %v does not define any seLinuxOptions", [wl.metadata.name]),
@@ -82,12 +76,10 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-no_seLinuxOptions_in_securityContext(spec, path_to_search){
-    object.get(spec, path_to_search, "") == ""
+no_seLinuxOptions_in_securityContext(spec, path_to_search) if {
+	object.get(spec, path_to_search, "") == ""
 }

--- a/rules/set-seLinuxOptions/raw.rego
+++ b/rules/set-seLinuxOptions/raw.rego
@@ -1,16 +1,17 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
 
 # Fails if pod does not define seLinuxOptions
 deny contains msga if {
+	path_to_search := ["securityContext", "seLinuxOptions"]
+	path_to_containers := ["spec", "containers"]
 	wl := input[_]
 	wl.kind == "Pod"
 	spec := wl.spec
-	path_to_search := ["securityContext", "seLinuxOptions"]
 	no_seLinuxOptions_in_securityContext(spec, path_to_search)
 
-	path_to_containers := ["spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
 	no_seLinuxOptions_in_securityContext(container, path_to_search)
@@ -30,14 +31,14 @@ deny contains msga if {
 
 # Fails if workload does not define seLinuxOptions
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	path_to_search := ["securityContext", "seLinuxOptions"]
+	path_to_containers := ["spec", "template", "spec", "containers"]
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	spec := wl.spec.template.spec
-	path_to_search := ["securityContext", "seLinuxOptions"]
 	no_seLinuxOptions_in_securityContext(spec, path_to_search)
 
-	path_to_containers := ["spec", "template", "spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
 	no_seLinuxOptions_in_securityContext(container, path_to_search)
@@ -57,13 +58,13 @@ deny contains msga if {
 
 # Fails if CronJob does not define seLinuxOptions
 deny contains msga if {
+	path_to_search := ["securityContext", "seLinuxOptions"]
+	path_to_containers := ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
 	wl := input[_]
 	wl.kind == "CronJob"
 	spec := wl.spec.jobTemplate.spec.template.spec
-	path_to_search := ["securityContext", "seLinuxOptions"]
 	no_seLinuxOptions_in_securityContext(spec, path_to_search)
 
-	path_to_containers := ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
 	no_seLinuxOptions_in_securityContext(container, path_to_search)

--- a/rules/set-seccomp-profile-RuntimeDefault/raw.rego
+++ b/rules/set-seccomp-profile-RuntimeDefault/raw.rego
@@ -1,14 +1,16 @@
 package armo_builtins
 
+import rego.v1
+
 # Fails if pod does not define seccompProfile as RuntimeDefault
-deny[msga] {
-    wl := input[_]
-    wl.kind == "Pod"
-    wl_spec := wl.spec
+deny contains msga if {
+	wl := input[_]
+	wl.kind == "Pod"
+	wl_spec := wl.spec
 	path_to_containers := ["spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
-	
+
 	path_to_search := ["securityContext", "seccompProfile", "type"]
 
 	seccompProfile_result := get_seccompProfile_definition(wl_spec, container, i, path_to_containers, path_to_search)
@@ -21,22 +23,20 @@ deny[msga] {
 		"reviewPaths": seccompProfile_result.failed_path,
 		"failedPaths": seccompProfile_result.failed_path,
 		"fixPaths": seccompProfile_result.fix_path,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if workload does not define seccompProfile as RuntimeDefault
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    wl_spec := wl.spec.template.spec
+	wl_spec := wl.spec.template.spec
 	path_to_containers := ["spec", "template", "spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
-	
+
 	path_to_search := ["securityContext", "seccompProfile", "type"]
 
 	seccompProfile_result := get_seccompProfile_definition(wl_spec, container, i, path_to_containers, path_to_search)
@@ -49,22 +49,19 @@ deny[msga] {
 		"reviewPaths": seccompProfile_result.failed_path,
 		"failedPaths": seccompProfile_result.failed_path,
 		"fixPaths": seccompProfile_result.fix_path,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
 # Fails if CronJob does not define seccompProfile as RuntimeDefault
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
-    wl_spec := wl.spec.jobTemplate.spec.template.spec
+	wl_spec := wl.spec.jobTemplate.spec.template.spec
 	path_to_containers := ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
-	
+
 	path_to_search := ["securityContext", "seccompProfile", "type"]
 
 	seccompProfile_result := get_seccompProfile_definition(wl_spec, container, i, path_to_containers, path_to_search)
@@ -77,33 +74,26 @@ deny[msga] {
 		"reviewPaths": seccompProfile_result.failed_path,
 		"failedPaths": seccompProfile_result.failed_path,
 		"fixPaths": seccompProfile_result.fix_path,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
 # container definition takes precedence
-get_seccompProfile_definition(wl, container, i, path_to_containers, path_to_search) = seccompProfile_result {
+get_seccompProfile_definition(wl, container, i, path_to_containers, path_to_search) := seccompProfile_result if {
 	container.securityContext.seccompProfile.type == "RuntimeDefault"
-    seccompProfile_result := {"failed": false, "failed_path": [], "fix_path": []}
-
-} else = seccompProfile_result {
+	seccompProfile_result := {"failed": false, "failed_path": [], "fix_path": []}
+} else := seccompProfile_result if {
 	container.securityContext.seccompProfile.type != "RuntimeDefault"
-    failed_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)])
-    seccompProfile_result := {"failed": true, "failed_path": [failed_path], "fix_path": []}
-
-} else = seccompProfile_result {
-	wl.securityContext.seccompProfile.type == "RuntimeDefault" 
-    seccompProfile_result := {"failed": false,  "failed_path": [], "fix_path": []}
-
-} else = seccompProfile_result {
-	wl.securityContext.seccompProfile.type != "RuntimeDefault" 
+	failed_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)])
+	seccompProfile_result := {"failed": true, "failed_path": [failed_path], "fix_path": []}
+} else := seccompProfile_result if {
+	wl.securityContext.seccompProfile.type == "RuntimeDefault"
+	seccompProfile_result := {"failed": false, "failed_path": [], "fix_path": []}
+} else := seccompProfile_result if {
+	wl.securityContext.seccompProfile.type != "RuntimeDefault"
 	failed_path := sprintf("%s.%s", [trim_suffix(concat(".", path_to_containers), ".containers"), concat(".", path_to_search)])
-    seccompProfile_result := {"failed": true,  "failed_path": [failed_path], "fix_path": []}
-
-} else = seccompProfile_result{
-	fix_path := [{"path": sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)]), "value":"RuntimeDefault"}]
+	seccompProfile_result := {"failed": true, "failed_path": [failed_path], "fix_path": []}
+} else := seccompProfile_result if {
+	fix_path := [{"path": sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)]), "value": "RuntimeDefault"}]
 	seccompProfile_result := {"failed": true, "failed_path": [], "fix_path": fix_path}
 }

--- a/rules/set-seccomp-profile-RuntimeDefault/raw.rego
+++ b/rules/set-seccomp-profile-RuntimeDefault/raw.rego
@@ -1,17 +1,17 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
 
 # Fails if pod does not define seccompProfile as RuntimeDefault
 deny contains msga if {
+	path_to_containers := ["spec", "containers"]
+	path_to_search := ["securityContext", "seccompProfile", "type"]
 	wl := input[_]
 	wl.kind == "Pod"
 	wl_spec := wl.spec
-	path_to_containers := ["spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
-
-	path_to_search := ["securityContext", "seccompProfile", "type"]
 
 	seccompProfile_result := get_seccompProfile_definition(wl_spec, container, i, path_to_containers, path_to_search)
 	seccompProfile_result.failed == true
@@ -29,15 +29,14 @@ deny contains msga if {
 
 # Fails if workload does not define seccompProfile as RuntimeDefault
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	path_to_containers := ["spec", "template", "spec", "containers"]
+	path_to_search := ["securityContext", "seccompProfile", "type"]
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	wl_spec := wl.spec.template.spec
-	path_to_containers := ["spec", "template", "spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
-
-	path_to_search := ["securityContext", "seccompProfile", "type"]
 
 	seccompProfile_result := get_seccompProfile_definition(wl_spec, container, i, path_to_containers, path_to_search)
 	seccompProfile_result.failed == true
@@ -55,14 +54,13 @@ deny contains msga if {
 
 # Fails if CronJob does not define seccompProfile as RuntimeDefault
 deny contains msga if {
+	path_to_containers := ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
+	path_to_search := ["securityContext", "seccompProfile", "type"]	
 	wl := input[_]
 	wl.kind == "CronJob"
 	wl_spec := wl.spec.jobTemplate.spec.template.spec
-	path_to_containers := ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
-
-	path_to_search := ["securityContext", "seccompProfile", "type"]
 
 	seccompProfile_result := get_seccompProfile_definition(wl_spec, container, i, path_to_containers, path_to_search)
 	seccompProfile_result.failed == true

--- a/rules/set-seccomp-profile/raw.rego
+++ b/rules/set-seccomp-profile/raw.rego
@@ -1,19 +1,21 @@
 package armo_builtins
 
+import rego.v1
+
 # Fails if pod does not define seccompProfile
-deny[msga] {
-    wl := input[_]
-    wl.kind == "Pod"
-    spec := wl.spec
+deny contains msga if {
+	wl := input[_]
+	wl.kind == "Pod"
+	spec := wl.spec
 	path_to_search := ["securityContext", "seccompProfile"]
 	seccompProfile_not_defined(spec, path_to_search)
 
 	path_to_containers := ["spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
-    seccompProfile_not_defined(container, path_to_search)
+	seccompProfile_not_defined(container, path_to_search)
 
-	fix_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)]) 
+	fix_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)])
 	fixPaths := [{"path": fix_path, "value": "YOUR_VALUE"}]
 
 	msga := {
@@ -22,27 +24,25 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
 # Fails if workload does not define seccompProfile
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    spec := wl.spec.template.spec
+	spec := wl.spec.template.spec
 	path_to_search := ["securityContext", "seccompProfile"]
 	seccompProfile_not_defined(spec, path_to_search)
 
 	path_to_containers := ["spec", "template", "spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
-    seccompProfile_not_defined(container, path_to_search)
+	seccompProfile_not_defined(container, path_to_search)
 
-	fix_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)]) 
+	fix_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)])
 	fixPaths := [{"path": fix_path, "value": "YOUR_VALUE"}]
 
 	msga := {
@@ -51,29 +51,25 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
 # Fails if CronJob does not define seccompProfile
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
-    spec := wl.spec.jobTemplate.spec.template.spec
+	spec := wl.spec.jobTemplate.spec.template.spec
 	path_to_search := ["securityContext", "seccompProfile"]
 	seccompProfile_not_defined(spec, path_to_search)
 
 	path_to_containers := ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
-    seccompProfile_not_defined(container, path_to_search)
+	seccompProfile_not_defined(container, path_to_search)
 
-	fix_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)]) 
+	fix_path := sprintf("%s[%d].%s", [concat(".", path_to_containers), i, concat(".", path_to_search)])
 	fixPaths := [{"path": fix_path, "value": "YOUR_VALUE"}]
-
 
 	msga := {
 		"alertMessage": sprintf("Cronjob: %v does not define seccompProfile", [wl.metadata.name]),
@@ -81,12 +77,10 @@ deny[msga] {
 		"alertScore": 7,
 		"failedPaths": [],
 		"fixPaths": fixPaths,
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		}
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-seccompProfile_not_defined(spec, path_to_search){
+seccompProfile_not_defined(spec, path_to_search) if {
 	object.get(spec, path_to_search, "") == ""
 }

--- a/rules/set-seccomp-profile/raw.rego
+++ b/rules/set-seccomp-profile/raw.rego
@@ -1,16 +1,17 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
 
 # Fails if pod does not define seccompProfile
 deny contains msga if {
+	path_to_containers := ["spec", "containers"]
+	path_to_search := ["securityContext", "seccompProfile"]
 	wl := input[_]
 	wl.kind == "Pod"
 	spec := wl.spec
-	path_to_search := ["securityContext", "seccompProfile"]
 	seccompProfile_not_defined(spec, path_to_search)
 
-	path_to_containers := ["spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
 	seccompProfile_not_defined(container, path_to_search)
@@ -30,14 +31,14 @@ deny contains msga if {
 
 # Fails if workload does not define seccompProfile
 deny contains msga if {
-	wl := input[_]
+	path_to_containers := ["spec", "template", "spec", "containers"]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	path_to_search := ["securityContext", "seccompProfile"]
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	spec := wl.spec.template.spec
-	path_to_search := ["securityContext", "seccompProfile"]
 	seccompProfile_not_defined(spec, path_to_search)
 
-	path_to_containers := ["spec", "template", "spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
 	seccompProfile_not_defined(container, path_to_search)
@@ -57,13 +58,13 @@ deny contains msga if {
 
 # Fails if CronJob does not define seccompProfile
 deny contains msga if {
+	path_to_search := ["securityContext", "seccompProfile"]
+	path_to_containers := ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
 	wl := input[_]
 	wl.kind == "CronJob"
 	spec := wl.spec.jobTemplate.spec.template.spec
-	path_to_search := ["securityContext", "seccompProfile"]
 	seccompProfile_not_defined(spec, path_to_search)
 
-	path_to_containers := ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
 	containers := object.get(wl, path_to_containers, [])
 	container := containers[i]
 	seccompProfile_not_defined(container, path_to_search)

--- a/rules/set-supplementalgroups-values/raw.rego
+++ b/rules/set-supplementalgroups-values/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -20,12 +21,12 @@ _deny_supplemental_groups_msg(kind_label, obj, groups, path) := msga if {
 
 # Fails if securityContext.supplementalGroups contains the root group (0)
 deny contains msga if {
+	path := "spec.securityContext.supplementalGroups"
 	# verify the object kind
 	pod := input[_]
 	pod.kind == "Pod"
 
 	groups := pod.spec.securityContext.supplementalGroups
-	path := "spec.securityContext.supplementalGroups"
 	msga := _deny_supplemental_groups_msg("Pod", pod, groups, path)
 }
 
@@ -33,13 +34,13 @@ deny contains msga if {
 
 # Fails if securityContext.supplementalGroups contains the root group (0)
 deny contains msga if {
+	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	path := "spec.template.spec.securityContext.supplementalGroups"
 	# verify the object kind
 	wl := input[_]
-	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	manifest_kind[wl.kind]
 
 	groups := wl.spec.template.spec.securityContext.supplementalGroups
-	path := "spec.template.spec.securityContext.supplementalGroups"
 	msga := _deny_supplemental_groups_msg("Workload", wl, groups, path)
 }
 
@@ -47,11 +48,11 @@ deny contains msga if {
 
 # Fails if securityContext.supplementalGroups contains the root group (0)
 deny contains msga if {
+	path := "spec.jobTemplate.spec.template.spec.securityContext.supplementalGroups"
 	# verify the object kind
 	cj := input[_]
 	cj.kind == "CronJob"
 
 	groups := cj.spec.jobTemplate.spec.template.spec.securityContext.supplementalGroups
-	path := "spec.jobTemplate.spec.template.spec.securityContext.supplementalGroups"
 	msga := _deny_supplemental_groups_msg("CronJob", cj, groups, path)
 }

--- a/rules/set-supplementalgroups-values/raw.rego
+++ b/rules/set-supplementalgroups-values/raw.rego
@@ -1,6 +1,8 @@
 package armo_builtins
 
-_deny_supplemental_groups_msg(kind_label, obj, groups, path) = msga {
+import rego.v1
+
+_deny_supplemental_groups_msg(kind_label, obj, groups, path) := msga if {
 	# regal ignore: use-in-operator
 	groups[_] == 0
 
@@ -17,7 +19,7 @@ _deny_supplemental_groups_msg(kind_label, obj, groups, path) = msga {
 ### POD ###
 
 # Fails if securityContext.supplementalGroups contains the root group (0)
-deny[msga] {
+deny contains msga if {
 	# verify the object kind
 	pod := input[_]
 	pod.kind == "Pod"
@@ -30,7 +32,7 @@ deny[msga] {
 ### WORKLOAD ###
 
 # Fails if securityContext.supplementalGroups contains the root group (0)
-deny[msga] {
+deny contains msga if {
 	# verify the object kind
 	wl := input[_]
 	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
@@ -44,7 +46,7 @@ deny[msga] {
 ### CRONJOB ###
 
 # Fails if securityContext.supplementalGroups contains the root group (0)
-deny[msga] {
+deny contains msga if {
 	# verify the object kind
 	cj := input[_]
 	cj.kind == "CronJob"

--- a/rules/set-sysctls-params/raw.rego
+++ b/rules/set-sysctls-params/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -50,12 +51,12 @@ _deny_sysctls_msg(kind_label, obj, sysctls, path) := msga if {
 
 # Fails if securityContext.sysctls contains values outside the safe list
 deny contains msga if {
+	path := "spec.securityContext.sysctls"
 	# verify the object kind
 	pod := input[_]
 	pod.kind == "Pod"
 
 	sysctls := pod.spec.securityContext.sysctls
-	path := "spec.securityContext.sysctls"
 	msga := _deny_sysctls_msg("Pod", pod, sysctls, path)
 }
 
@@ -63,13 +64,13 @@ deny contains msga if {
 
 # Fails if securityContext.sysctls contains values outside the safe list
 deny contains msga if {
+	path := "spec.template.spec.securityContext.sysctls"
+	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	# verify the object kind
 	wl := input[_]
-	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	manifest_kind[wl.kind]
 
 	sysctls := wl.spec.template.spec.securityContext.sysctls
-	path := "spec.template.spec.securityContext.sysctls"
 	msga := _deny_sysctls_msg("Workload", wl, sysctls, path)
 }
 
@@ -77,11 +78,11 @@ deny contains msga if {
 
 # Fails if securityContext.sysctls contains values outside the safe list
 deny contains msga if {
+	path := "spec.jobTemplate.spec.template.spec.securityContext.sysctls"
 	# verify the object kind
 	cj := input[_]
 	cj.kind == "CronJob"
 
 	sysctls := cj.spec.jobTemplate.spec.template.spec.securityContext.sysctls
-	path := "spec.jobTemplate.spec.template.spec.securityContext.sysctls"
 	msga := _deny_sysctls_msg("CronJob", cj, sysctls, path)
 }

--- a/rules/set-sysctls-params/raw.rego
+++ b/rules/set-sysctls-params/raw.rego
@@ -1,6 +1,8 @@
 package armo_builtins
 
-_builtin_safe_sysctl(name) {
+import rego.v1
+
+_builtin_safe_sysctl(name) if {
 	# NOTE: This set mirrors Kubernetes' safe sysctls. During each
 	# Armo/Kubescape release, compare it with the upstream list in
 	# pkg/kubelet/sysctl/safe_sysctls.go and update any changes.
@@ -21,11 +23,11 @@ _builtin_safe_sysctl(name) {
 	builtin_safe_sysctls[name]
 }
 
-safe_sysctl(name) {
+safe_sysctl(name) if {
 	_builtin_safe_sysctl(name)
 }
 
-_deny_sysctls_msg(kind_label, obj, sysctls, path) = msga {
+_deny_sysctls_msg(kind_label, obj, sysctls, path) := msga if {
 	count(sysctls) > 0
 	unsafe_sysctls := [sysctl.name |
 		sysctl := sysctls[_]
@@ -47,7 +49,7 @@ _deny_sysctls_msg(kind_label, obj, sysctls, path) = msga {
 ### POD ###
 
 # Fails if securityContext.sysctls contains values outside the safe list
-deny[msga] {
+deny contains msga if {
 	# verify the object kind
 	pod := input[_]
 	pod.kind == "Pod"
@@ -60,10 +62,10 @@ deny[msga] {
 ### WORKLOAD ###
 
 # Fails if securityContext.sysctls contains values outside the safe list
-deny[msga] {
+deny contains msga if {
 	# verify the object kind
 	wl := input[_]
-	manifest_kind := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+	manifest_kind := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	manifest_kind[wl.kind]
 
 	sysctls := wl.spec.template.spec.securityContext.sysctls
@@ -74,7 +76,7 @@ deny[msga] {
 ### CRONJOB ###
 
 # Fails if securityContext.sysctls contains values outside the safe list
-deny[msga] {
+deny contains msga if {
 	# verify the object kind
 	cj := input[_]
 	cj.kind == "CronJob"

--- a/rules/sudo-in-container-entrypoint/raw.rego
+++ b/rules/sudo-in-container-entrypoint/raw.rego
@@ -1,12 +1,13 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	start_of_path := "spec."
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
-	start_of_path := "spec."
 	result := is_sudo_entrypoint(container, start_of_path, i)
 	msga := {
 		"alertMessage": sprintf("container: %v in pod: %v  have sudo in entrypoint", [container.name, pod.metadata.name]),
@@ -20,11 +21,11 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	start_of_path := "spec.template.spec."
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
-	start_of_path := "spec.template.spec."
 	result := is_sudo_entrypoint(container, start_of_path, i)
 	msga := {
 		"alertMessage": sprintf("container: %v in %v: %v  have sudo in entrypoint", [container.name, wl.kind, wl.metadata.name]),
@@ -38,10 +39,10 @@ deny contains msga if {
 }
 
 deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
 	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
-	start_of_path := "spec.jobTemplate.spec.template.spec."
 	result := is_sudo_entrypoint(container, start_of_path, i)
 	msga := {
 		"alertMessage": sprintf("container: %v in cronjob: %v  have sudo in entrypoint", [container.name, wl.metadata.name]),

--- a/rules/system-authenticated-allowed-to-take-over-cluster/raw.rego
+++ b/rules/system-authenticated-allowed-to-take-over-cluster/raw.rego
@@ -1,32 +1,31 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
-deny[msga] {
-    subjectVector := input[_]
+deny contains msga if {
+	subjectVector := input[_]
 
 	rolebinding := subjectVector.relatedObjects[j]
 	endswith(rolebinding.kind, "Binding")
 
+	subject := rolebinding.subjects[k]
 
-    subject := rolebinding.subjects[k]
-    # Check if the subject is gourp
-    subject.kind == "Group"
-    # Check if the subject is system:authenticated
-    subject.name == "system:authenticated"
+	# Check if the subject is gourp
+	subject.kind == "Group"
 
+	# Check if the subject is system:authenticated
+	subject.name == "system:authenticated"
 
-    # Find the bound roles
+	# Find the bound roles
 	role := subjectVector.relatedObjects[i]
 	endswith(role.kind, "Role")
 
-    # Check if the role and rolebinding bound
-    is_same_role_and_binding(role, rolebinding)
+	# Check if the role and rolebinding bound
+	is_same_role_and_binding(role, rolebinding)
 
-
-    # Check if the role has access to workloads, exec, attach, portforward
+	# Check if the role has access to workloads, exec, attach, portforward
 	rule := role.rules[p]
-    rule.resources[l] in ["*","pods", "pods/exec", "pods/attach", "pods/portforward","deployments","statefulset","daemonset","jobs","cronjobs","nodes","secrets"]
+	rule.resources[l] in ["*", "pods", "pods/exec", "pods/attach", "pods/portforward", "deployments", "statefulset", "daemonset", "jobs", "cronjobs", "nodes", "secrets"]
 
 	finalpath := array.concat([""], [
 		sprintf("relatedObjects[%d].subjects[%d]", [j, k]),
@@ -42,24 +41,24 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"alertObject": {
 			"k8sApiObjects": [],
-            "externalObjects" : subjectVector
+			"externalObjects": subjectVector,
 		},
 	}
 }
 
-is_same_role_and_binding(role, rolebinding) {
-    rolebinding.kind == "RoleBinding"
-    role.kind == "Role"
-    rolebinding.metadata.namespace == role.metadata.namespace
-    rolebinding.roleRef.name == role.metadata.name
-    rolebinding.roleRef.kind == role.kind
-    startswith(role.apiVersion, rolebinding.roleRef.apiGroup)
+is_same_role_and_binding(role, rolebinding) if {
+	rolebinding.kind == "RoleBinding"
+	role.kind == "Role"
+	rolebinding.metadata.namespace == role.metadata.namespace
+	rolebinding.roleRef.name == role.metadata.name
+	rolebinding.roleRef.kind == role.kind
+	startswith(role.apiVersion, rolebinding.roleRef.apiGroup)
 }
 
-is_same_role_and_binding(role, rolebinding) {
-    rolebinding.kind == "ClusterRoleBinding"
-    role.kind == "ClusterRole"
-    rolebinding.roleRef.name == role.metadata.name
-    rolebinding.roleRef.kind == role.kind
-    startswith(role.apiVersion, rolebinding.roleRef.apiGroup)
+is_same_role_and_binding(role, rolebinding) if {
+	rolebinding.kind == "ClusterRoleBinding"
+	role.kind == "ClusterRole"
+	rolebinding.roleRef.name == role.metadata.name
+	rolebinding.roleRef.kind == role.kind
+	startswith(role.apiVersion, rolebinding.roleRef.apiGroup)
 }

--- a/rules/system-authenticated-allowed-to-take-over-cluster/raw.rego
+++ b/rules/system-authenticated-allowed-to-take-over-cluster/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1

--- a/rules/unauthenticated-service/raw.rego
+++ b/rules/unauthenticated-service/raw.rego
@@ -1,7 +1,6 @@
 package armo_builtins
 
-import future.keywords.contains
-import future.keywords.if
+import rego.v1
 
 deny contains msga if {
 	service := input[_]
@@ -35,8 +34,6 @@ has_unauthenticated_service(service_name, namespace, service_scan_result) if {
 	service_scan_result.spec.ports[_].authenticated == false
 }
 
-
-
 wl_connected_to_service(wl, svc) if {
 	count({x | svc.spec.selector[x] == wl.metadata.labels[x]}) == count(svc.spec.selector)
 }
@@ -45,22 +42,21 @@ wl_connected_to_service(wl, svc) if {
 	wl.spec.selector.matchLabels == svc.spec.selector
 }
 
-
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	metadata1.namespace == metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	not metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata2.namespace
 	metadata1.namespace == "default"
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	metadata2.namespace == "default"
 }

--- a/rules/unauthenticated-service/raw.rego
+++ b/rules/unauthenticated-service/raw.rego
@@ -1,13 +1,14 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
 	service := input[_]
 	service.kind == "Service"
 
 	wl := input[_]
-	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Pod", "Job", "CronJob"}
 	spec_template_spec_patterns[wl.kind]
 	is_same_namespace(wl, service)
 	wl_connected_to_service(wl, service)

--- a/rules/validate-kubelet-tls-configuration-updated/raw.rego
+++ b/rules/validate-kubelet-tls-configuration-updated/raw.rego
@@ -1,8 +1,10 @@
 package armo_builtins
 
+import rego.v1
+
 # CIS 4.2.10 https://workbench.cisecurity.org/sections/1126668/recommendations/1838657
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -27,7 +29,7 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -61,7 +63,7 @@ deny[msga] {
 	}
 }
 
-deny[msga] {
+deny contains msga if {
 	obj := input[_]
 	is_kubelet_info(obj)
 
@@ -98,7 +100,7 @@ deny[msga] {
 	}
 }
 
-extract_failed_object(resultList, keyField) = failed_objects {
+extract_failed_object(resultList, keyField) := failed_objects if {
 	failed_objects_array = [mapped |
 		singleResult := resultList[_]
 		mapped := singleResult[keyField]
@@ -107,7 +109,7 @@ extract_failed_object(resultList, keyField) = failed_objects {
 	failed_objects = concat(", ", failed_objects_array)
 }
 
-not_set_arguments(cmd) = result {
+not_set_arguments(cmd) := result if {
 	wanted = [
 		["--tls-cert-file", "tlsCertFile"],
 		["--tls-private-key-file", "tlsPrivateKeyFile"],
@@ -121,7 +123,7 @@ not_set_arguments(cmd) = result {
 	]
 }
 
-not_set_props(yamlConfig) = result {
+not_set_props(yamlConfig) := result if {
 	wanted = [
 		["tlsCertFile", "--tls-cert-file"],
 		["tlsPrivateKeyFile", "--tls-private-key-file"],
@@ -135,7 +137,7 @@ not_set_props(yamlConfig) = result {
 	]
 }
 
-is_kubelet_info(obj) {
+is_kubelet_info(obj) if {
 	obj.kind == "KubeletInfo"
 	obj.apiVersion == "hostdata.kubescape.cloud/v1beta0"
 }

--- a/rules/validate-kubelet-tls-configuration-updated/raw.rego
+++ b/rules/validate-kubelet-tls-configuration-updated/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1

--- a/rules/verify-image-signature/raw.rego
+++ b/rules/verify-image-signature/raw.rego
@@ -1,13 +1,14 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
 
-    pod := input[_]
-    pod.kind == "Pod"
+deny contains msga if {
+	pod := input[_]
+	pod.kind == "Pod"
 	container := pod.spec.containers[i]
 
-    verified_keys := [trusted_key | trusted_key = data.postureControlInputs.trustedCosignPublicKeys[_]; cosign.verify(container.image, trusted_key)]
-    count(verified_keys) == 0
+	verified_keys := [trusted_key | trusted_key = data.postureControlInputs.trustedCosignPublicKeys[_]; cosign.verify(container.image, trusted_key)]
+	count(verified_keys) == 0
 
 	path := sprintf("spec.containers[%v].image", [i])
 
@@ -18,56 +19,49 @@ deny[msga] {
 		"reviewPaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [pod]
-		},
+		"alertObject": {"k8sApiObjects": [pod]},
 	}
 }
 
-deny[msga] {
-    wl := input[_]
-	spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+deny contains msga if {
+	wl := input[_]
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	spec_template_spec_patterns[wl.kind]
-    container := wl.spec.template.spec.containers[i]
+	container := wl.spec.template.spec.containers[i]
 
 	verified_keys := [trusted_key | trusted_key = data.postureControlInputs.trustedCosignPublicKeys[_]; cosign.verify(container.image, trusted_key)]
-    count(verified_keys) == 0
+	count(verified_keys) == 0
 
 	path := sprintf("spec.template.spec.containers[%v].image", [i])
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("signature not verified for image: %v", [container.image]),
 		"alertScore": 7,
 		"fixPaths": [],
 		"reviewPaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		},
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
 
-
-deny[msga] {
+deny contains msga if {
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 
-    verified_keys := [trusted_key | trusted_key = data.postureControlInputs.trustedCosignPublicKeys[_]; cosign.verify(container.image, trusted_key)]
-    count(verified_keys) == 0
+	verified_keys := [trusted_key | trusted_key = data.postureControlInputs.trustedCosignPublicKeys[_]; cosign.verify(container.image, trusted_key)]
+	count(verified_keys) == 0
 
 	path := sprintf("spec.jobTemplate.spec.template.spec.containers[%v].image", [i])
 
-    msga := {
+	msga := {
 		"alertMessage": sprintf("signature not verified for image: %v", [container.image]),
 		"alertScore": 7,
 		"fixPaths": [],
 		"reviewPaths": [path],
 		"failedPaths": [path],
 		"packagename": "armo_builtins",
-		"alertObject": {
-			"k8sApiObjects": [wl]
-		},
+		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }

--- a/rules/verify-image-signature/raw.rego
+++ b/rules/verify-image-signature/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -24,8 +25,8 @@ deny contains msga if {
 }
 
 deny contains msga if {
-	wl := input[_]
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 

--- a/rules/workload-mounted-configmap/raw.rego
+++ b/rules/workload-mounted-configmap/raw.rego
@@ -1,6 +1,8 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	resource := input[_]
 	volumes_path := get_volumes_path(resource)
 	volumes := object.get(resource, volumes_path, [])
@@ -17,84 +19,75 @@ deny[msga] {
 	container := containers[j]
 	container.volumeMounts
 
- 	# check if volume is mounted
+	# check if volume is mounted
 	container.volumeMounts[k].name == volume.name
 
 	failedPaths := sprintf("%s[%d].volumeMounts[%d]", [concat(".", containers_path), j, k])
-
 
 	msga := {
 		"alertMessage": sprintf("%v: %v has mounted configMap", [resource.kind, resource.metadata.name]),
 		"packagename": "armo_builtins",
 		"deletePaths": [failedPaths],
 		"failedPaths": [failedPaths],
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		},
-        "relatedObjects": [{
-            "object": configMap
-        }]
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [resource]},
+		"relatedObjects": [{"object": configMap}],
 	}
 }
 
-
-
 # get_containers_path - get resource containers paths for  {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-get_containers_path(resource) := result {
-	resource_kinds := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+get_containers_path(resource) := result if {
+	resource_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	resource_kinds[resource.kind]
 	result = ["spec", "template", "spec", "containers"]
 }
 
 # get_containers_path - get resource containers paths for "Pod"
-get_containers_path(resource) := result {
+get_containers_path(resource) := result if {
 	resource.kind == "Pod"
 	result = ["spec", "containers"]
 }
 
 # get_containers_path - get resource containers paths for  "CronJob"
-get_containers_path(resource) := result {
+get_containers_path(resource) := result if {
 	resource.kind == "CronJob"
 	result = ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
 }
 
 # get_volume_path - get resource volumes paths for {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-get_volumes_path(resource) := result {
-	resource_kinds := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+get_volumes_path(resource) := result if {
+	resource_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	resource_kinds[resource.kind]
 	result = ["spec", "template", "spec", "volumes"]
 }
 
 # get_volumes_path - get resource volumes paths for "Pod"
-get_volumes_path(resource) := result {
+get_volumes_path(resource) := result if {
 	resource.kind == "Pod"
 	result = ["spec", "volumes"]
 }
 
 # get_volumes_path - get resource volumes paths for "CronJob"
-get_volumes_path(resource) := result {
+get_volumes_path(resource) := result if {
 	resource.kind == "CronJob"
 	result = ["spec", "jobTemplate", "spec", "template", "spec", "volumes"]
 }
 
-
-
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	metadata1.namespace == metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	not metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata2.namespace
 	metadata1.namespace == "default"
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	metadata2.namespace == "default"
 }

--- a/rules/workload-mounted-configmap/raw.rego
+++ b/rules/workload-mounted-configmap/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -17,7 +18,6 @@ deny contains msga if {
 	containers_path := get_containers_path(resource)
 	containers := object.get(resource, containers_path, [])
 	container := containers[j]
-	container.volumeMounts
 
 	# check if volume is mounted
 	container.volumeMounts[k].name == volume.name

--- a/rules/workload-mounted-pvc/raw.rego
+++ b/rules/workload-mounted-pvc/raw.rego
@@ -1,6 +1,8 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	resource := input[_]
 	volumes_path := get_volumes_path(resource)
 	volumes := object.get(resource, volumes_path, [])
@@ -17,7 +19,7 @@ deny[msga] {
 	container := containers[j]
 	container.volumeMounts
 
- 	# check if volume is mounted
+	# check if volume is mounted
 	container.volumeMounts[k].name == volume.name
 
 	failedPaths := sprintf("%s[%d].volumeMounts[%d]", [concat(".", containers_path), j, k])
@@ -27,72 +29,65 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"deletePaths": [failedPaths],
 		"failedPaths": [failedPaths],
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		},
-        "relatedObjects": [{
-            "object": PVC
-        }]
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [resource]},
+		"relatedObjects": [{"object": PVC}],
 	}
 }
 
-
 # get_containers_path - get resource containers paths for  {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-get_containers_path(resource) := result {
-	resource_kinds := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+get_containers_path(resource) := result if {
+	resource_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	resource_kinds[resource.kind]
 	result = ["spec", "template", "spec", "containers"]
 }
 
 # get_containers_path - get resource containers paths for "Pod"
-get_containers_path(resource) := result {
+get_containers_path(resource) := result if {
 	resource.kind == "Pod"
 	result = ["spec", "containers"]
 }
 
 # get_containers_path - get resource containers paths for  "CronJob"
-get_containers_path(resource) := result {
+get_containers_path(resource) := result if {
 	resource.kind == "CronJob"
 	result = ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
 }
 
 # get_volume_path - get resource volumes paths for {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-get_volumes_path(resource) := result {
-	resource_kinds := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+get_volumes_path(resource) := result if {
+	resource_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	resource_kinds[resource.kind]
 	result = ["spec", "template", "spec", "volumes"]
 }
 
 # get_volumes_path - get resource volumes paths for "Pod"
-get_volumes_path(resource) := result {
+get_volumes_path(resource) := result if {
 	resource.kind == "Pod"
 	result = ["spec", "volumes"]
 }
 
 # get_volumes_path - get resource volumes paths for "CronJob"
-get_volumes_path(resource) := result {
+get_volumes_path(resource) := result if {
 	resource.kind == "CronJob"
 	result = ["spec", "jobTemplate", "spec", "template", "spec", "volumes"]
 }
 
-
-
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	metadata1.namespace == metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	not metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata2.namespace
 	metadata1.namespace == "default"
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	metadata2.namespace == "default"
 }

--- a/rules/workload-mounted-pvc/raw.rego
+++ b/rules/workload-mounted-pvc/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -17,7 +18,6 @@ deny contains msga if {
 	containers_path := get_containers_path(resource)
 	containers := object.get(resource, containers_path, [])
 	container := containers[j]
-	container.volumeMounts
 
 	# check if volume is mounted
 	container.volumeMounts[k].name == volume.name

--- a/rules/workload-mounted-secrets/raw.rego
+++ b/rules/workload-mounted-secrets/raw.rego
@@ -1,6 +1,8 @@
 package armo_builtins
 
-deny[msga] {
+import rego.v1
+
+deny contains msga if {
 	resource := input[_]
 	volumes_path := get_volumes_path(resource)
 	volumes := object.get(resource, volumes_path, [])
@@ -17,7 +19,7 @@ deny[msga] {
 	container := containers[j]
 	container.volumeMounts
 
- 	# check if volume is mounted
+	# check if volume is mounted
 	container.volumeMounts[k].name == volume.name
 
 	failedPaths := sprintf("%s[%d].volumeMounts[%d]", [concat(".", containers_path), j, k])
@@ -27,71 +29,65 @@ deny[msga] {
 		"packagename": "armo_builtins",
 		"deletePaths": [failedPaths],
 		"failedPaths": [failedPaths],
-		"fixPaths":[],
-		"alertObject": {
-			"k8sApiObjects": [resource]
-		},
-        "relatedObjects": [{
-            "object": secret
-        }]
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [resource]},
+		"relatedObjects": [{"object": secret}],
 	}
 }
 
 # get_volume_path - get resource volumes paths for {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-get_volumes_path(resource) := result {
-	resource_kinds := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+get_volumes_path(resource) := result if {
+	resource_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	resource_kinds[resource.kind]
 	result = ["spec", "template", "spec", "volumes"]
 }
 
 # get_containers_path - get resource containers paths for  {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-get_containers_path(resource) := result {
-	resource_kinds := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
+get_containers_path(resource) := result if {
+	resource_kinds := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	resource_kinds[resource.kind]
 	result = ["spec", "template", "spec", "containers"]
 }
 
 # get_containers_path - get resource containers paths for "Pod"
-get_containers_path(resource) := result {
+get_containers_path(resource) := result if {
 	resource.kind == "Pod"
 	result = ["spec", "containers"]
 }
 
 # get_containers_path - get resource containers paths for  "CronJob"
-get_containers_path(resource) := result {
+get_containers_path(resource) := result if {
 	resource.kind == "CronJob"
 	result = ["spec", "jobTemplate", "spec", "template", "spec", "containers"]
 }
 
 # get_volumes_path - get resource volumes paths for "Pod"
-get_volumes_path(resource) := result {
+get_volumes_path(resource) := result if {
 	resource.kind == "Pod"
 	result = ["spec", "volumes"]
 }
 
 # get_volumes_path - get resource volumes paths for "CronJob"
-get_volumes_path(resource) := result {
+get_volumes_path(resource) := result if {
 	resource.kind == "CronJob"
 	result = ["spec", "jobTemplate", "spec", "template", "spec", "volumes"]
 }
 
-
-
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	metadata1.namespace == metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	not metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata2.namespace
 	metadata1.namespace == "default"
 }
 
-is_same_namespace(metadata1, metadata2) {
+is_same_namespace(metadata1, metadata2) if {
 	not metadata1.namespace
 	metadata2.namespace == "default"
 }

--- a/rules/workload-mounted-secrets/raw.rego
+++ b/rules/workload-mounted-secrets/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -17,7 +18,6 @@ deny contains msga if {
 	containers_path := get_containers_path(resource)
 	containers := object.get(resource, containers_path, [])
 	container := containers[j]
-	container.volumeMounts
 
 	# check if volume is mounted
 	container.volumeMounts[k].name == volume.name
@@ -62,6 +62,7 @@ get_containers_path(resource) := result if {
 }
 
 # get_volumes_path - get resource volumes paths for "Pod"
+# regal ignore:messy-rule
 get_volumes_path(resource) := result if {
 	resource.kind == "Pod"
 	result = ["spec", "volumes"]

--- a/rules/workload-with-administrative-roles/filter.rego
+++ b/rules/workload-with-administrative-roles/filter.rego
@@ -1,32 +1,31 @@
 package armo_builtins
 
-deny[msga] {
-    wl := input[_]
-    start_of_path := get_beginning_of_path(wl)
+import rego.v1
 
-    msga := {
-        "alertMessage": sprintf("%v: %v in the following namespace: %v mounts service account tokens by default", [wl.kind, wl.metadata.name, wl.metadata.namespace]),
-        "packagename": "armo_builtins",
-        "alertScore": 9,
-        "alertObject": {
-            "k8sApiObjects": [wl]
-        },
-    }
+deny contains msga if {
+	wl := input[_]
+	start_of_path := get_beginning_of_path(wl)
+
+	msga := {
+		"alertMessage": sprintf("%v: %v in the following namespace: %v mounts service account tokens by default", [wl.kind, wl.metadata.name, wl.metadata.namespace]),
+		"packagename": "armo_builtins",
+		"alertScore": 9,
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
 }
 
-
-get_beginning_of_path(workload) = start_of_path {
-    spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-    spec_template_spec_patterns[workload.kind]
-    start_of_path := ["spec", "template", "spec"]
+get_beginning_of_path(workload) := start_of_path if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	spec_template_spec_patterns[workload.kind]
+	start_of_path := ["spec", "template", "spec"]
 }
 
-get_beginning_of_path(workload) = start_of_path {
-    workload.kind == "Pod"
-    start_of_path := ["spec"]
+get_beginning_of_path(workload) := start_of_path if {
+	workload.kind == "Pod"
+	start_of_path := ["spec"]
 }
 
-get_beginning_of_path(workload) = start_of_path {
-    workload.kind == "CronJob"
-    start_of_path := ["spec", "jobTemplate", "spec", "template", "spec"]
+get_beginning_of_path(workload) := start_of_path if {
+	workload.kind == "CronJob"
+	start_of_path := ["spec", "jobTemplate", "spec", "template", "spec"]
 }

--- a/rules/workload-with-administrative-roles/filter.rego
+++ b/rules/workload-with-administrative-roles/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1

--- a/rules/workload-with-administrative-roles/raw.rego
+++ b/rules/workload-with-administrative-roles/raw.rego
@@ -1,129 +1,123 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
-deny[msga] {
-    wl := input[_]
-    start_of_path := get_start_of_path(wl)
-    wl_spec := object.get(wl, start_of_path, [])
+deny contains msga if {
+	wl := input[_]
+	start_of_path := get_start_of_path(wl)
+	wl_spec := object.get(wl, start_of_path, [])
 
-    # get service account wl is using
-    sa := input[_]
-    sa.kind == "ServiceAccount"
-    is_same_sa(wl_spec, sa.metadata, wl.metadata)
+	# get service account wl is using
+	sa := input[_]
+	sa.kind == "ServiceAccount"
+	is_same_sa(wl_spec, sa.metadata, wl.metadata)
 
-    # check service account token is mounted
-    is_sa_auto_mounted(wl_spec, sa)
+	# check service account token is mounted
+	is_sa_auto_mounted(wl_spec, sa)
 
-    # check if sa has administrative roles
-    role := input[_]
-    role.kind in ["Role", "ClusterRole"]
-    is_administrative_role(role)
+	# check if sa has administrative roles
+	role := input[_]
+	role.kind in ["Role", "ClusterRole"]
+	is_administrative_role(role)
 
-    rolebinding := input[_]
-    rolebinding.kind in ["RoleBinding", "ClusterRoleBinding"]
-    rolebinding.roleRef.name == role.metadata.name
-    rolebinding.subjects[j].kind == "ServiceAccount"
-    rolebinding.subjects[j].name == sa.metadata.name
-    rolebinding.subjects[j].namespace == sa.metadata.namespace
+	rolebinding := input[_]
+	rolebinding.kind in ["RoleBinding", "ClusterRoleBinding"]
+	rolebinding.roleRef.name == role.metadata.name
+	rolebinding.subjects[j].kind == "ServiceAccount"
+	rolebinding.subjects[j].name == sa.metadata.name
+	rolebinding.subjects[j].namespace == sa.metadata.namespace
 
-    reviewPath := "roleRef"
-    deletePath := sprintf("subjects[%d]", [j])
+	reviewPath := "roleRef"
+	deletePath := sprintf("subjects[%d]", [j])
 
-    msga := {
-        "alertMessage": sprintf("%v: %v in the following namespace: %v has administrative roles", [wl.kind, wl.metadata.name, wl.metadata.namespace]),
-        "packagename": "armo_builtins",
-        "alertScore": 9,
-        "alertObject": {
-            "k8sApiObjects": [wl]
-        },
-        "relatedObjects": [{
-            "object": sa,
-        },
-        {
-            "object": rolebinding,
-            "reviewPaths": [reviewPath],
-            "deletePaths": [deletePath],
-        },
-        {
-            "object": role,
-        },]
-    }
+	msga := {
+		"alertMessage": sprintf("%v: %v in the following namespace: %v has administrative roles", [wl.kind, wl.metadata.name, wl.metadata.namespace]),
+		"packagename": "armo_builtins",
+		"alertScore": 9,
+		"alertObject": {"k8sApiObjects": [wl]},
+		"relatedObjects": [
+			{"object": sa},
+			{
+				"object": rolebinding,
+				"reviewPaths": [reviewPath],
+				"deletePaths": [deletePath],
+			},
+			{"object": role},
+		],
+	}
 }
 
-
-get_start_of_path(workload) = start_of_path {
-    spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-    spec_template_spec_patterns[workload.kind]
-    start_of_path := ["spec", "template", "spec"]
+get_start_of_path(workload) := start_of_path if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	spec_template_spec_patterns[workload.kind]
+	start_of_path := ["spec", "template", "spec"]
 }
 
-get_start_of_path(workload) = start_of_path {
-    workload.kind == "Pod"
-    start_of_path := ["spec"]
+get_start_of_path(workload) := start_of_path if {
+	workload.kind == "Pod"
+	start_of_path := ["spec"]
 }
 
-get_start_of_path(workload) = start_of_path {
-    workload.kind == "CronJob"
-    start_of_path := ["spec", "jobTemplate", "spec", "template", "spec"]
+get_start_of_path(workload) := start_of_path if {
+	workload.kind == "CronJob"
+	start_of_path := ["spec", "jobTemplate", "spec", "template", "spec"]
 }
 
+is_sa_auto_mounted(wl_spec, sa) if {
+	# automountServiceAccountToken not in pod spec
+	not wl_spec.automountServiceAccountToken == false
+	not wl_spec.automountServiceAccountToken == true
 
-is_sa_auto_mounted(wl_spec, sa)    {
-    # automountServiceAccountToken not in pod spec
-    not wl_spec.automountServiceAccountToken == false
-    not wl_spec.automountServiceAccountToken == true
-
-    not sa.automountServiceAccountToken == false
+	not sa.automountServiceAccountToken == false
 }
 
-is_sa_auto_mounted(wl_spec, sa)  {
-    # automountServiceAccountToken set to true in pod spec
-    wl_spec.automountServiceAccountToken == true
+is_sa_auto_mounted(wl_spec, sa) if {
+	# automountServiceAccountToken set to true in pod spec
+	wl_spec.automountServiceAccountToken == true
 }
 
-
-is_same_sa(wl_spec, sa_metadata, wl_metadata) {
-    wl_spec.serviceAccountName == sa_metadata.name
-    is_same_namespace(sa_metadata , wl_metadata)
+is_same_sa(wl_spec, sa_metadata, wl_metadata) if {
+	wl_spec.serviceAccountName == sa_metadata.name
+	is_same_namespace(sa_metadata, wl_metadata)
 }
 
-is_same_sa(wl_spec, sa_metadata, wl_metadata) {
-    not wl_spec.serviceAccountName 
-    sa_metadata.name == "default"
-    is_same_namespace(sa_metadata , wl_metadata)
+is_same_sa(wl_spec, sa_metadata, wl_metadata) if {
+	not wl_spec.serviceAccountName
+	sa_metadata.name == "default"
+	is_same_namespace(sa_metadata, wl_metadata)
 }
 
 # is_same_namespace supports cases where ns is not configured in the metadata
 # for yaml scans
-is_same_namespace(metadata1, metadata2) {
-    metadata1.namespace == metadata2.namespace
+is_same_namespace(metadata1, metadata2) if {
+	metadata1.namespace == metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
-    not metadata1.namespace
-    not metadata2.namespace
+is_same_namespace(metadata1, metadata2) if {
+	not metadata1.namespace
+	not metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
-    not metadata2.namespace
-    metadata1.namespace == "default"
+is_same_namespace(metadata1, metadata2) if {
+	not metadata2.namespace
+	metadata1.namespace == "default"
 }
 
-is_same_namespace(metadata1, metadata2) {
-    not metadata1.namespace
-    metadata2.namespace == "default"
+is_same_namespace(metadata1, metadata2) if {
+	not metadata1.namespace
+	metadata2.namespace == "default"
 }
 
+is_administrative_role(role) if {
+	administrative_resources := ["*"]
+	administrative_verbs := ["*"]
+	administrative_api_groups := ["", "*"]
 
-is_administrative_role(role){
-    administrative_resources := ["*"]
-    administrative_verbs := ["*"]
-    administrative_api_groups := ["", "*"]
-    
-    administrative_rule := [rule | rule = role.rules[i] ; 
-                        rule.resources[a] in administrative_resources ; 
-                        rule.verbs[b] in administrative_verbs ; 
-                        rule.apiGroups[c] in administrative_api_groups]
-    count(administrative_rule) > 0
+	administrative_rule := [rule |
+		rule = role.rules[i]
+		rule.resources[a] in administrative_resources
+		rule.verbs[b] in administrative_verbs
+		rule.apiGroups[c] in administrative_api_groups
+	]
+	count(administrative_rule) > 0
 }

--- a/rules/workload-with-administrative-roles/raw.rego
+++ b/rules/workload-with-administrative-roles/raw.rego
@@ -1,8 +1,10 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
 
 deny contains msga if {
+	reviewPath := "roleRef"
 	wl := input[_]
 	start_of_path := get_start_of_path(wl)
 	wl_spec := object.get(wl, start_of_path, [])
@@ -27,7 +29,6 @@ deny contains msga if {
 	rolebinding.subjects[j].name == sa.metadata.name
 	rolebinding.subjects[j].namespace == sa.metadata.namespace
 
-	reviewPath := "roleRef"
 	deletePath := sprintf("subjects[%d]", [j])
 
 	msga := {

--- a/rules/workload-with-cluster-takeover-roles/filter.rego
+++ b/rules/workload-with-cluster-takeover-roles/filter.rego
@@ -1,32 +1,31 @@
 package armo_builtins
 
-deny[msga] {
-    wl := input[_]
-    start_of_path := get_beginning_of_path(wl)
+import rego.v1
 
-    msga := {
-        "alertMessage": sprintf("%v: %v in the following namespace: %v mounts service account tokens by default", [wl.kind, wl.metadata.name, wl.metadata.namespace]),
-        "packagename": "armo_builtins",
-        "alertScore": 9,
-        "alertObject": {
-            "k8sApiObjects": [wl]
-        },
-    }
+deny contains msga if {
+	wl := input[_]
+	start_of_path := get_beginning_of_path(wl)
+
+	msga := {
+		"alertMessage": sprintf("%v: %v in the following namespace: %v mounts service account tokens by default", [wl.kind, wl.metadata.name, wl.metadata.namespace]),
+		"packagename": "armo_builtins",
+		"alertScore": 9,
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
 }
 
-
-get_beginning_of_path(workload) = start_of_path {
-    spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-    spec_template_spec_patterns[workload.kind]
-    start_of_path := ["spec", "template", "spec"]
+get_beginning_of_path(workload) := start_of_path if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	spec_template_spec_patterns[workload.kind]
+	start_of_path := ["spec", "template", "spec"]
 }
 
-get_beginning_of_path(workload) = start_of_path {
-    workload.kind == "Pod"
-    start_of_path := ["spec"]
+get_beginning_of_path(workload) := start_of_path if {
+	workload.kind == "Pod"
+	start_of_path := ["spec"]
 }
 
-get_beginning_of_path(workload) = start_of_path {
-    workload.kind == "CronJob"
-    start_of_path := ["spec", "jobTemplate", "spec", "template", "spec"]
+get_beginning_of_path(workload) := start_of_path if {
+	workload.kind == "CronJob"
+	start_of_path := ["spec", "jobTemplate", "spec", "template", "spec"]
 }

--- a/rules/workload-with-cluster-takeover-roles/filter.rego
+++ b/rules/workload-with-cluster-takeover-roles/filter.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1

--- a/rules/workload-with-cluster-takeover-roles/raw.rego
+++ b/rules/workload-with-cluster-takeover-roles/raw.rego
@@ -1,143 +1,139 @@
 package armo_builtins
 
-import future.keywords.in
+import rego.v1
 
-deny[msga] {
-    wl := input[_]
-    start_of_path := get_start_of_path(wl)
-    wl_spec := object.get(wl, start_of_path, [])
+deny contains msga if {
+	wl := input[_]
+	start_of_path := get_start_of_path(wl)
+	wl_spec := object.get(wl, start_of_path, [])
 
-    # get service account wl is using
-    sa := input[_]
-    sa.kind == "ServiceAccount"
-    is_same_sa(wl_spec, sa.metadata, wl.metadata)
+	# get service account wl is using
+	sa := input[_]
+	sa.kind == "ServiceAccount"
+	is_same_sa(wl_spec, sa.metadata, wl.metadata)
 
-    # check service account token is mounted
-    is_sa_auto_mounted(wl_spec, sa)
+	# check service account token is mounted
+	is_sa_auto_mounted(wl_spec, sa)
 
-    # check if sa has cluster takeover roles
-    role := input[_]
-    role.kind in ["Role", "ClusterRole"]
-    is_takeover_role(role)
+	# check if sa has cluster takeover roles
+	role := input[_]
+	role.kind in ["Role", "ClusterRole"]
+	is_takeover_role(role)
 
-    rolebinding := input[_]
-	rolebinding.kind in ["RoleBinding", "ClusterRoleBinding"] 
-    rolebinding.roleRef.name == role.metadata.name
-    rolebinding.roleRef.kind == role.kind
-    rolebinding.subjects[j].kind == "ServiceAccount"
-    rolebinding.subjects[j].name == sa.metadata.name
-    rolebinding.subjects[j].namespace == sa.metadata.namespace
+	rolebinding := input[_]
+	rolebinding.kind in ["RoleBinding", "ClusterRoleBinding"]
+	rolebinding.roleRef.name == role.metadata.name
+	rolebinding.roleRef.kind == role.kind
+	rolebinding.subjects[j].kind == "ServiceAccount"
+	rolebinding.subjects[j].name == sa.metadata.name
+	rolebinding.subjects[j].namespace == sa.metadata.namespace
 
-    deletePath := sprintf("subjects[%d]", [j])
+	deletePath := sprintf("subjects[%d]", [j])
 
-    msga := {
-        "alertMessage": sprintf("%v: %v in the following namespace: %v has cluster takeover roles", [wl.kind, wl.metadata.name, wl.metadata.namespace]),
-        "packagename": "armo_builtins",
-        "alertScore": 9,
-        "alertObject": {
-            "k8sApiObjects": [wl]
-        },
-        "relatedObjects": [{
-            "object": sa,
-        },
-        {
-            "object": rolebinding,
-            "deletePaths": [deletePath],
-        },
-        {
-            "object": role,
-        },]
-    }
+	msga := {
+		"alertMessage": sprintf("%v: %v in the following namespace: %v has cluster takeover roles", [wl.kind, wl.metadata.name, wl.metadata.namespace]),
+		"packagename": "armo_builtins",
+		"alertScore": 9,
+		"alertObject": {"k8sApiObjects": [wl]},
+		"relatedObjects": [
+			{"object": sa},
+			{
+				"object": rolebinding,
+				"deletePaths": [deletePath],
+			},
+			{"object": role},
+		],
+	}
 }
 
-
-get_start_of_path(workload) = start_of_path {
-    spec_template_spec_patterns := {"Deployment","ReplicaSet","DaemonSet","StatefulSet","Job"}
-    spec_template_spec_patterns[workload.kind]
-    start_of_path := ["spec", "template", "spec"]
+get_start_of_path(workload) := start_of_path if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	spec_template_spec_patterns[workload.kind]
+	start_of_path := ["spec", "template", "spec"]
 }
 
-get_start_of_path(workload) = start_of_path {
-    workload.kind == "Pod"
-    start_of_path := ["spec"]
+get_start_of_path(workload) := start_of_path if {
+	workload.kind == "Pod"
+	start_of_path := ["spec"]
 }
 
-get_start_of_path(workload) = start_of_path {
-    workload.kind == "CronJob"
-    start_of_path := ["spec", "jobTemplate", "spec", "template", "spec"]
+get_start_of_path(workload) := start_of_path if {
+	workload.kind == "CronJob"
+	start_of_path := ["spec", "jobTemplate", "spec", "template", "spec"]
 }
 
+is_sa_auto_mounted(wl_spec, sa) if {
+	# automountServiceAccountToken not in pod spec
+	not wl_spec.automountServiceAccountToken == false
+	not wl_spec.automountServiceAccountToken == true
 
-is_sa_auto_mounted(wl_spec, sa)    {
-    # automountServiceAccountToken not in pod spec
-    not wl_spec.automountServiceAccountToken == false
-    not wl_spec.automountServiceAccountToken == true
-
-    not sa.automountServiceAccountToken == false
+	not sa.automountServiceAccountToken == false
 }
 
-is_sa_auto_mounted(wl_spec, sa)  {
-    # automountServiceAccountToken set to true in pod spec
-    wl_spec.automountServiceAccountToken == true
+is_sa_auto_mounted(wl_spec, sa) if {
+	# automountServiceAccountToken set to true in pod spec
+	wl_spec.automountServiceAccountToken == true
 }
 
-
-is_same_sa(wl_spec, sa_metadata, wl_metadata) {
-    wl_spec.serviceAccountName == sa_metadata.name
-    is_same_namespace(sa_metadata , wl_metadata)
+is_same_sa(wl_spec, sa_metadata, wl_metadata) if {
+	wl_spec.serviceAccountName == sa_metadata.name
+	is_same_namespace(sa_metadata, wl_metadata)
 }
 
-is_same_sa(wl_spec, sa_metadata, wl_metadata) {
-    not wl_spec.serviceAccountName 
-    sa_metadata.name == "default"
-    is_same_namespace(sa_metadata , wl_metadata)
+is_same_sa(wl_spec, sa_metadata, wl_metadata) if {
+	not wl_spec.serviceAccountName
+	sa_metadata.name == "default"
+	is_same_namespace(sa_metadata, wl_metadata)
 }
 
 # is_same_namespace supports cases where ns is not configured in the metadata
 # for yaml scans
-is_same_namespace(metadata1, metadata2) {
-    metadata1.namespace == metadata2.namespace
+is_same_namespace(metadata1, metadata2) if {
+	metadata1.namespace == metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
-    not metadata1.namespace
-    not metadata2.namespace
+is_same_namespace(metadata1, metadata2) if {
+	not metadata1.namespace
+	not metadata2.namespace
 }
 
-is_same_namespace(metadata1, metadata2) {
-    not metadata2.namespace
-    metadata1.namespace == "default"
+is_same_namespace(metadata1, metadata2) if {
+	not metadata2.namespace
+	metadata1.namespace == "default"
 }
 
-is_same_namespace(metadata1, metadata2) {
-    not metadata1.namespace
-    metadata2.namespace == "default"
+is_same_namespace(metadata1, metadata2) if {
+	not metadata1.namespace
+	metadata2.namespace == "default"
 }
-
 
 # look for rule allowing create/update workloads
-is_takeover_role(role){
-    takeover_resources := ["pods", "*"]
-    takeover_verbs := ["create", "update", "patch", "*"]
-    takeover_api_groups := ["", "*"]
-    
-    takeover_rule := [rule | rule = role.rules[i] ; 
-                        rule.resources[a] in takeover_resources ; 
-                        rule.verbs[b] in takeover_verbs ; 
-                        rule.apiGroups[c] in takeover_api_groups]
-    count(takeover_rule) > 0
+is_takeover_role(role) if {
+	takeover_resources := ["pods", "*"]
+	takeover_verbs := ["create", "update", "patch", "*"]
+	takeover_api_groups := ["", "*"]
+
+	takeover_rule := [rule |
+		rule = role.rules[i]
+		rule.resources[a] in takeover_resources
+		rule.verbs[b] in takeover_verbs
+		rule.apiGroups[c] in takeover_api_groups
+	]
+	count(takeover_rule) > 0
 }
 
 # look for rule allowing secret access
-is_takeover_role(role){
-    rule := role.rules[i]
-    takeover_resources := ["secrets", "*"]
-    takeover_verbs :=  ["get", "list", "watch", "*"]
-    takeover_api_groups := ["", "*"]
-    
-    takeover_rule := [rule | rule = role.rules[i] ; 
-                        rule.resources[a] in takeover_resources ; 
-                        rule.verbs[b] in takeover_verbs ; 
-                        rule.apiGroups[c] in takeover_api_groups]
-    count(takeover_rule) > 0
+is_takeover_role(role) if {
+	rule := role.rules[i]
+	takeover_resources := ["secrets", "*"]
+	takeover_verbs := ["get", "list", "watch", "*"]
+	takeover_api_groups := ["", "*"]
+
+	takeover_rule := [rule |
+		rule = role.rules[i]
+		rule.resources[a] in takeover_resources
+		rule.verbs[b] in takeover_verbs
+		rule.apiGroups[c] in takeover_api_groups
+	]
+	count(takeover_rule) > 0
 }

--- a/rules/workload-with-cluster-takeover-roles/raw.rego
+++ b/rules/workload-with-cluster-takeover-roles/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch  
 package armo_builtins
 
 import rego.v1
@@ -124,10 +125,10 @@ is_takeover_role(role) if {
 
 # look for rule allowing secret access
 is_takeover_role(role) if {
-	rule := role.rules[i]
 	takeover_resources := ["secrets", "*"]
 	takeover_verbs := ["get", "list", "watch", "*"]
 	takeover_api_groups := ["", "*"]
+	rule := role.rules[i]
 
 	takeover_rule := [rule |
 		rule = role.rules[i]


### PR DESCRIPTION
## Overview

1. This PR migrates the ninth batch of Rego rules to OPA v1 syntax.

## Additional Information

This batch cover rules from `rules/rule-identify-old-k8s-registry` through `rules/workload-with-cluster-takeover-roles`

### Fixes: https://github.com/kubescape/kubescape/issues/1819

- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated policy rules to Rego v1 syntax and modernized rule declarations.
  * Normalized alert payload formatting and helper expression forms.
  * Preserved existing detection logic, alert contents, and validation behavior (no functional changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->