### PR TITLE
feat(frameworks): add AgentRuntimeHardening framework

### DIFF
--- a/frameworks/agent-runtime-hardening.json
+++ b/frameworks/agent-runtime-hardening.json
@@ -1,0 +1,30 @@
+{
+    "name": "AgentRuntimeHardening",
+    "description": "Security posture framework for agent-runtime workloads (GKE Agent Sandbox / Agent Substrate). It verifies that model-generated, untrusted agent code is confined to a hardened sandbox runtime and a default-deny egress posture, rather than sharing the host kernel or having open network access. Controls map to the OWASP Top 10 for LLM Applications (2025) and MITRE ATLAS (see the accompanying design note for the full mapping). Implements the static-posture half (Part A) of kubescape/kubescape#2557 and gives the already-merged agent-sandbox controls a named framework to run under.",
+    "attributes": {
+        "builtin": true
+    },
+    "typeTags": [
+        "security"
+    ],
+    "scanningScope": {
+        "matches": [
+            "cluster",
+            "file"
+        ]
+    },
+    "activeControls": [
+        {
+            "controlID": "C-0297",
+            "patch": {
+                "name": "Agent Sandbox hardened runtime class"
+            }
+        },
+        {
+            "controlID": "C-0301",
+            "patch": {
+                "name": "Agent Sandbox egress policy enforcement"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## feat(frameworks): add `AgentRuntimeHardening` framework

### What
Adds a new framework, `frameworks/agent-runtime-hardening.json`, that wires the
already-merged agent-sandbox posture controls into a named framework:

- `C-0297` — Agent Sandbox hardened runtime class
- `C-0301` — Agent Sandbox egress policy enforcement

### Why
These controls currently exist in the library but are referenced by **zero**
frameworks, so `kubescape scan framework ...` never exercises them. This adds the
`AgentRuntimeHardening` framework — the deliverable Part A of
kubescape/kubescape#2557 is named after — so the merged work actually runs, and
gives GKE Agent Sandbox / Agent Substrate agent-runtime CRDs a home framework.

### Standards mapping
Controls map to the OWASP Top 10 for LLM Applications (2025) and MITRE ATLAS:

| Control | OWASP LLM (2025) | MITRE ATLAS |
|---|---|---|
| C-0297 hardened runtime class | LLM06 Excessive Agency; LLM05 Improper Output Handling | Execution / Defense-Evasion tactics; limits blast radius of AML.T0086 (Exfiltration via AI Agent Tool Invocation) |
| C-0301 egress default-deny | LLM02 Sensitive Information Disclosure; LLM06 Excessive Agency | Exfiltration tactic; AML.T0024 (Exfiltration via AI Inference API), AML.T0086 |

(Technique IDs from the current ATLAS matrix; tactic-level mapping where a
technique doesn't map 1:1 — happy to refine to maintainer preference. If you'd
prefer the mapping as per-control `attributes` rather than in the framework
description, I can move it.)

### Validation
`scripts/validations.py` passes for this framework (both controls resolve).

> Dependency note: this references `C-0301` (Agent Sandbox egress policy). Right
> now `master` has a duplicate `C-0301` (the dangling Gateway backend control),
> which trips the duplicate-ID check repo-wide. Per the thread on #784 the gateway
> one is being renumbered; this framework should land together with / after that
> dedup so the ID set is unambiguous. I verified locally that with the pending
> renumber applied, `validations.py` passes and `C-0301` resolves to the agent
> egress control. I intentionally did **not** include the renumber here to avoid
> conflicting with that in-flight change.

### Follow-ups (not in this PR)
- Add resource-ceilings control to the framework once #787 merges.
- First `WorkerPool`/`ActorTemplate` (Agent Substrate) controls.

Refs: kubescape/kubescape#2557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a built-in security framework for cluster and file scanning.
  * Introduced controls for hardened runtime configuration and egress policy enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->