### PR TITLE
fix(rule-credentials-in-env-var): restore sensitiveKeyNames lookup fo…

### DIFF
--- a/rules/rule-credentials-in-env-var/raw.rego
+++ b/rules/rule-credentials-in-env-var/raw.rego
@@ -4,7 +4,7 @@ package armo_builtins
 import rego.v1
 
 deny contains msga if {
-	sensitive_key_names := data.postureControlInputs.sensitiveKeyName
+	sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
 	pod := input[_]
 	pod.kind == "Pod"
 

--- a/rules/rule-credentials-in-env-var/test/pod-sensitive-key-regression/expected.json
+++ b/rules/rule-credentials-in-env-var/test/pod-sensitive-key-regression/expected.json
@@ -1,0 +1,31 @@
+[
+    {
+        "alertMessage": "Pod: audit-pod has sensitive information in environment variables",
+        "deletePaths": [
+            "spec.containers[0].env[1].name",
+            "spec.containers[0].env[1].value"
+        ],
+        "failedPaths": [
+            "spec.containers[0].env[1].name",
+            "spec.containers[0].env[1].value"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 9,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "labels": {
+                            "app": "payment-service"
+                        },
+                        "name": "audit-pod"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/rule-credentials-in-env-var/test/pod-sensitive-key-regression/input/input.yml
+++ b/rules/rule-credentials-in-env-var/test/pod-sensitive-key-regression/input/input.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: audit-pod
+  labels:
+    app: payment-service
+spec:
+  containers:
+    - name: payment-api
+      image: nginx:1.29
+      securityContext:
+        allowPrivilegeEscalation: true
+      env:
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_PASSWORD
+          value: hunter2
+        - name: PORT
+          value: "8080"


### PR DESCRIPTION
Fixes #762.
## Overview

Restore the correct `sensitiveKeyNames` configuration lookup for the Pod-specific branch of `rule-credentials-in-env-var`.

The OPA v1 migration in #745 (commit `6e75c7a5`) accidentally changed the lookup from `sensitiveKeyNames` to `sensitiveKeyName`, causing the Pod branch to evaluate against a non-existent configuration key while the Deployment/ReplicaSet/DaemonSet/StatefulSet/Job and CronJob branches continued using the correct key.

This change restores the original behavior by using `data.postureControlInputs.sensitiveKeyNames` consistently across all workload types.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of sensitive credentials in Pod environment variables using the configured list of sensitive key names.
  * Added regression coverage for detecting a database password in a Pod configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->