### PR TITLE
fix: resolve eval_conflict_error in exposure-to-internet-via-gateway-api

### DIFF
--- a/rules/exposure-to-internet-via-gateway-api/raw.rego
+++ b/rules/exposure-to-internet-via-gateway-api/raw.rego
@@ -96,12 +96,10 @@ get_pod_spec(resources) := result if {
 	result = {"spec": resources.spec.jobTemplate.spec.template.spec, "start_of_path": "spec.jobTemplate.spec.template.spec."}
 }
 
-svc_connected_to_httproute(svc, httproute) := result if {
-	result := [
-		sprintf("spec.rules[%d].backendRefs[%d].name", [i, j]) |
-		rule := httproute.spec.rules[i]
-		ref := rule.backendRefs[j]
-		ref.kind == "Service"
-		svc.metadata.name == ref.name
-	]
-}
+svc_connected_to_httproute(svc, httproute) := [
+	sprintf("spec.rules[%d].backendRefs[%d].name", [i, j]) |
+	rule := httproute.spec.rules[i]
+	ref := rule.backendRefs[j]
+	ref.kind == "Service"
+	svc.metadata.name == ref.name
+]

--- a/rules/exposure-to-internet-via-gateway-api/raw.rego
+++ b/rules/exposure-to-internet-via-gateway-api/raw.rego
@@ -97,9 +97,11 @@ get_pod_spec(resources) := result if {
 }
 
 svc_connected_to_httproute(svc, httproute) := result if {
-	rule := httproute.spec.rules[i]
-	ref := rule.backendRefs[j]
-	ref.kind == "Service"
-	svc.metadata.name == ref.name
-	result := [sprintf("spec.rules[%d].backendRefs[%d].name", [i, j])]
+	result := [
+		sprintf("spec.rules[%d].backendRefs[%d].name", [i, j]) |
+		rule := httproute.spec.rules[i]
+		ref := rule.backendRefs[j]
+		ref.kind == "Service"
+		svc.metadata.name == ref.name
+	]
 }

