### PR TITLE
chore: resolve Regal lint issues for OPA v1 migration for batch-4

### DIFF
--- a/rules/ensure-that-the-API-server-pod-specification-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-API-server-pod-specification-file-ownership-is-set-to-root-root/raw.rego
@@ -1,19 +1,22 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	allowed_user := "root"
+	allowed_group := "root"
+	file_obj_path := ["data", "APIServerInfo", "specsFile"]
+
+
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_control_plane_info(obj)
 
-	file_obj_path := ["data", "APIServerInfo", "specsFile"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual ownership check
-	allowed_user := "root"
-	allowed_group := "root"
 	not allowed_ownership(file.ownership, allowed_user, allowed_group)
 
 	# Build the message

--- a/rules/ensure-that-the-API-server-pod-specification-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-API-server-pod-specification-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,18 +1,20 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "APIServerInfo", "specsFile"]
+    allowed_perms := 384 # == 0o600
+	
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_control_plane_info(obj)
 
-	file_obj_path := ["data", "APIServerInfo", "specsFile"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual permissions test
-	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 
 	# Build the message

--- a/rules/ensure-that-the-Container-Network-Interface-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-Container-Network-Interface-file-ownership-is-set-to-root-root/raw.rego
@@ -1,20 +1,23 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "CNIConfigFiles"]
+	allowed_user := "root"
+	allowed_group := "root"
+
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_CNIInfo(obj)
 
-	file_obj_path := ["data", "CNIConfigFiles"]
 	files := object.get(obj, file_obj_path, false)
 	file := files[file_index]
 
 	# Actual ownership check
-	allowed_user := "root"
-	allowed_group := "root"
+	
 	not allowed_ownership(file.ownership, allowed_user, allowed_group)
 
 	# Build the message

--- a/rules/ensure-that-the-Container-Network-Interface-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-Container-Network-Interface-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,19 +1,21 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "CNIConfigFiles"]
+	allowed_perms := 384 # == 0o600
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_CNIInfo(obj)
 
-	file_obj_path := ["data", "CNIConfigFiles"]
 	files := object.get(obj, file_obj_path, false)
 	file := files[file_index]
 
 	# Actual permissions test
-	allowed_perms := 384 # == 0o600
+	
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 
 	# Build the message

