### PR TITLE
fix: use sensitiveKeyNames config key for Pod env check

### DIFF
--- a/rules/rule-credentials-in-env-var/raw.rego
+++ b/rules/rule-credentials-in-env-var/raw.rego
@@ -4,7 +4,7 @@ package armo_builtins
 import rego.v1
 
 deny contains msga if {
-	sensitive_key_names := data.postureControlInputs.sensitiveKeyName
+	sensitive_key_names := data.postureControlInputs.sensitiveKeyNames
 	pod := input[_]
 	pod.kind == "Pod"
 

--- a/rules/rule-credentials-in-env-var/test/pod-sensitive-key-name/expected.json
+++ b/rules/rule-credentials-in-env-var/test/pod-sensitive-key-name/expected.json
@@ -1,0 +1,31 @@
+[
+    {
+        "alertMessage": "Pod: creds-pod has sensitive information in environment variables",
+        "deletePaths": [
+            "spec.containers[0].env[0].name",
+            "spec.containers[0].env[0].value"
+        ],
+        "failedPaths": [
+            "spec.containers[0].env[0].name",
+            "spec.containers[0].env[0].value"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 9,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "labels": {
+                            "app": "creds-pod"
+                        },
+                        "name": "creds-pod"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/rule-credentials-in-env-var/test/pod-sensitive-key-name/input/pod.yaml
+++ b/rules/rule-credentials-in-env-var/test/pod-sensitive-key-name/input/pod.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: creds-pod
+  labels:
+    app: creds-pod
+spec:
+  containers:
+  - name: app
+    env:
+      - name: DB_PASSWORD
+        value: hunter2
+    image: hashicorp/http-echo:0.2.3


### PR DESCRIPTION
## Overview

This is the fix for #762 

The issue was that `raw.rego:7`'s Pod branch read `data.postureControlInputs.sensitiveKeyName` (singular), a key that doesn't exist in the control inputs schema. Since that key is always undefined, the rule body never evaluated, so bare Pods with sensitive environment variable names (e.g. `DB_PASSWORD`) were never flagged. The Deployment and CronJob branches used the correct plural `sensitiveKeyNames` and worked as expected -- only the Pod path was broken. Regression from `6e75c7a5`.

The fix is a one-word key correction: `sensitiveKeyName` to `sensitiveKeyNames`.

Added fixture `test/pod-sensitive-key-name/` (bare Pod with `DB_PASSWORD: hunter2`, plus expected output) to cover the branch. The pre-existing Pod fixtures passed regardless of the bug, which is why CI never caught it.

Affects C-0012 and C-0259.

Now the two cases are actually distinct:

- Deployment/CronJob with sensitive env key names -> flagged (unchanged)
- Bare Pod with sensitive env key names -> flagged (was silently passing before)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes Pod checks to recognize sensitive credentials using the configured list of sensitive environment-variable names.
  * Sensitive values such as database passwords are now correctly identified and reported with relevant alert details and severity scoring.

* **Tests**
  * Added coverage for Pods containing sensitive environment variables, including affected field paths and Kubernetes metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->