### PR TITLE
Fix eval_conflict_error in alert-any-hostpath for multi-mounted volumes

### DIFF
--- a/rules/alert-any-hostpath/raw.rego
+++ b/rules/alert-any-hostpath/raw.rego
@@ -146,7 +146,7 @@ is_dangerous_volume(volume, start_of_path, i) := path if {
 	path = sprintf("%vvolumes[%v]", [start_of_path, format_int(i, 10)])
 }
 
-volume_mounts(name, volume_mounts, str) := [path] if {
-	name == volume_mounts[j].name
-	path := sprintf("%s.volumeMounts[%v]", [str, j])
-} else := []
+volume_mounts(name, mounts, str) := [sprintf("%s.volumeMounts[%v]", [str, j]) |
+	some j
+	mounts[j].name == name
+]

--- a/rules/alert-any-hostpath/test/pod-multiple-mounts/expected.json
+++ b/rules/alert-any-hostpath/test/pod-multiple-mounts/expected.json
@@ -1,0 +1,30 @@
+[
+	{
+		"alertMessage": "pod: test-pd has: test-volume as hostPath volume",
+		"failedPaths": [
+			"spec.volumes[0]",
+			"spec.containers[0].volumeMounts[0]",
+			"spec.containers[0].volumeMounts[1]"
+		],
+		"deletePaths": [
+			"spec.volumes[0]",
+			"spec.containers[0].volumeMounts[0]",
+			"spec.containers[0].volumeMounts[1]"
+		],
+		"fixPaths": [],
+		"ruleStatus": "",
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"alertObject": {
+			"k8sApiObjects": [
+				{
+					"apiVersion": "v1",
+					"kind": "Pod",
+					"metadata": {
+						"name": "test-pd"
+					}
+				}
+			]
+		}
+	}
+]

--- a/rules/alert-any-hostpath/test/pod-multiple-mounts/input/pod.yaml
+++ b/rules/alert-any-hostpath/test/pod-multiple-mounts/input/pod.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pd
+spec:
+  containers:
+  - image: k8s.gcr.io/test-webserver
+    name: test-container
+    volumeMounts:
+    # same hostPath volume mounted twice in one container (via subPath) -
+    # a valid Kubernetes pattern that previously crashed the rule
+    - mountPath: /conf
+      name: test-volume
+      subPath: conf
+    - mountPath: /state
+      name: test-volume
+      subPath: state
+  volumes:
+  - name: test-volume
+    hostPath:
+      path: /var


### PR DESCRIPTION
## Problem

`alert-any-hostpath` (control C-0048) crashes evaluation when a container mounts the same volume at more than one path. The `volume_mounts` helper is a single-valued function:

```rego
volume_mounts(name, volume_mounts, str) := [path] if {
	name == volume_mounts[j].name
	path := sprintf("%s.volumeMounts[%v]", [str, j])
} else := []
```

When two `volumeMounts` entries share the same `name` — a valid Kubernetes pattern using `subPath` — `j` has multiple solutions, so the function returns multiple different outputs for the same inputs and Rego aborts the whole evaluation:

```
eval_conflict_error: functions must not produce multiple outputs for same inputs
```

Because C-0048 is part of the MITRE framework, `kubescape scan framework MITRE` then fails entirely on any cluster that has such a workload:

```
control "C-0048": rule "alert-any-hostpath": rego eval failed for namespace "X":
eval_conflict_error: functions must not produce multiple outputs for same inputs
```

A minimal reproducer is a container that mounts one hostPath volume at two paths via `subPath`.

## Fix

Rewrite `volume_mounts` to gather all matching mount paths in a single array comprehension, which always yields exactly one (possibly empty) array — deterministic, no conflict:

```rego
volume_mounts(name, mounts, str) := paths if {
	paths := [sprintf("%s.volumeMounts[%v]", [str, j]) |
		some j
		mounts[j].name == name
	]
}
```

Behaviour is unchanged for the existing single-mount cases; a volume mounted multiple times now reports all of its mount paths in `failedPaths`/`deletePaths` instead of crashing.

## Test

Adds a regression test `test/pod-multiple-mounts` — a pod with one hostPath volume mounted twice in the same container via `subPath`. `go test -tags=static rego_test.go -run TestSingleRule -args -rule alert-any-hostpath` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hostPath alert handling to correctly capture all matching `volumeMount` paths when the same volume is mounted multiple times with different `subPath` values.

* **Tests**
  * Added a Pod fixture covering the “multiple mounts in one container” scenario.
  * Updated expected alert output to validate that all failing paths are included for matching `volumeMount` entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->