### PR TITLE
CI: update Regal for Rego v1

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Regal
         uses: StyraInc/setup-regal@v1
         with:
-          version: v0.10.1
+          version: latest
 
       - name: Lint Rego
         run: regal lint --format github rules

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Regal
         uses: StyraInc/setup-regal@v1
         with:
-          version: latest
+          version: v0.41.1
 
       - name: Lint Rego
         run: regal lint --format github rules

--- a/rules/.regal/config.yaml
+++ b/rules/.regal/config.yaml
@@ -1,3 +1,5 @@
+project:
+  rego-version: 1
 rules:
   idiomatic:
     custom-has-key-construct:


### PR DESCRIPTION
## Overview
This PR updates the Regal toolchain to support Rego v1 syntax. It upgrades the Regal version used in CI to a Rego v1-compatible release and configures Regal with `project.rego-version: 1`. These changes are required for the ongoing OPA v0 to v1 migration, ensuring that rules using import rego.v1 are linted correctly and do not fail the CI workflow.

Related comment: https://github.com/kubescape/regolibrary/pull/741#discussion_r3350399150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to use a newer Regal validation tool version, improving rule validation and strengthening pipeline quality checks.
  * Added a project-level configuration specifying the Rego language version to ensure consistent rule processing and predictable behavior across development and testing environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->