### PR TITLE
fix: resolve Regal unconditional-assignment lint in exposed-sensitive-interfaces-v1

### DIFF
--- a/rules/exposed-sensitive-interfaces-v1/filter.rego
+++ b/rules/exposed-sensitive-interfaces-v1/filter.rego
@@ -36,13 +36,11 @@ deny contains msga if {
 	}
 }
 
-get_wl_connectedto_service(wl) := services if {
-	services := [service |
-		service := input[_]
-		service.kind == "Service"
-		wl_connectedto_service(wl, service)
-	]
-}
+get_wl_connectedto_service(wl) := [service |
+	service := input[_]
+	service.kind == "Service"
+	wl_connectedto_service(wl, service)
+]
 
 wl_connectedto_service(wl, service) if {
 	wl.metadata.namespace == service.metadata.namespace


### PR DESCRIPTION
## Problem

The `Lint Rego` step (Regal 0.41.1, run in `pr-tests.yaml`) fails on **every** open PR with a repo-wide style violation that is unrelated to the PR's own changes:

```
Rule:      unconditional-assignment  (style)
Location:  rules/exposed-sensitive-interfaces-v1/filter.rego:40:2
Text:      services := [service |
```

The violation exists on `master` and is not caught by the master push workflow (`push-releasedev-updates.yaml` has no lint step), so it only surfaces on PRs. It was introduced when Regal was bumped/re-pointed in #755 — the linter now enforces `unconditional-assignment`, and this pre-existing rule was never updated.

## Fix

Inline the comprehension into the function head instead of assigning it to an intermediate variable inside a conditional body:

```rego
get_wl_connectedto_service(wl) := [service |
	service := input[_]
	service.kind == "Service"
	wl_connectedto_service(wl, service)
]
```

This is the transformation Regal's own [`unconditional-assignment` docs](https://www.openpolicyagent.org/projects/regal/rules/style/unconditional-assignment) recommend.

## Behavior

Unchanged. A comprehension always produces a value, so the function was already total — inlining it is a pure style refactor.

`cd testrunner && go test -tags=static rego_test.go -run 'TestAllRules/exposed-sensitive-interfaces' -v` — all four cases (`workloads`, `filter-multi-service`, `pod`, `workloads2`) pass.

## Why this matters

Unblocks the `Lint Rego` gate for all in-flight PRs (e.g. #754), which currently go red on this violation despite not touching this file.

AI-skills: review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how matching connected services are collected for workload checks, keeping the same results while simplifying the underlying logic.
  * Security/validation outputs that reference related objects continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->