### PR TITLE
chore: ignore Regal unresolved-reference for runtime-injected data

### DIFF
--- a/rules/.regal/config.yaml
+++ b/rules/.regal/config.yaml
@@ -13,6 +13,8 @@ rules:
   imports:
     prefer-package-imports:
       level: ignore
+    unresolved-reference:
+      level: ignore
   style:
     avoid-get-and-list-prefix:
       level: ignore


### PR DESCRIPTION
## Overview
Regal reports `unresolved-reference` for `data.dataControlInputs.cloudProvider` and similar references because these values are injected at runtime by Kubescape and are not available during static analysis. This change suppresses the warning to avoid false positives while preserving the existing rule behavior.

- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting rules configuration to adjust reporting levels for development quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->