### PR TITLE
feat: add C-0305 no-rolling-update-strategy rule

### DIFF
--- a/controls/C-0305-norollingupdatestrategy.json
+++ b/controls/C-0305-norollingupdatestrategy.json
@@ -1,0 +1,25 @@
+{
+    "name": "No rolling update strategy",
+    "attributes": {
+        "controlTypeTags": [
+            "devops"
+        ]
+    },
+    "description": "A Deployment that explicitly uses a non-rolling update strategy can cause avoidable service interruption during workload updates.",
+    "remediation": "Set spec.strategy.type to RollingUpdate.",
+    "rulesNames": [
+        "no-rolling-update-strategy"
+    ],
+    "test": "Check that Deployments with an explicit strategy type use a rolling update strategy.",
+    "controlID": "C-0305",
+    "baseScore": 3.0,
+    "category": {
+        "name": "Workload"
+    },
+    "scanningScope": {
+        "matches": [
+            "cluster",
+            "file"
+        ]
+    }
+}

--- a/frameworks/allcontrols.json
+++ b/frameworks/allcontrols.json
@@ -1663,6 +1663,12 @@
             "patch": {
                 "name": "Dangling Gateway API backend"
             }
+        },
+        {
+            "controlID": "C-0305",
+            "patch": {
+                "name": "No rolling update strategy"
+            }
         }
     ]
 }

--- a/frameworks/devopsbest.json
+++ b/frameworks/devopsbest.json
@@ -151,6 +151,12 @@
             "patch": {
                 "name": "Dangling Gateway API backend"
             }
+        },
+        {
+            "controlID": "C-0305",
+            "patch": {
+                "name": "No rolling update strategy"
+            }
         }
     ]
 }

