### PR TITLE
fix(ci): update setup-regal action to open-policy-agent org

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -55,7 +55,7 @@ jobs:
           GOPATH=$(go env GOPATH) make
 
       - name: Set up Regal
-        uses: StyraInc/setup-regal@v1
+        uses: open-policy-agent/setup-regal@v1
         with:
           version: v0.41.1
 


### PR DESCRIPTION
## Summary
- `StyraInc/setup-regal` has been renamed/moved to `open-policy-agent/setup-regal`; the old org path returns 404 and would break the CI job.
- Updates the `pr-tests.yaml` workflow to reference the new action path.

## Test plan
- [ ] Confirm the "Set up Regal" step in the PR checks succeeds on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pull request test workflow to use a different Regal setup action, keeping CI maintenance current without changing product behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->