--- a/rules/exposure-to-internet-via-gateway-api/test/failed_with_httproute_duplicate_backendref/expected.json
+++ b/rules/exposure-to-internet-via-gateway-api/test/failed_with_httproute_duplicate_backendref/expected.json
@@ -1,0 +1,182 @@
+[
+   {
+      "alertMessage": "workload 'httpbin' is exposed through httproute 'httpbin'",
+      "failedPaths": [],
+      "fixPaths": [],
+      "ruleStatus": "",
+      "packagename": "armo_builtins",
+      "alertScore": 7,
+      "alertObject": {
+         "k8sApiObjects": [
+            {
+               "apiVersion": "apps/v1",
+               "kind": "Deployment",
+               "metadata": {
+                  "name": "httpbin"
+               }
+            }
+         ]
+      },
+      "relatedObjects": [
+         {
+            "object": {
+               "apiVersion": "gateway.networking.k8s.io/v1",
+               "kind": "HTTPRoute",
+               "metadata": {
+                  "creationTimestamp": "2024-02-04T19:06:03Z",
+                  "generation": 1,
+                  "labels": {
+                     "example": "httpbin-route"
+                  },
+                  "name": "httpbin",
+                  "namespace": "httpbin",
+                  "resourceVersion": "914",
+                  "uid": "fd820080-801d-4fa7-934a-e23abe8bf746"
+               },
+               "spec": {
+                  "hostnames": [
+                     "www.example.com"
+                  ],
+                  "parentRefs": [
+                     {
+                        "group": "gateway.networking.k8s.io",
+                        "kind": "Gateway",
+                        "name": "http",
+                        "namespace": "gloo-system"
+                     }
+                  ],
+                  "rules": [
+                     {
+                        "backendRefs": [
+                           {
+                              "group": "",
+                              "kind": "Service",
+                              "name": "httpbin",
+                              "port": 8000,
+                              "weight": 1
+                           }
+                        ],
+                        "matches": [
+                           {
+                              "path": {
+                                 "type": "PathPrefix",
+                                 "value": "/"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "backendRefs": [
+                           {
+                              "group": "",
+                              "kind": "Service",
+                              "name": "httpbin",
+                              "port": 8000,
+                              "weight": 1
+                           }
+                        ],
+                        "matches": [
+                           {
+                              "path": {
+                                 "type": "PathPrefix",
+                                 "value": "/status"
+                              }
+                           }
+                        ]
+                     }
+                  ]
+               },
+               "status": {
+                  "parents": [
+                     {
+                        "conditions": [
+                           {
+                              "lastTransitionTime": "2024-02-04T19:06:03Z",
+                              "message": "",
+                              "observedGeneration": 1,
+                              "reason": "Accepted",
+                              "status": "True",
+                              "type": "Accepted"
+                           },
+                           {
+                              "lastTransitionTime": "2024-02-04T19:06:03Z",
+                              "message": "",
+                              "observedGeneration": 1,
+                              "reason": "ResolvedRefs",
+                              "status": "True",
+                              "type": "ResolvedRefs"
+                           }
+                        ],
+                        "controllerName": "solo.io/gloo-gateway",
+                        "parentRef": {
+                           "group": "gateway.networking.k8s.io",
+                           "kind": "Gateway",
+                           "name": "http",
+                           "namespace": "gloo-system"
+                        }
+                     }
+                  ]
+               }
+            },
+            "failedPaths": [
+               "spec.rules[0].backendRefs[0].name",
+               "spec.rules[1].backendRefs[0].name"
+            ],
+            "reviewPaths": [
+               "spec.rules[0].backendRefs[0].name",
+               "spec.rules[1].backendRefs[0].name"
+            ]
+         },
+         {
+            "object": {
+               "apiVersion": "v1",
+               "kind": "Service",
+               "metadata": {
+                  "creationTimestamp": "2024-02-04T19:05:12Z",
+                  "labels": {
+                     "app": "httpbin",
+                     "service": "httpbin"
+                  },
+                  "name": "httpbin",
+                  "namespace": "httpbin",
+                  "resourceVersion": "811",
+                  "uid": "c391feb7-54e5-41b2-869b-33166869f1b7"
+               },
+               "spec": {
+                  "clusterIP": "10.96.162.234",
+                  "clusterIPs": [
+                     "10.96.162.234"
+                  ],
+                  "internalTrafficPolicy": "Cluster",
+                  "ipFamilies": [
+                     "IPv4"
+                  ],
+                  "ipFamilyPolicy": "SingleStack",
+                  "ports": [
+                     {
+                        "name": "http",
+                        "port": 8000,
+                        "protocol": "TCP",
+                        "targetPort": 8080
+                     },
+                     {
+                        "name": "tcp",
+                        "port": 9000,
+                        "protocol": "TCP",
+                        "targetPort": 9000
+                     }
+                  ],
+                  "selector": {
+                     "app": "httpbin"
+                  },
+                  "sessionAffinity": "None",
+                  "type": "ClusterIP"
+               },
+               "status": {
+                  "loadBalancer": {}
+               }
+            }
+         }
+      ]
+   }
+]

--- a/rules/exposure-to-internet-via-gateway-api/test/failed_with_httproute_duplicate_backendref/input/deployment.yaml
+++ b/rules/exposure-to-internet-via-gateway-api/test/failed_with_httproute_duplicate_backendref/input/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: "2024-02-04T19:05:12Z"
+  generation: 1
+  name: httpbin
+  namespace: httpbin
+  resourceVersion: "870"
+  uid: 7462bb4c-b5a2-413e-80ee-c1baaf34aade
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: httpbin
+        version: v1
+    spec:
+      containers:
+      - args:
+        - -port
+        - "8080"
+        - -max-duration
+        - 600s
+        command:
+        - go-httpbin
+        image: docker.io/mccutchen/go-httpbin:v2.6.0
+        imagePullPolicy: IfNotPresent
+        name: httpbin
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: httpbin
+      serviceAccountName: httpbin
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 1
+  conditions:
+  - lastTransitionTime: "2024-02-04T19:05:32Z"
+    lastUpdateTime: "2024-02-04T19:05:32Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2024-02-04T19:05:12Z"
+    lastUpdateTime: "2024-02-04T19:05:32Z"
+    message: ReplicaSet "httpbin-f46cc8b9b" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1

--- a/rules/exposure-to-internet-via-gateway-api/test/failed_with_httproute_duplicate_backendref/input/httproute.yaml
+++ b/rules/exposure-to-internet-via-gateway-api/test/failed_with_httproute_duplicate_backendref/input/httproute.yaml
@@ -1,0 +1,61 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: "2024-02-04T19:06:03Z"
+  generation: 1
+  labels:
+    example: httpbin-route
+  name: httpbin
+  namespace: httpbin
+  resourceVersion: "914"
+  uid: fd820080-801d-4fa7-934a-e23abe8bf746
+spec:
+  hostnames:
+  - www.example.com
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: http
+    namespace: gloo-system
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: httpbin
+      port: 8000
+      weight: 1
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: httpbin
+      port: 8000
+      weight: 1
+    matches:
+    - path:
+        type: PathPrefix
+        value: /status
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2024-02-04T19:06:03Z"
+      message: ""
+      observedGeneration: 1
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2024-02-04T19:06:03Z"
+      message: ""
+      observedGeneration: 1
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: solo.io/gloo-gateway
+    parentRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: http
+      namespace: gloo-system

--- a/rules/exposure-to-internet-via-gateway-api/test/failed_with_httproute_duplicate_backendref/input/service.yaml
+++ b/rules/exposure-to-internet-via-gateway-api/test/failed_with_httproute_duplicate_backendref/input/service.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2024-02-04T19:05:12Z"
+  labels:
+    app: httpbin
+    service: httpbin
+  name: httpbin
+  namespace: httpbin
+  resourceVersion: "811"
+  uid: c391feb7-54e5-41b2-869b-33166869f1b7
+spec:
+  clusterIP: 10.96.162.234
+  clusterIPs:
+  - 10.96.162.234
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 8000
+    protocol: TCP
+    targetPort: 8080
+  - name: tcp
+    port: 9000
+    protocol: TCP
+    targetPort: 9000
+  selector:
+    app: httpbin
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}


### PR DESCRIPTION
## Summary
- `svc_connected_to_httproute` (control C-0266 / rule `exposure-to-internet-via-gateway-api`) is a complete function (`:=`) that iterated over unbound `rule`/`backendRef` indices. When an `HTTPRoute`/`TCPRoute`/`UDPRoute` references the same backend `Service` more than once (multiple rules, or multiple `backendRefs`, pointing at the same service — a normal path-based routing pattern), the function produced multiple different `result` values for the identical `(svc, httproute)` input pair.
- OPA rejects this at eval time with:
  ```
  rego eval failed: eval_conflict_error: functions must not produce multiple outputs for same inputs
  ```
  which crashes the whole `kubescape scan` for the affected cluster/customer (seen in production: `control "C-0266": rule "exposure-to-internet-via-gateway-api": rego eval failed ...`).
- Fix: aggregate all matches into a single array via a comprehension, so the function always returns exactly one value per `(svc, httproute)` pair, regardless of how many rules/backendRefs reference the service. Output shape is unchanged for the existing single-match case.

## Test plan
- [x] Added `test/failed_with_httproute_duplicate_backendref/`: an HTTPRoute with two rules whose `backendRefs` both reference the same `Service`. This reproduces the `eval_conflict_error` pre-fix and asserts the aggregated `failedPaths`/`reviewPaths` (`spec.rules[0].backendRefs[0].name`, `spec.rules[1].backendRefs[0].name`) post-fix.
- [x] Existing tests under `rules/exposure-to-internet-via-gateway-api/test/` are unaffected — the single-match output shape (one-element array) is unchanged by the comprehension rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of services exposed to the internet through Gateway API HTTP routes.
  - Correctly identifies matching service backend references across HTTPRoute rules, including duplicate references.
  - Review results now point to the specific backend reference associated with the detected exposure.

- **Tests**
  - Added coverage for HTTPRoutes containing duplicate backend references and validated exposure results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->