### PR TITLE
fix(scripts): report Readme API failures with status, URL and body

### DIFF
--- a/scripts/upload-readme.py
+++ b/scripts/upload-readme.py
@@ -19,9 +19,47 @@ import os
 import json
 import re
 
+def raise_api_error(response, action: str):
+    """
+    Function to raise a uniform, diagnosable error for a failed Readme API call.
+
+    Reports the request method, the URL, the HTTP status code and whatever the
+    Readme API returned in its body. Readme answers failures with a JSON object
+    carrying `error`, `message` and `suggestion` fields, and those are what tell
+    you whether the key was rejected, the endpoint no longer exists or the
+    project is misconfigured. Raising a bare message instead throws all of that
+    away and leaves the CI log with nothing to act on.
+
+    The API key is sent as basic auth, so it is not part of the logged URL.
+    """
+    detail = response.text.strip()
+
+    try:
+        body = response.json()
+    except ValueError:
+        body = None
+
+    if isinstance(body, dict):
+        fields = [str(body[key]) for key in ('error', 'message', 'suggestion') if body.get(key)]
+        if fields:
+            detail = ' | '.join(fields)
+
+    if len(detail) > 500:
+        detail = detail[:500] + '... (truncated)'
+
+    message = 'Failed to %s: %s %s returned %d' % (
+        action,
+        response.request.method,
+        response.url,
+        response.status_code,
+    )
+
+    raise Exception('%s - %s' % (message, detail) if detail else message)
+
+
 class ReadmeApi(object):
     """
-    The script uses the ReadmeApi class to interact with the Readme API. This class has methods to authenticate, get categories, 
+    The script uses the ReadmeApi class to interact with the Readme API. This class has methods to authenticate, get categories,
     get docs in a category, get a specific doc, delete a doc, create a doc, and update a doc.
     """
     def __init__(self):
@@ -30,11 +68,11 @@ class ReadmeApi(object):
 
     def authenticate(self, api_key):
         """
-        Function to authenticate with the Readme API 
+        Function to authenticate with the Readme API
         """
         r = requests.get('https://dash.readme.com/api/v1', auth=(api_key, ''))
         if r.status_code != 200:
-            raise Exception('Failed to authenticate')
+            raise_api_error(r, 'authenticate')
         auth_response = r.json()
         self.jwt = auth_response['jwtSecret']
         self.base_url = auth_response['baseUrl']
@@ -57,7 +95,7 @@ class ReadmeApi(object):
         r = requests.request("GET", url, params=querystring, auth=(self.api_key, ''))
 
         if r.status_code != 200:
-            raise Exception('Failed to get categories')
+            raise_api_error(r, 'get categories')
 
         return r.json()
 
@@ -70,7 +108,7 @@ class ReadmeApi(object):
         r = requests.request("GET", url,headers={"Accept": "application/json"}, auth=(self.api_key, ''))
 
         if r.status_code != 200:
-            raise Exception('Failed to get categories')
+            raise_api_error(r, 'get category "%s"' % category_slug)
 
         return r.json()
 
@@ -83,7 +121,7 @@ class ReadmeApi(object):
         r = requests.request("GET", url, headers={"Accept":"application/json"}, auth=(self.api_key, ''))
 
         if r.status_code != 200:
-            raise Exception('Failed to docs for category')
+            raise_api_error(r, 'get docs for category "%s"' % category_slug)
 
         return r.json()
 
@@ -98,7 +136,7 @@ class ReadmeApi(object):
         if r.status_code == 404:
             return None
         if r.status_code < 200 or 299 < r.status_code:
-            raise Exception(f'Failed to docs for category, status_code: {r.status_code}, url: {url}')
+            raise_api_error(r, 'get doc "%s"' % doc_slug)
 
         return r.json()
 
@@ -111,7 +149,7 @@ class ReadmeApi(object):
         r = requests.request("DELETE", url, headers={"Accept":"application/json"}, auth=(self.api_key, ''))
 
         if r.status_code < 200 or 299 < r.status_code:
