### PR TITLE
fix: make floating image tags configurable

### DIFF
--- a/default-config-inputs.json
+++ b/default-config-inputs.json
@@ -8,8 +8,8 @@
     },
     "settings": {
         "postureControlInputs": {
-            "imageRepositoryAllowList": [
-            ],
+            "imageRepositoryAllowList": [],
+            "floatingImageTags": [],
             "trustedCosignPublicKeys": [],
             "insecureCapabilities": [
                 "SETPCAP",

--- a/rules/image-pull-policy-is-not-set-to-always/raw.rego
+++ b/rules/image-pull-policy-is-not-set-to-always/raw.rego
@@ -65,6 +65,13 @@ is_bad_container(container) if {
 	img == ":latest"
 }
 
+# Configured floating image tags are treated as latest-like.
+
+is_bad_container(container) if {
+    not_image_pull_policy(container)
+    is_floating_image_tag(container.image)
+}
+
 # No image tag or digest (== latest)
 is_bad_container(container) if {
 	not is_tag_image(container.image)
@@ -85,13 +92,6 @@ is_tag_image(image) if {
 	v := version[_]
 	img := v[_]
 	not endswith(img, "/")
-}
-
-# Configured floating image tags are treated as latest-like.
-
-is_bad_container(container) if {
-    not_image_pull_policy(container)
-    is_floating_image_tag(container.image)
 }
 
 is_floating_image_tag(image) if {

--- a/rules/image-pull-policy-is-not-set-to-always/raw.rego
+++ b/rules/image-pull-policy-is-not-set-to-always/raw.rego
@@ -71,12 +71,6 @@ is_bad_container(container) if {
 	not_image_pull_policy(container)
 }
 
-# image tag is only letters (== latest)
-is_bad_container(container) if {
-	is_tag_image_only_letters(container.image)
-	not_image_pull_policy(container)
-}
-
 not_image_pull_policy(container) if {
 	container.imagePullPolicy == "Never"
 }
@@ -93,12 +87,19 @@ is_tag_image(image) if {
 	not endswith(img, "/")
 }
 
-# The image has a tag, and contains only letters
-is_tag_image_only_letters(image) if {
-	reg1 := "^:[a-zA-Z]{1,127}$"
-	reg := ":[\\w][\\w.-]{0,127}(\/)?"
-	version := regex.find_all_string_submatch_n(reg, image, -1)
-	v := version[_]
-	img := v[_]
-	regex.match(reg1, img)
+# Configured floating image tags are treated as latest-like.
+
+is_bad_container(container) if {
+    not_image_pull_policy(container)
+    is_floating_image_tag(container.image)
+}
+
+is_floating_image_tag(image) if {
+    not contains(image, "@")
+    parts := split(image, "/")
+    last := parts[count(parts) - 1]
+    tag_parts := split(last, ":")
+    count(tag_parts) == 2
+    tag := tag_parts[1]
+    tag in data.postureControlInputs.floatingImageTags
 }

--- a/rules/image-pull-policy-is-not-set-to-always/rule.metadata.json
+++ b/rules/image-pull-policy-is-not-set-to-always/rule.metadata.json
@@ -42,7 +42,15 @@
         ]
       }
     ],
-    "ruleDependencies": [],
+   "ruleDependencies": [],
+   "configInputs": ["settings.postureControlInputs.floatingImageTags"],
+   "controlConfigInputs": [
+    {
+      "path": "settings.postureControlInputs.floatingImageTags",
+      "name": "Floating image tags",
+      "description": "Additional image tags that should be treated as mutable and require imagePullPolicy Always."
+    }
+  ],
     "description": "check imagePullPolicy filed, if imagePullPolicy = always pass, else fail.",
     "remediation": "",
     "ruleQuery": "armo_builtins"

--- a/rules/image-pull-policy-is-not-set-to-always/test/pod-configured-floating-tag/data.json
+++ b/rules/image-pull-policy-is-not-set-to-always/test/pod-configured-floating-tag/data.json
@@ -1,0 +1,7 @@
+{
+  "postureControlInputs": {
+    "floatingImageTags": [
+      "alpine"
+    ]
+  }
+}

--- a/rules/image-pull-policy-is-not-set-to-always/test/pod-configured-floating-tag/expected.json
+++ b/rules/image-pull-policy-is-not-set-to-always/test/pod-configured-floating-tag/expected.json
@@ -1,0 +1,28 @@
+[
+  {
+    "alertMessage": "container: redis in pod: floating-tag-test  has 'latest' tag on image but imagePullPolicy is not set to 'Always'",
+    "reviewPaths": [
+      "spec.containers[0].image",
+      "spec.containers[0].imagePullPolicy"
+    ],
+    "failedPaths": [
+      "spec.containers[0].image",
+      "spec.containers[0].imagePullPolicy"
+    ],
+    "fixPaths": [],
+    "ruleStatus": "",
+    "packagename": "armo_builtins",
+    "alertScore": 2,
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "v1",
+          "kind": "Pod",
+          "metadata": {
+            "name": "floating-tag-test"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/rules/image-pull-policy-is-not-set-to-always/test/pod-configured-floating-tag/input/pod.yaml
+++ b/rules/image-pull-policy-is-not-set-to-always/test/pod-configured-floating-tag/input/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: floating-tag-test
+spec:
+  containers:
+    - name: redis
+      image: redis:alpine
+      imagePullPolicy: IfNotPresent

--- a/rules/image-pull-policy-is-not-set-to-always/test/pod/input/pod.yaml
+++ b/rules/image-pull-policy-is-not-set-to-always/test/pod/input/pod.yaml
@@ -14,4 +14,6 @@ spec:
         imagePullPolicy: Never
       - name : test2
         image : test
-      
+      - name: hash-like-tag
+        image: test:befacaad
+        imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Fixes : #351 
## Overview 
 resolves ``#351`` by making non-`latest` floating image tags configurable instead of treating all letter-only tags as `latest`.

### Changes

* Removed the letter-only tag heuristic that caused false positives for hash-like tags such as `befacaad`.
* Added configurable `floatingImageTags` control input.
* Tags listed in `floatingImageTags` are now treated as mutable and require `imagePullPolicy: Always`.
* Added a regression test covering a configured floating tag (`redis:alpine`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration for identifying additional mutable (“floating”) image tags.
  * Image-pull policy checks now recognize configured floating tags and require `imagePullPolicy: Always`.
* **Bug Fixes**
  * Improved detection of image tags that may change over time, helping prevent workloads from running stale or unexpected images.
  * Updated validation coverage for configured floating tags and hash-like tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->