### PR TITLE
chore: ignore Regal unresolved-import to finish Rego v1 migration

### DIFF
--- a/rules/.regal/config.yaml
+++ b/rules/.regal/config.yaml
@@ -13,6 +13,11 @@ rules:
   imports:
     prefer-package-imports:
       level: ignore
+    unresolved-import:
+      # data.cautils and other shared libraries are injected by kubescape at
+      # runtime and are not part of the linted rules/ tree, so Regal cannot
+      # resolve them statically (same case as unresolved-reference below).
+      level: ignore
     unresolved-reference:
       level: ignore
   style:


### PR DESCRIPTION
## What

Adds a single Regal config ignore for the `imports/unresolved-import` rule in `rules/.regal/config.yaml`.

## Why

With all rule batches now migrated to Rego v1 (#738 and the other `opa-v0tov1-b*` PRs), the only remaining `regal lint rules` failures are **43 `unresolved-import` errors** — every `import data.cautils` (and similar shared libraries). `cautils` is injected by kubescape at runtime and isn't part of the linted `rules/` tree, so Regal can't resolve it statically. These are false positives, the same class as the `unresolved-reference` rule that was already ignored in #748.

This is the last thing keeping the `Lint Rego` CI step red, so this change finishes the Rego v1 migration by getting the whole library to a clean lint.

## Verification

Locally, against current `master` + this change:

```
$ regal lint rules
357 files linted. No violations found.
```

(Before this change: 43 `unresolved-import` errors, all `import data.cautils` in already-migrated rules.)

## Note / alternative

A global ignore disables `unresolved-import` for all imports, so a genuine typo in an import path would no longer be caught. The alternative is a per-file `# regal ignore:unresolved-import` on each of the ~38 affected files (consistent with how `directory-package-mismatch` is handled), but the global ignore mirrors the precedent set for its sibling rule `unresolved-reference` in #748 and keeps the config in one place. Happy to switch to per-file directives if you'd prefer to keep the rule active elsewhere.