--- a/rules/ensure-that-the-api-server-profiling-argument-is-set-to-false/filter.rego
+++ b/rules/ensure-that-the-api-server-profiling-argument-is-set-to-false/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-api-server-profiling-argument-is-set-to-false/raw.rego
+++ b/rules/ensure-that-the-api-server-profiling-argument-is-set-to-false/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 	msg := {

--- a/rules/ensure-that-the-api-server-request-timeout-argument-is-set-as-appropriate/filter.rego
+++ b/rules/ensure-that-the-api-server-request-timeout-argument-is-set-as-appropriate/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-api-server-request-timeout-argument-is-set-as-appropriate/raw.rego
+++ b/rules/ensure-that-the-api-server-request-timeout-argument-is-set-as-appropriate/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 	msg := {

--- a/rules/ensure-that-the-api-server-secure-port-argument-is-not-set-to-0/filter.rego
+++ b/rules/ensure-that-the-api-server-secure-port-argument-is-not-set-to-0/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-api-server-secure-port-argument-is-not-set-to-0/raw.rego
+++ b/rules/ensure-that-the-api-server-secure-port-argument-is-not-set-to-0/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	contains(obj.spec.containers[0].command[i], "--secure-port=0")
 	msg := {

--- a/rules/ensure-that-the-api-server-service-account-extend-token-expiration-is-set-to-false/filter.rego
+++ b/rules/ensure-that-the-api-server-service-account-extend-token-expiration-is-set-to-false/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-api-server-service-account-extend-token-expiration-is-set-to-false/raw.rego
+++ b/rules/ensure-that-the-api-server-service-account-extend-token-expiration-is-set-to-false/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 	msg := {

--- a/rules/ensure-that-the-api-server-service-account-key-file-argument-is-set-as-appropriate/filter.rego
+++ b/rules/ensure-that-the-api-server-service-account-key-file-argument-is-set-as-appropriate/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-api-server-service-account-key-file-argument-is-set-as-appropriate/raw.rego
+++ b/rules/ensure-that-the-api-server-service-account-key-file-argument-is-set-as-appropriate/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 	msg := {

--- a/rules/ensure-that-the-api-server-service-account-lookup-argument-is-set-to-true/filter.rego
+++ b/rules/ensure-that-the-api-server-service-account-lookup-argument-is-set-to-true/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-api-server-service-account-lookup-argument-is-set-to-true/raw.rego
+++ b/rules/ensure-that-the-api-server-service-account-lookup-argument-is-set-to-true/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 	msg := {

--- a/rules/ensure-that-the-api-server-tls-cert-file-and-tls-private-key-file-arguments-are-set-as-appropriate/filter.rego
+++ b/rules/ensure-that-the-api-server-tls-cert-file-and-tls-private-key-file-arguments-are-set-as-appropriate/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-api-server-tls-cert-file-and-tls-private-key-file-arguments-are-set-as-appropriate/raw.rego
+++ b/rules/ensure-that-the-api-server-tls-cert-file-and-tls-private-key-file-arguments-are-set-as-appropriate/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 	msg := {

--- a/rules/ensure-that-the-api-server-token-auth-file-parameter-is-not-set/filter.rego
+++ b/rules/ensure-that-the-api-server-token-auth-file-parameter-is-not-set/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-api-server-token-auth-file-parameter-is-not-set/raw.rego
+++ b/rules/ensure-that-the-api-server-token-auth-file-parameter-is-not-set/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_api_server(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 	msg := {

--- a/rules/ensure-that-the-certificate-authorities-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-certificate-authorities-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,18 +1,19 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "clientCAFile"]
+	allowed_perms := 384 # == 0o600
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_kubelet_info(obj)
 
-	file_obj_path := ["data", "clientCAFile"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual permissions test
-	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 
 	# Build the message

--- a/rules/ensure-that-the-client-certificate-authorities-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-client-certificate-authorities-file-ownership-is-set-to-root-root/raw.rego
@@ -1,19 +1,21 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "clientCAFile"]
+	allowed_user := "root"
+	allowed_group := "root"
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_kubelet_info(obj)
 
-	file_obj_path := ["data", "clientCAFile"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual ownership check
-	allowed_user := "root"
-	allowed_group := "root"
+	
 	not allowed_ownership(file.ownership, allowed_user, allowed_group)
 
 	# Build the message

--- a/rules/ensure-that-the-cni-in-use-supports-network-policies/raw.rego
+++ b/rules/ensure-that-the-cni-in-use-supports-network-policies/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
@@ -6,7 +7,7 @@ import rego.v1
 
 deny contains msg if {
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 
 	is_CNIInfo(obj)
 

--- a/rules/ensure-that-the-controller-manager-RotateKubeletServerCertificate-argument-is-set-to-true/filter.rego
+++ b/rules/ensure-that-the-controller-manager-RotateKubeletServerCertificate-argument-is-set-to-true/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-controller-manager-RotateKubeletServerCertificate-argument-is-set-to-true/raw.rego
+++ b/rules/ensure-that-the-controller-manager-RotateKubeletServerCertificate-argument-is-set-to-true/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 	msg := {

--- a/rules/ensure-that-the-controller-manager-bind-address-argument-is-set-to-127.0.0.1/filter.rego
+++ b/rules/ensure-that-the-controller-manager-bind-address-argument-is-set-to-127.0.0.1/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-controller-manager-bind-address-argument-is-set-to-127.0.0.1/raw.rego
+++ b/rules/ensure-that-the-controller-manager-bind-address-argument-is-set-to-127.0.0.1/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 

--- a/rules/ensure-that-the-controller-manager-pod-specification-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-controller-manager-pod-specification-file-ownership-is-set-to-root-root/raw.rego
@@ -1,19 +1,21 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "controllerManagerInfo", "specsFile"]
+	allowed_user := "root"
+	allowed_group := "root"
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_control_plane_info(obj)
 
-	file_obj_path := ["data", "controllerManagerInfo", "specsFile"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual ownership check
-	allowed_user := "root"
-	allowed_group := "root"
+	
 	not allowed_ownership(file.ownership, allowed_user, allowed_group)
 
 	# Build the message

--- a/rules/ensure-that-the-controller-manager-pod-specification-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-controller-manager-pod-specification-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,18 +1,20 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "controllerManagerInfo", "specsFile"]
+	allowed_perms := 384 # == 0o600
+
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_control_plane_info(obj)
 
-	file_obj_path := ["data", "controllerManagerInfo", "specsFile"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual permissions test
-	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 
 	# Build the message

--- a/rules/ensure-that-the-controller-manager-profiling-argument-is-set-to-false/filter.rego
+++ b/rules/ensure-that-the-controller-manager-profiling-argument-is-set-to-false/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-controller-manager-profiling-argument-is-set-to-false/raw.rego
+++ b/rules/ensure-that-the-controller-manager-profiling-argument-is-set-to-false/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 	msg := {

--- a/rules/ensure-that-the-controller-manager-root-ca-file-argument-is-set-as-appropriate/filter.rego
+++ b/rules/ensure-that-the-controller-manager-root-ca-file-argument-is-set-as-appropriate/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-controller-manager-root-ca-file-argument-is-set-as-appropriate/raw.rego
+++ b/rules/ensure-that-the-controller-manager-root-ca-file-argument-is-set-as-appropriate/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 	msg := {

--- a/rules/ensure-that-the-controller-manager-service-account-private-key-file-argument-is-set-as-appropriate/filter.rego
+++ b/rules/ensure-that-the-controller-manager-service-account-private-key-file-argument-is-set-as-appropriate/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-controller-manager-service-account-private-key-file-argument-is-set-as-appropriate/raw.rego
+++ b/rules/ensure-that-the-controller-manager-service-account-private-key-file-argument-is-set-as-appropriate/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 	msg := {

--- a/rules/ensure-that-the-controller-manager-terminated-pod-gc-threshold-argument-is-set-as-appropriate/filter.rego
+++ b/rules/ensure-that-the-controller-manager-terminated-pod-gc-threshold-argument-is-set-as-appropriate/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-controller-manager-terminated-pod-gc-threshold-argument-is-set-as-appropriate/raw.rego
+++ b/rules/ensure-that-the-controller-manager-terminated-pod-gc-threshold-argument-is-set-as-appropriate/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 	msg := {

--- a/rules/ensure-that-the-controller-manager-use-service-account-credentials-argument-is-set-to-true/filter.rego
+++ b/rules/ensure-that-the-controller-manager-use-service-account-credentials-argument-is-set-to-true/filter.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	msg := {"alertObject": {"k8sApiObjects": [obj]}}
 }

--- a/rules/ensure-that-the-controller-manager-use-service-account-credentials-argument-is-set-to-true/raw.rego
+++ b/rules/ensure-that-the-controller-manager-use-service-account-credentials-argument-is-set-to-true/raw.rego
@@ -1,9 +1,10 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import rego.v1
 
 deny contains msg if {
-	obj = input[_]
+	some obj in input
 	is_controller_manager(obj)
 	result = invalid_flag(obj.spec.containers[0].command)
 	msg := {

--- a/rules/ensure-that-the-controller-manager.conf-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-controller-manager.conf-file-ownership-is-set-to-root-root/raw.rego
@@ -1,19 +1,21 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "controllerManagerInfo", "configFile"]
+	allowed_user := "root"
+	allowed_group := "root"
+
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_control_plane_info(obj)
 
-	file_obj_path := ["data", "controllerManagerInfo", "configFile"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual ownership check
-	allowed_user := "root"
-	allowed_group := "root"
 	not allowed_ownership(file.ownership, allowed_user, allowed_group)
 
 	# Build the message

--- a/rules/ensure-that-the-controller-manager.conf-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-controller-manager.conf-file-permissions-are-set-to-600-or-more-restrictive/raw.rego
@@ -1,18 +1,20 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "controllerManagerInfo", "configFile"]
+	allowed_perms := 384 # == 0o600
+
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_control_plane_info(obj)
 
-	file_obj_path := ["data", "controllerManagerInfo", "configFile"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual permissions test
-	allowed_perms := 384 # == 0o600
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 
 	# Build the message

--- a/rules/ensure-that-the-etcd-data-directory-ownership-is-set-to-etcd-etcd/raw.rego
+++ b/rules/ensure-that-the-etcd-data-directory-ownership-is-set-to-etcd-etcd/raw.rego
@@ -1,19 +1,20 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "etcdDataDir"]
+    allowed_user := "root"
+	allowed_group := "root"
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_control_plane_info(obj)
 
-	file_obj_path := ["data", "etcdDataDir"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual ownership check
-	allowed_user := "root"
-	allowed_group := "root"
 	not allowed_ownership(file.ownership, allowed_user, allowed_group)
 
 	# Build the message

--- a/rules/ensure-that-the-etcd-data-directory-permissions-are-set-to-700-or-more-restrictive/raw.rego
+++ b/rules/ensure-that-the-etcd-data-directory-permissions-are-set-to-700-or-more-restrictive/raw.rego
@@ -1,18 +1,19 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "etcdDataDir"]
+    allowed_perms := 448 # == 0o700
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_control_plane_info(obj)
 
-	file_obj_path := ["data", "etcdDataDir"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual permissions test
-	allowed_perms := 448 # == 0o700
 	not cautils.unix_permissions_allow(allowed_perms, file.permissions)
 
 	# Build the message

--- a/rules/ensure-that-the-etcd-pod-specification-file-ownership-is-set-to-root-root/raw.rego
+++ b/rules/ensure-that-the-etcd-pod-specification-file-ownership-is-set-to-root-root/raw.rego
@@ -1,19 +1,21 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import data.cautils
 import rego.v1
 
 deny contains msg if {
+	file_obj_path := ["data", "etcdConfigFile"]
+	allowed_user := "root"
+	allowed_group := "root"
+
 	# Filter out irrelevent resources
-	obj = input[_]
+	some obj in input
 	is_control_plane_info(obj)
 
-	file_obj_path := ["data", "etcdConfigFile"]
 	file := object.get(obj, file_obj_path, false)
 
 	# Actual ownership check
-	allowed_user := "root"
-	allowed_group := "root"
 	not allowed_ownership(file.ownership, allowed_user, allowed_group)
 
 	# Build the message


### PR DESCRIPTION
https://github.com/kubescape/regolibrary/pull/741#issuecomment-4635501174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized Rego iteration syntax across multiple security compliance policies, updating from index-based to existential quantification patterns for improved code clarity.
  * Reorganized variable declarations within policy rules for better logical flow and consistency.
  * Added linter directives to suppress package-mismatch warnings across policy files.

* **Style**
  * Standardized whitespace and formatting throughout policy definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->