### PR TITLE
fix(ci): publish release artifacts to the full semver tag

### DIFF
--- a/.github/workflows/create-release-v2.yaml
+++ b/.github/workflows/create-release-v2.yaml
@@ -166,6 +166,10 @@ jobs:
           name: ${{ env.REGO_ARTIFACT_KEY_NAME }}
           path: ${{ env.REGO_ARTIFACT_PATH }}
 
+      # Rolling release for the short tag (v2) - the default source for
+      # consumers that do not pin a version. Unchanged behaviour, and kept
+      # first so the default path is never gated behind the versioned upload
+      # below: if that one fails, v2 has already been refreshed.
       - name: Create or Update Release and Upload Assets
         uses: softprops/action-gh-release@v2
         with:
@@ -177,6 +181,30 @@ jobs:
           draft: false
           fail_on_unmatched_files: true
           prerelease: false
+          make_latest: "false"
+
+      # Immutable release for the full version tag (e.g. v2.0.31). Without this
+      # the artifacts only ever land on the rolling short tag, so every
+      # `releases/download/v2.0.x/<artifact>` URL 404s and consumers have no
+      # stable release to pin to (`kubescape scan --controls-version v2.0.31`).
+      - name: Create or Update Versioned Release and Upload Assets
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ steps.generate_tag.outputs.NEW_TAG }}
+          name: ${{ steps.generate_tag.outputs.NEW_TAG }}
+          body: "Automated release for ${{ steps.generate_tag.outputs.NEW_TAG }}"
+          files: ${{ env.REGO_ARTIFACT_PATH }}/*
+          draft: false
+          fail_on_unmatched_files: true
+          prerelease: false
+          # A published version must never change underneath a consumer that
+          # pinned it. If an asset already exists on this tag it is left alone
+          # (the action skips it and continues, it does not fail), so re-running
+          # the job cannot silently rewrite an already-released artifact.
+          overwrite_files: false
+          # Keep the "Latest" pointer on the rolling short tag so the
+          # `releases/latest/download` path keeps resolving as it does today.
           make_latest: "false"
 
   # Update regolibrary documentation with latest controls and rules.


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->
## Summary

The release pipeline uploads its generated artifacts only to the rolling `v2` tag, so every `releases/download/v2.0.x/<artifact>` URL 404s and there is no immutable release to pin to. This uploads the same artifacts to the full semver tag as well, leaving the rolling `v2` release and the "Latest" pointer untouched.

## Overview

The release job creates the full version tag (e.g. `v2.0.31`) and force-pushes the short tag (`v2`), but uploads the generated artifacts **only** to the short tag's release:

```yaml
tag_name: ${{ env.SHORT_TAG }}   # SHORT_TAG = "v2"
```

The versioned tag therefore ends up with an empty release, or no release at all, and every `releases/download/v2.0.x/<artifact>` URL returns 404.

**Current behaviour** — only the rolling `v2` release carries assets:

| URL | Result |
|---|---|
| `releases/download/v2/frameworks` | 200 |
| `releases/download/v2.0.30/frameworks` | **404** |
| `releases/download/v2.0.29/frameworks` | **404** |
| `releases/download/v2.0.28/frameworks` | **404** |

`v2.0.29` / `v2.0.30` are git tags with no GitHub Release at all; `v2.0.28` has a release with 0 assets. This is a v2-era regression — every `v1.0.x` release published its 21 artifacts per version.

**Future behaviour** — the same artifacts are uploaded to the full version tag as well, so each release is immutable and pinnable.

## Additional Information

This leaves consumers with no immutable release to pin to: every non-air-gapped scan resolves through the rolling `v2` release, so republishing it silently changes the control set used by downstream scans with no user opt-in.

It also blocks kubescape#2498 (`kubescape scan --controls-version <tag>`), which builds `releases/download/<tag>/<artifact>` and treats a pinned download failure as a hard error — so today every pinned value fails.

Deliberately conservative:

- The existing rolling `v2` upload step is **unchanged**, so the default path stays backward-compatible. The net diff is purely additive (+23/-0).
- The new upload runs **after** the rolling `v2` step, not before it. Both use `fail_on_unmatched_files` with no `continue-on-error`, so ordering it first would gate the default path that every unpinned consumer relies on behind new, never-yet-executed code — an upload flake or API 5xx there would abort the job before `v2` was refreshed. Running it last leaves the success path identical.
- `make_latest: "false"` on the new step keeps the "Latest" pointer on the rolling tag, so `releases/latest/download` (used by `NewGitRegoStoreV2Latest`) keeps resolving exactly as it does today.
- `overwrite_files: false` on the new step makes a published version genuinely immutable: once `v2.0.31`'s assets exist, re-running the job cannot rewrite them underneath someone who pinned it. An already-present asset is skipped and the job continues (the action logs it and moves on, it does not fail), so re-runs stay safe. The rolling `v2` step keeps the default overwriting behaviour — that is what makes it rolling.

## How to Test

After the next `v*.*.*-rc.*` tag push completes the pipeline, both URLs should return 200:

```bash
curl -sIL -o /dev/null -w '%{http_code}\n' https://github.com/kubescape/regolibrary/releases/download/v2/frameworks
curl -sIL -o /dev/null -w '%{http_code}\n' https://github.com/kubescape/regolibrary/releases/download/v2.0.31/frameworks
```

The workflow YAML parses and `actionlint` reports no new findings (the pre-existing `actions/setup-go@v4` warning on line 41 is untouched by this PR).

## Related issues/PRs

* Unblocks kubescape/kubescape#2498

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code

## Ticket

None (tracked in Multica KUB-595)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a second, immutable GitHub Release for each full generated version tag.
  * Full version releases now upload the generated release artifacts.
  * The existing rolling short-tag release remains the default and continues to control the “Latest” pointer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