--- a/rules/no-rolling-update-strategy/raw.rego
+++ b/rules/no-rolling-update-strategy/raw.rego
@@ -1,0 +1,25 @@
+package armo_builtins
+
+import future.keywords.contains
+import future.keywords.if
+
+deny contains msga if {
+	deployment := input[_]
+	deployment.kind == "Deployment"
+	strategy_type := deployment.spec.strategy.type
+	not usable_rolling_update_strategy(strategy_type)
+
+	msga := {
+		"alertMessage": sprintf("Deployment: %v does not use a rolling update strategy", [deployment.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 3,
+		"reviewPaths": ["spec.strategy.type"],
+		"failedPaths": ["spec.strategy.type"],
+		"fixPaths": [{"path": "spec.strategy.type", "value": "RollingUpdate"}],
+		"alertObject": {"k8sApiObjects": [deployment]},
+	}
+}
+
+usable_rolling_update_strategy(strategy_type) if {
+	strategy_type == "RollingUpdate"
+}

--- a/rules/no-rolling-update-strategy/raw.rego
+++ b/rules/no-rolling-update-strategy/raw.rego
@@ -1,3 +1,4 @@
+# regal ignore:directory-package-mismatch
 package armo_builtins
 
 import future.keywords.contains
@@ -20,6 +21,4 @@ deny contains msga if {
 	}
 }
 
-usable_rolling_update_strategy(strategy_type) if {
-	strategy_type == "RollingUpdate"
-}
+usable_rolling_update_strategy("RollingUpdate")

--- a/rules/no-rolling-update-strategy/rule.metadata.json
+++ b/rules/no-rolling-update-strategy/rule.metadata.json
@@ -1,0 +1,24 @@
+{
+    "name": "no-rolling-update-strategy",
+    "attributes": {
+    },
+    "ruleLanguage": "Rego",
+    "match": [
+        {
+            "apiGroups": [
+                "apps"
+            ],
+            "apiVersions": [
+                "v1"
+            ],
+            "resources": [
+                "Deployment"
+            ]
+        }
+    ],
+    "ruleDependencies": [
+    ],
+    "description": "Fails if a Deployment explicitly defines a non-rolling update strategy.",
+    "remediation": "Set spec.strategy.type to RollingUpdate.",
+    "ruleQuery": "armo_builtins"
+}

--- a/rules/no-rolling-update-strategy/test/deployment/expected.json
+++ b/rules/no-rolling-update-strategy/test/deployment/expected.json
@@ -1,0 +1,34 @@
+[
+  {
+    "alertMessage": "Deployment: recreate-strategy does not use a rolling update strategy",
+    "packagename": "armo_builtins",
+    "alertScore": 3,
+    "reviewPaths": [
+      "spec.strategy.type"
+    ],
+    "failedPaths": [
+      "spec.strategy.type"
+    ],
+    "fixPaths": [
+      {
+        "path": "spec.strategy.type",
+        "value": "RollingUpdate"
+      }
+    ],
+    "ruleStatus": "",
+    "alertObject": {
+      "k8sApiObjects": [
+        {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "metadata": {
+            "labels": {
+              "app": "recreate-strategy"
+            },
+            "name": "recreate-strategy"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/rules/no-rolling-update-strategy/test/deployment/input/empty-rolling-update.yaml
+++ b/rules/no-rolling-update-strategy/test/deployment/input/empty-rolling-update.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: empty-rolling-update
+  labels:
+    app: empty-rolling-update
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate: {}
+  selector:
+    matchLabels:
+      app: empty-rolling-update
+  template:
+    metadata:
+      labels:
+        app: empty-rolling-update
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.25

--- a/rules/no-rolling-update-strategy/test/deployment/input/missing-strategy.yaml
+++ b/rules/no-rolling-update-strategy/test/deployment/input/missing-strategy.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: missing-strategy
+  labels:
+    app: missing-strategy
+spec:
+  strategy: null
+  selector:
+    matchLabels:
+      app: missing-strategy
+  template:
+    metadata:
+      labels:
+        app: missing-strategy
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.25

--- a/rules/no-rolling-update-strategy/test/deployment/input/missing-strategy.yaml
+++ b/rules/no-rolling-update-strategy/test/deployment/input/missing-strategy.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: missing-strategy
 spec:
-  strategy: null
   selector:
     matchLabels:
       app: missing-strategy

--- a/rules/no-rolling-update-strategy/test/deployment/input/recreate-strategy.yaml
+++ b/rules/no-rolling-update-strategy/test/deployment/input/recreate-strategy.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recreate-strategy
+  labels:
+    app: recreate-strategy
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: recreate-strategy
+  template:
+    metadata:
+      labels:
+        app: recreate-strategy
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.25

--- a/rules/no-rolling-update-strategy/test/deployment/input/usable-rolling-update.yaml
+++ b/rules/no-rolling-update-strategy/test/deployment/input/usable-rolling-update.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: usable-rolling-update
+  labels:
+    app: usable-rolling-update
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: usable-rolling-update
+  template:
+    metadata:
+      labels:
+        app: usable-rolling-update
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.25

--- a/rules/no-rolling-update-strategy/test/deployment/input/zero-rolling-update.yaml
+++ b/rules/no-rolling-update-strategy/test/deployment/input/zero-rolling-update.yaml
@@ -8,7 +8,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 0
+      maxSurge: 1
       maxUnavailable: 0
   selector:
     matchLabels:

--- a/rules/no-rolling-update-strategy/test/deployment/input/zero-rolling-update.yaml
+++ b/rules/no-rolling-update-strategy/test/deployment/input/zero-rolling-update.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zero-rolling-update
+  labels:
+    app: zero-rolling-update
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: zero-rolling-update
+  template:
+    metadata:
+      labels:
+        app: zero-rolling-update
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.25


### PR DESCRIPTION
## Overview

Adds Kubescape support for the kube-linter `no-rolling-update-strategy` check.

This PR introduces a new **C-0305** control and Rego rule that flags Deployments with an explicit non-`RollingUpdate` strategy type. The rule only fires when `spec.strategy.type` is explicitly set to something other than `RollingUpdate` (e.g. `Recreate`), matching upstream kube-linter semantics.

The control is wired into **DevOpsBest** and **AllControls** (via `generate_allcontrols.py`).

### Why C-0305?

This continues the work from stale PR #729 (originally C-0298). C-0298 is now assigned to `dangling-ingress-backend` on master, and my other in-flight PRs already use C-0303 and C-0304, so the next available ID is C-0305.

## Changes

| File | Change |
|---|---|
| `controls/C-0305-norollingupdatestrategy.json` | New control definition |
| `rules/no-rolling-update-strategy/raw.rego` | Rego deny rule targeting `apps/v1` Deployments |
| `rules/no-rolling-update-strategy/rule.metadata.json` | Rule metadata |
| `frameworks/devopsbest.json` | Added C-0305 to `activeControls` |
| `frameworks/allcontrols.json` | Regenerated via `generate_allcontrols.py` |
| `rules/no-rolling-update-strategy/test/deployment/` | 5 test fixtures + expected output |

## Test Fixtures

| Fixture | Strategy | Expected |
|---|---|---|
| `recreate-strategy.yaml` | `Recreate` | ❌ Fails (alert) |
| `missing-strategy.yaml` | `null` | ✅ Passes |
| `empty-rolling-update.yaml` | `RollingUpdate` (empty config) | ✅ Passes |
| `usable-rolling-update.yaml` | `RollingUpdate` (25%/0) | ✅ Passes |
| `zero-rolling-update.yaml` | `RollingUpdate` (0/0) | ✅ Passes |

## How to Test

```bash
cd testrunner && go test -v -tags="static" rego_test.go -run TestSingleRule -args -rule no-rolling-update-strategy
````


## Summary by CodeRabbit

* **New Features**
  * Added a control that detects Kubernetes Deployments configured without a rolling update strategy.
  * Included remediation guidance and coverage in supported security frameworks.
  * RollingUpdate configurations, including explicit zero-value settings, are recognized as valid.

* **Tests**
  * Added coverage for missing, empty, recreate, valid, and zero-value rolling update configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a security control that detects Kubernetes Deployments configured without a rolling update strategy.
  * Included remediation guidance and scan details for affected Deployments.
  * Enabled the control across the applicable built-in frameworks.

* **Tests**
  * Added coverage for missing, recreate, empty, valid, and zero-value rolling update configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->