-            raise Exception('Failed to delete doc (%d)'%r.status_code)
+            raise_api_error(r, 'delete doc "%s"' % doc_slug)
     
     def create_doc(self, slug: str, parent_id: str, order: any, title: str, body: str, category: str):
         """
@@ -138,7 +176,7 @@ class ReadmeApi(object):
 
 
         if r.status_code < 200 or 299 < r.status_code:
-            raise Exception('Failed to create doc: %s'%r.text)
+            raise_api_error(r, 'create doc "%s"' % slug)
 
         return r.json()
 
@@ -163,7 +201,7 @@ class ReadmeApi(object):
         r = requests.request("PUT", url, json=payload, headers=headers, auth=(self.api_key, ''))
 
         if r.status_code < 200 or 299 < r.status_code:
-            raise Exception('Failed to update doc: %s'%r.text)
+            raise_api_error(r, 'update doc "%s"' % doc_slug)
 
         return r.json()
 


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->
## Summary

The `update-documentation` job fails with `Exception: Failed to get categories` and nothing else — no status code, no URL, no response body. This routes every Readme API failure through a shared helper that reports all three, and fixes three call sites that named the wrong operation. It does not fix the job; it makes the next run say why it failed.

## Overview

`update-documentation` has failed on every release run I checked — v2.0.29-rc.4 (Feb), v2.0.30-rc.1 (Jun), v2.0.31-rc.0 (Jul) — so the control docs have been going stale for months. The entire diagnostic output is:

```
Authenticated
...
File "./scripts/upload-readme.py", line 60, in get_categories
Exception: Failed to get categories
```

That is not enough to act on. Readme answers failures with a JSON body carrying `error`, `message` and `suggestion`, which is exactly what distinguishes a rejected key from a removed endpoint from a misconfigured project — and all of it was being discarded.

Three call sites also reported the wrong operation, so even the failing call was not identifiable from the message:

| Method | Reported |
|---|---|
| `get_category` | `Failed to get categories` |
| `get_docs_in_category` | `Failed to docs for category` |
| `get_doc` | `Failed to docs for category` |

**Future behaviour** — the same failure now reads:

```
Failed to get categories: GET https://dash.readme.com/api/v1/categories?perPage=1000&page=1
returned 401 - APIKEY_NOTFOUND | We couldn't find your API key. | The API key you passed in
(aW5··········To=) doesn't match any keys we have in our system. ...
```

## Additional Information

All eight raise sites (`authenticate`, `get_categories`, `get_category`, `get_docs_in_category`, `get_doc`, `delete_doc`, `create_doc`, `update_doc`) now go through one `raise_api_error` helper, and slug-taking methods name their target so a failure points at the specific doc or category.

Notes on safety and robustness:

- **No credential in the URL.** The key is sent as basic auth, so it is not part of the logged URL. Readme's own `suggestion` text includes a masked form of the value (`aW5··········To=`) — that masking is Readme's, and GitHub Actions additionally masks the real secret in logs.
- **Non-JSON bodies** (an HTML 502 from a proxy, say) fall back to raw text rather than throwing inside the error handler.
- **Bodies are truncated at 500 characters** so an HTML error page can't flood the log.

## How to Test

Exercised against the live Readme API with a deliberately invalid key, which reproduces the CI failure shape exactly:

```
Failed to authenticate: GET https://dash.readme.com/api/v1 returned 401 - APIKEY_NOTFOUND | ...
Failed to get categories: GET https://dash.readme.com/api/v1/categories?perPage=1000&page=1 returned 401 - ...
Failed to get docs for category "review-controls": GET .../categories/review-controls/docs returned 401 - ...
```

Edge cases checked with stubbed responses — non-JSON body, empty body, JSON list body, JSON dict without the expected fields, and a 2000-character body — all produce a clean message and none raise inside the handler. `python3 -m py_compile scripts/upload-readme.py` passes.

## Related issues/PRs

* Follow-up to #759 — surfaced while checking the v2.0.31 release run

## Ticket

None (tracked in Multica KUB-595)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error messages with clearer failure details, including the action, request information, status code, and available guidance.
  * Standardized error handling across authentication, document, and category operations.
  * Long error responses are now shortened for easier readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->