### PR TITLE
test: cover env var reference exemptions

### DIFF
--- a/rules/rule-credentials-in-env-var/test/pod-allowed-values-keys/input/pod.yaml
+++ b/rules/rule-credentials-in-env-var/test/pod-allowed-values-keys/input/pod.yaml
@@ -20,7 +20,17 @@ spec:
       - name : random
         value : "Hello from the environment"
       - name: AWS_TOKEN_FILE
-        value: /etc/secret-volume/aws
+        value: hunter2
+      - name: DB_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: database-secret
+            key: password
+      - name: CONFIG_PASSWORD
+        valueFrom:
+          configMapKeyRef:
+            name: database-config
+            key: password
       - name: my_password
         value: my/secret/file/path
     image : hashicorp/http-echo:0.2.3


### PR DESCRIPTION
Fixes : #772

## Overview

- Added regression coverage for the `_FILE` sensitive key-name exemption.
- Added coverage for environment variables using `secretKeyRef`.
- Added coverage for environment variables using `configMapKeyRef`.
- No Rego behavior changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded validation coverage for pod environment variables.
  * Added scenarios for literal credential values and credentials sourced from Secrets and ConfigMaps.
  * Updated an existing token-file environment variable scenario to use a literal value.
  * Verified handling of credentials from multiple configuration sources within the same container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->