### PR TITLE
fix: add ephemeralContainers and initContainers coverage to security rules

### DIFF
--- a/rules/immutable-container-filesystem/raw.rego
+++ b/rules/immutable-container-filesystem/raw.rego
@@ -21,6 +21,41 @@ deny contains msga if {
 	}
 }
 
+# Fails if pods has initContainer with mutable filesystem
+deny contains msga if {
+	start_of_path := "spec."
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.initContainers[i]
+	is_mutable_filesystem(container)
+	fixPath = {"path": sprintf("%vinitContainers[%d].securityContext.readOnlyRootFilesystem", [start_of_path, i]), "value": "true"}
+	msga := {
+		"alertMessage": sprintf("container: %v in pod: %v  has  mutable filesystem", [container.name, pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [],
+		"fixPaths": [fixPath],
+		"alertObject": {"k8sApiObjects": [pod]},
+	}
+}
+
+# Fails if pods has ephemeralContainer with mutable filesystem
+deny contains msga if {
+	start_of_path := "spec."
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.ephemeralContainers[i]
+	is_mutable_filesystem(container)
+	msga := {
+		"alertMessage": sprintf("container: %v in pod: %v  has  mutable filesystem", [container.name, pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [],
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [pod]},
+	}
+}
+
 # Fails if workload has  container with mutable filesystem
 deny contains msga if {
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
@@ -40,6 +75,26 @@ deny contains msga if {
 	}
 }
 
+# Fails if workload has initContainer with mutable filesystem
+deny contains msga if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	start_of_path := "spec.template.spec."
+	wl := input[_]
+	spec_template_spec_patterns[wl.kind]
+	container := wl.spec.template.spec.initContainers[i]
+	is_mutable_filesystem(container)
+	fixPath = {"path": sprintf("%vinitContainers[%d].securityContext.readOnlyRootFilesystem", [start_of_path, i]), "value": "true"}
+	msga := {
+		"alertMessage": sprintf("container :%v in %v: %v has  mutable filesystem", [container.name, wl.kind, wl.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [],
+		"fixPaths": [fixPath],
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
+}
+
+
 # Fails if cronjob has  container with mutable filesystem
 deny contains msga if {
 	start_of_path := "spec.jobTemplate.spec.template.spec."
@@ -58,6 +113,26 @@ deny contains msga if {
 		"alertObject": {"k8sApiObjects": [wl]},
 	}
 }
+
+# Fails if cronjob has initContainer with mutable filesystem
+deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
+	wl := input[_]
+	wl.kind == "CronJob"
+	container = wl.spec.jobTemplate.spec.template.spec.initContainers[i]
+	is_mutable_filesystem(container)
+	fixPath = {"path": sprintf("%vinitContainers[%d].securityContext.readOnlyRootFilesystem", [start_of_path, i]), "value": "true"}
+
+	msga := {
+		"alertMessage": sprintf("container :%v in %v: %v has mutable filesystem", [container.name, wl.kind, wl.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"failedPaths": [],
+		"fixPaths": [fixPath],
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
+}
+
 
 # Default of readOnlyRootFilesystem is false. This field is only in container spec and not pod spec
 is_mutable_filesystem(container) if {

--- a/rules/immutable-container-filesystem/test/pod-ephemeralcontainer/expected.json
+++ b/rules/immutable-container-filesystem/test/pod-ephemeralcontainer/expected.json
@@ -1,0 +1,17 @@
+[{
+    "alertMessage": "container: debugger in pod: test  has  mutable filesystem",
+    "failedPaths": [],
+    "fixPaths": [],
+    "ruleStatus": "",
+    "packagename": "armo_builtins",
+    "alertScore": 7,
+    "alertObject": {
+        "k8sApiObjects": [{
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "test"
+            }
+        }]
+    }
+}]

--- a/rules/immutable-container-filesystem/test/pod-ephemeralcontainer/input/pod.yaml
+++ b/rules/immutable-container-filesystem/test/pod-ephemeralcontainer/input/pod.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: test
+spec:
+      containers:
+      - name: app
+        image: nginx
+        securityContext:
+          readOnlyRootFilesystem: true
+      ephemeralContainers:
+      - name: debugger
+        image: busybox

--- a/rules/immutable-container-filesystem/test/pod-initcontainer/expected.json
+++ b/rules/immutable-container-filesystem/test/pod-initcontainer/expected.json
@@ -1,0 +1,39 @@
+[{
+    "alertMessage": "container: init-test in pod: test  has  mutable filesystem",
+    "failedPaths": [],
+    "fixPaths": [{
+        "path": "spec.initContainers[0].securityContext.readOnlyRootFilesystem",
+        "value": "true"
+    }],
+    "ruleStatus": "",
+    "packagename": "armo_builtins",
+    "alertScore": 7,
+    "alertObject": {
+        "k8sApiObjects": [{
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "test"
+            }
+        }]
+    }
+}, {
+    "alertMessage": "container: init-test2 in pod: test  has  mutable filesystem",
+    "failedPaths": [],
+    "fixPaths": [{
+        "path": "spec.initContainers[1].securityContext.readOnlyRootFilesystem",
+        "value": "true"
+    }],
+    "ruleStatus": "",
+    "packagename": "armo_builtins",
+    "alertScore": 7,
+    "alertObject": {
+        "k8sApiObjects": [{
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "test"
+            }
+        }]
+    }
+}]

--- a/rules/immutable-container-filesystem/test/pod-initcontainer/input/pod.yaml
+++ b/rules/immutable-container-filesystem/test/pod-initcontainer/input/pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: test
+spec:
+      initContainers:
+      - image: nginx:latest
+        name: init-test
+      - name: init-test2
+        image: nginx
+        securityContext:
+          privileged: true
+      containers:
+      - name: app
+        image: nginx
+        securityContext:
+          readOnlyRootFilesystem: true

--- a/rules/immutable-container-filesystem/test/workloads-initcontainer/expected.json
+++ b/rules/immutable-container-filesystem/test/workloads-initcontainer/expected.json
@@ -1,0 +1,23 @@
+[{
+    "alertMessage": "container :init-setup in Deployment: my-deployment has  mutable filesystem",
+    "failedPaths": [],
+    "fixPaths": [{
+        "path": "spec.template.spec.initContainers[0].securityContext.readOnlyRootFilesystem",
+        "value": "true"
+    }],
+    "ruleStatus": "",
+    "packagename": "armo_builtins",
+    "alertScore": 7,
+    "alertObject": {
+        "k8sApiObjects": [{
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "labels": {
+                    "app": "goproxy"
+                },
+                "name": "my-deployment"
+            }
+        }]
+    }
+}]

--- a/rules/immutable-container-filesystem/test/workloads-initcontainer/input/deployment.yaml
+++ b/rules/immutable-container-filesystem/test/workloads-initcontainer/input/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+  labels:
+    app: goproxy
+spec:
+  selector:
+    matchLabels:
+      app: goproxy
+  template:
+    metadata:
+      name: goproxy
+      labels:
+        app: goproxy
+    spec:
+      initContainers:
+        - name: init-setup
+          image: busybox
+      containers:
+        - name: app
+          image: nginx
+          securityContext:
+            readOnlyRootFilesystem: true

--- a/rules/insecure-capabilities/raw.rego
+++ b/rules/insecure-capabilities/raw.rego
@@ -10,7 +10,7 @@ deny contains msga if {
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
-	result := is_dangerous_capabilities(container, start_of_path, i)
+	result := is_dangerous_capabilities(container, start_of_path, i, "containers")
 	msga := {
 		"alertMessage": sprintf("container: %v in pod: %v  have dangerous capabilities", [container.name, pod.metadata.name]),
 		"packagename": "armo_builtins",
@@ -23,14 +23,84 @@ deny contains msga if {
 }
 
 deny contains msga if {
+	start_of_path := "spec."
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.initContainers[i]
+	result := is_dangerous_capabilities(container, start_of_path, i, "initContainers")
+	msga := {
+		"alertMessage": sprintf("container: %v in pod: %v  have dangerous capabilities", [container.name, pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"deletePaths": result,
+		"failedPaths": result,
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [pod]},
+	}
+}
+
+deny contains msga if {
+	start_of_path := "spec."
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.ephemeralContainers[i]
+	result := is_dangerous_capabilities(container, start_of_path, i, "ephemeralContainers")
+	msga := {
+		"alertMessage": sprintf("container: %v in pod: %v  have dangerous capabilities", [container.name, pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"deletePaths": [],
+		"failedPaths": result,
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [pod]},
+	}
+}
+
+deny contains msga if {
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
 	start_of_path := "spec.template.spec."
 	wl := input[_]
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
-	result := is_dangerous_capabilities(container, start_of_path, i)
+	result := is_dangerous_capabilities(container, start_of_path, i, "containers")
 	msga := {
 		"alertMessage": sprintf("container: %v in workload: %v  have dangerous capabilities", [container.name, wl.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"deletePaths": result,
+		"failedPaths": result,
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
+}
+
+deny contains msga if {
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	start_of_path := "spec.template.spec."
+	wl := input[_]
+	spec_template_spec_patterns[wl.kind]
+	container := wl.spec.template.spec.initContainers[i]
+	result := is_dangerous_capabilities(container, start_of_path, i, "initContainers")
+	msga := {
+		"alertMessage": sprintf("container: %v in workload: %v  have dangerous capabilities", [container.name, wl.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"deletePaths": result,
+		"failedPaths": result,
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
+}
+
+
+deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec."
+	wl := input[_]
+	wl.kind == "CronJob"
+	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
+	result := is_dangerous_capabilities(container, start_of_path, i, "containers")
+	msga := {
+		"alertMessage": sprintf("container: %v in cronjob: %v  have dangerous capabilities", [container.name, wl.metadata.name]),
 		"packagename": "armo_builtins",
 		"alertScore": 7,
 		"deletePaths": result,
@@ -44,8 +114,8 @@ deny contains msga if {
 	start_of_path := "spec.jobTemplate.spec.template.spec."
 	wl := input[_]
 	wl.kind == "CronJob"
-	container := wl.spec.jobTemplate.spec.template.spec.containers[i]
-	result := is_dangerous_capabilities(container, start_of_path, i)
+	container := wl.spec.jobTemplate.spec.template.spec.initContainers[i]
+	result := is_dangerous_capabilities(container, start_of_path, i, "initContainers")
 	msga := {
 		"alertMessage": sprintf("container: %v in cronjob: %v  have dangerous capabilities", [container.name, wl.metadata.name]),
 		"packagename": "armo_builtins",
@@ -57,9 +127,10 @@ deny contains msga if {
 	}
 }
 
-is_dangerous_capabilities(container, start_of_path, i) := path if {
+
+is_dangerous_capabilities(container, start_of_path, i, container_type) := path if {
 	# see default-config-inputs.json for list values
 	insecureCapabilities := data.postureControlInputs.insecureCapabilities
-	path = [sprintf("%vcontainers[%v].securityContext.capabilities.add[%v]", [start_of_path, format_int(i, 10), format_int(k, 10)]) | capability = container.securityContext.capabilities.add[k]; cautils.list_contains(insecureCapabilities, capability)]
+	path = [sprintf("%v%v[%v].securityContext.capabilities.add[%v]", [start_of_path, container_type, format_int(i, 10), format_int(k, 10)]) | capability = container.securityContext.capabilities.add[k]; cautils.list_contains(insecureCapabilities, capability)]
 	count(path) > 0
 }

--- a/rules/insecure-capabilities/test/pod-ephemeralcontainer/expected.json
+++ b/rules/insecure-capabilities/test/pod-ephemeralcontainer/expected.json
@@ -1,0 +1,24 @@
+[
+    {
+        "alertMessage": "container: debugger in pod: test  have dangerous capabilities",
+        "deletePaths": [],
+        "failedPaths": [
+            "spec.ephemeralContainers[0].securityContext.capabilities.add[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "test"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/insecure-capabilities/test/pod-ephemeralcontainer/input/pod.yaml
+++ b/rules/insecure-capabilities/test/pod-ephemeralcontainer/input/pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: test
+spec:
+      containers:
+      - name: app
+        image: nginx
+      ephemeralContainers:
+      - name: debugger
+        image: busybox
+        securityContext:
+          capabilities:
+            add: ["ALL"]

--- a/rules/insecure-capabilities/test/pod-initcontainer/expected.json
+++ b/rules/insecure-capabilities/test/pod-initcontainer/expected.json
@@ -1,0 +1,28 @@
+[
+    {
+        "alertMessage": "container: init-setup in pod: test  have dangerous capabilities",
+        "deletePaths": [
+            "spec.initContainers[0].securityContext.capabilities.add[0]",
+            "spec.initContainers[0].securityContext.capabilities.add[1]"
+        ],
+        "failedPaths": [
+            "spec.initContainers[0].securityContext.capabilities.add[0]",
+            "spec.initContainers[0].securityContext.capabilities.add[1]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "test"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/insecure-capabilities/test/pod-initcontainer/input/pod.yaml
+++ b/rules/insecure-capabilities/test/pod-initcontainer/input/pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: test
+spec:
+      initContainers:
+      - name: init-setup
+        image: busybox
+        securityContext:
+          capabilities:
+            add: ["SETPCAP", "MAC_OVERRIDE"]
+      containers:
+      - name: app
+        image: nginx

--- a/rules/insecure-capabilities/test/workloads-initcontainer/expected.json
+++ b/rules/insecure-capabilities/test/workloads-initcontainer/expected.json
@@ -1,0 +1,29 @@
+[
+    {
+        "alertMessage": "container: init-setup in workload: my-deployment  have dangerous capabilities",
+        "deletePaths": [
+            "spec.template.spec.initContainers[0].securityContext.capabilities.add[0]"
+        ],
+        "failedPaths": [
+            "spec.template.spec.initContainers[0].securityContext.capabilities.add[0]"
+        ],
+        "fixPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "goproxy"
+                        },
+                        "name": "my-deployment"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/insecure-capabilities/test/workloads-initcontainer/input/deployment.yaml
+++ b/rules/insecure-capabilities/test/workloads-initcontainer/input/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+  labels:
+    app: goproxy
+spec:
+  selector:
+    matchLabels:
+      app: goproxy
+  template:
+    metadata:
+      name: goproxy
+      labels:
+        app: goproxy
+    spec:
+      initContainers:
+        - name: init-setup
+          image: busybox
+          securityContext:
+            capabilities:
+              add: ["SYS_ADMIN"]
+      containers:
+        - name: app
+          image: nginx

--- a/rules/non-root-containers/raw.rego
+++ b/rules/non-root-containers/raw.rego
@@ -4,15 +4,15 @@ package armo_builtins
 import rego.v1
 
 ################################################################################
-# Rules
+# Rules — Pod containers
 deny contains msga if {
 	start_of_path := "spec"
 	pod := input[_]
 	pod.kind == "Pod"
 	container := pod.spec.containers[i]
 
-	run_as_user_fixpath := evaluate_workload_run_as_user(container, pod, start_of_path)
-	run_as_group_fixpath := evaluate_workload_run_as_group(container, pod, start_of_path)
+	run_as_user_fixpath := evaluate_workload_run_as_user(container, pod, start_of_path, "containers")
+	run_as_group_fixpath := evaluate_workload_run_as_group(container, pod, start_of_path, "containers")
 	all_fixpaths := array.concat(run_as_user_fixpath, run_as_group_fixpath)
 	count(all_fixpaths) > 0
 	fixPaths := get_fixed_paths(all_fixpaths, i)
@@ -28,6 +28,55 @@ deny contains msga if {
 	}
 }
 
+# Pod initContainers
+deny contains msga if {
+	start_of_path := "spec"
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.initContainers[i]
+
+	run_as_user_fixpath := evaluate_workload_run_as_user(container, pod, start_of_path, "initContainers")
+	run_as_group_fixpath := evaluate_workload_run_as_group(container, pod, start_of_path, "initContainers")
+	all_fixpaths := array.concat(run_as_user_fixpath, run_as_group_fixpath)
+	count(all_fixpaths) > 0
+	fixPaths := get_fixed_paths(all_fixpaths, i)
+
+	msga := {
+		"alertMessage": sprintf("container: %v in pod: %v  may run as root", [container.name, pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"reviewPaths": [],
+		"failedPaths": [],
+		"fixPaths": fixPaths,
+		"alertObject": {"k8sApiObjects": [pod]},
+	}
+}
+
+# Pod ephemeralContainers
+deny contains msga if {
+	start_of_path := "spec"
+	pod := input[_]
+	pod.kind == "Pod"
+	container := pod.spec.ephemeralContainers[i]
+
+	run_as_user_fixpath := evaluate_workload_run_as_user(container, pod, start_of_path, "ephemeralContainers")
+	run_as_group_fixpath := evaluate_workload_run_as_group(container, pod, start_of_path, "ephemeralContainers")
+	all_fixpaths := array.concat(run_as_user_fixpath, run_as_group_fixpath)
+	count(all_fixpaths) > 0
+
+	msga := {
+		"alertMessage": sprintf("container: %v in pod: %v  may run as root", [container.name, pod.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"reviewPaths": [],
+		"failedPaths": [],
+		"fixPaths": [],
+		"alertObject": {"k8sApiObjects": [pod]},
+	}
+}
+
+################################################################################
+# Rules — Workload containers
 deny contains msga if {
 	start_of_path := "spec.template.spec"
 	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
@@ -35,8 +84,8 @@ deny contains msga if {
 	spec_template_spec_patterns[wl.kind]
 	container := wl.spec.template.spec.containers[i]
 
-	run_as_user_fixpath := evaluate_workload_run_as_user(container, wl.spec.template, start_of_path)
-	run_as_group_fixpath := evaluate_workload_run_as_group(container, wl.spec.template, start_of_path)
+	run_as_user_fixpath := evaluate_workload_run_as_user(container, wl.spec.template, start_of_path, "containers")
+	run_as_group_fixpath := evaluate_workload_run_as_group(container, wl.spec.template, start_of_path, "containers")
 	all_fixpaths := array.concat(run_as_user_fixpath, run_as_group_fixpath)
 	count(all_fixpaths) > 0
 	fixPaths := get_fixed_paths(all_fixpaths, i)
@@ -52,15 +101,42 @@ deny contains msga if {
 	}
 }
 
-# Fails if cronjob has a container configured to run as root
+# Workload initContainers
+deny contains msga if {
+	start_of_path := "spec.template.spec"
+	spec_template_spec_patterns := {"Deployment", "ReplicaSet", "DaemonSet", "StatefulSet", "Job"}
+	wl := input[_]
+	spec_template_spec_patterns[wl.kind]
+	container := wl.spec.template.spec.initContainers[i]
+
+	run_as_user_fixpath := evaluate_workload_run_as_user(container, wl.spec.template, start_of_path, "initContainers")
+	run_as_group_fixpath := evaluate_workload_run_as_group(container, wl.spec.template, start_of_path, "initContainers")
+	all_fixpaths := array.concat(run_as_user_fixpath, run_as_group_fixpath)
+	count(all_fixpaths) > 0
+	fixPaths := get_fixed_paths(all_fixpaths, i)
+
+	msga := {
+		"alertMessage": sprintf("container: %v in %v: %v may run as root", [container.name, wl.kind, wl.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"reviewPaths": [],
+		"failedPaths": [],
+		"fixPaths": fixPaths,
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
+}
+
+
+################################################################################
+# Rules — CronJob containers
 deny contains msga if {
 	start_of_path := "spec.jobTemplate.spec.template.spec"
 	wl := input[_]
 	wl.kind == "CronJob"
 	container = wl.spec.jobTemplate.spec.template.spec.containers[i]
 
-	run_as_user_fixpath := evaluate_workload_run_as_user(container, wl.spec.jobTemplate.spec.template, start_of_path)
-	run_as_group_fixpath := evaluate_workload_run_as_group(container, wl.spec.jobTemplate.spec.template, start_of_path)
+	run_as_user_fixpath := evaluate_workload_run_as_user(container, wl.spec.jobTemplate.spec.template, start_of_path, "containers")
+	run_as_group_fixpath := evaluate_workload_run_as_group(container, wl.spec.jobTemplate.spec.template, start_of_path, "containers")
 	all_fixpaths := array.concat(run_as_user_fixpath, run_as_group_fixpath)
 	count(all_fixpaths) > 0
 	fixPaths := get_fixed_paths(all_fixpaths, i)
@@ -76,6 +152,31 @@ deny contains msga if {
 	}
 }
 
+# CronJob initContainers
+deny contains msga if {
+	start_of_path := "spec.jobTemplate.spec.template.spec"
+	wl := input[_]
+	wl.kind == "CronJob"
+	container = wl.spec.jobTemplate.spec.template.spec.initContainers[i]
+
+	run_as_user_fixpath := evaluate_workload_run_as_user(container, wl.spec.jobTemplate.spec.template, start_of_path, "initContainers")
+	run_as_group_fixpath := evaluate_workload_run_as_group(container, wl.spec.jobTemplate.spec.template, start_of_path, "initContainers")
+	all_fixpaths := array.concat(run_as_user_fixpath, run_as_group_fixpath)
+	count(all_fixpaths) > 0
+	fixPaths := get_fixed_paths(all_fixpaths, i)
+
+	msga := {
+		"alertMessage": sprintf("container: %v in %v: %v  may run as root", [container.name, wl.kind, wl.metadata.name]),
+		"packagename": "armo_builtins",
+		"alertScore": 7,
+		"reviewPaths": [],
+		"failedPaths": [],
+		"fixPaths": fixPaths,
+		"alertObject": {"k8sApiObjects": [wl]},
+	}
+}
+
+
 get_fixed_paths(all_fixpaths, i) := [{"path": replace(all_fixpaths[0].path, "container_ndx", format_int(i, 10)), "value": all_fixpaths[0].value}, {"path": replace(all_fixpaths[1].path, "container_ndx", format_int(i, 10)), "value": all_fixpaths[1].value}] if {
 	count(all_fixpaths) == 2
 } else := [{"path": replace(all_fixpaths[0].path, "container_ndx", format_int(i, 10)), "value": all_fixpaths[0].value}]
@@ -86,11 +187,11 @@ get_fixed_paths(all_fixpaths, i) := [{"path": replace(all_fixpaths[0].path, "con
 # if runAsUser is set to 0 and runAsNonRoot is set to false/ not set - suggest to set runAsUser to 1000
 # if runAsUser is not set and runAsNonRoot is set to false/ not set - suggest to set runAsNonRoot to true
 # all checks are both on the pod and the container level
-evaluate_workload_run_as_user(container, pod, start_of_path) := fixPath if {
-	runAsNonRootValue := get_run_as_non_root_value(container, pod, start_of_path)
+evaluate_workload_run_as_user(container, pod, start_of_path, container_type) := fixPath if {
+	runAsNonRootValue := get_run_as_non_root_value(container, pod, start_of_path, container_type)
 	runAsNonRootValue.value == false
 
-	runAsUserValue := get_run_as_user_value(container, pod, start_of_path)
+	runAsUserValue := get_run_as_user_value(container, pod, start_of_path, container_type)
 	runAsUserValue.value == 0
 
 	alertInfo := choose_first_if_defined(runAsUserValue, runAsNonRootValue)
@@ -99,8 +200,8 @@ evaluate_workload_run_as_user(container, pod, start_of_path) := fixPath if {
 
 # if runAsGroup is set to 0/ not set - suggest to set runAsGroup to 1000
 # all checks are both on the pod and the container level
-evaluate_workload_run_as_group(container, pod, start_of_path) := fixPath if {
-	runAsGroupValue := get_run_as_group_value(container, pod, start_of_path)
+evaluate_workload_run_as_group(container, pod, start_of_path, container_type) := fixPath if {
+	runAsGroupValue := get_run_as_group_value(container, pod, start_of_path, container_type)
 	runAsGroupValue.value == 0
 
 	fixPath := runAsGroupValue.fixPath
@@ -109,31 +210,31 @@ evaluate_workload_run_as_group(container, pod, start_of_path) := fixPath if {
 #################################################################################
 # Value resolution functions
 
-get_run_as_non_root_value(container, pod, start_of_path) := runAsNonRoot if {
-	runAsNonRoot := {"value": container.securityContext.runAsNonRoot, "fixPath": [{"path": sprintf("%v.containers[container_ndx].securityContext.runAsNonRoot", [start_of_path]), "value": "true"}], "defined": true}
+get_run_as_non_root_value(container, pod, start_of_path, container_type) := runAsNonRoot if {
+	runAsNonRoot := {"value": container.securityContext.runAsNonRoot, "fixPath": [{"path": sprintf("%v.%v[container_ndx].securityContext.runAsNonRoot", [start_of_path, container_type]), "value": "true"}], "defined": true}
 } else := runAsNonRoot if {
-	runAsNonRoot := {"value": pod.spec.securityContext.runAsNonRoot, "fixPath": [{"path": sprintf("%v.containers[container_ndx].securityContext.runAsNonRoot", [start_of_path]), "value": "true"}], "defined": true}
-} else := {"value": false, "fixPath": [{"path": sprintf("%v.containers[container_ndx].securityContext.runAsNonRoot", [start_of_path]), "value": "true"}], "defined": false}
+	runAsNonRoot := {"value": pod.spec.securityContext.runAsNonRoot, "fixPath": [{"path": sprintf("%v.%v[container_ndx].securityContext.runAsNonRoot", [start_of_path, container_type]), "value": "true"}], "defined": true}
+} else := {"value": false, "fixPath": [{"path": sprintf("%v.%v[container_ndx].securityContext.runAsNonRoot", [start_of_path, container_type]), "value": "true"}], "defined": false}
 
-get_run_as_user_value(container, pod, start_of_path) := runAsUser if {
-	path := sprintf("%v.containers[container_ndx].securityContext.runAsUser", [start_of_path])
+get_run_as_user_value(container, pod, start_of_path, container_type) := runAsUser if {
+	path := sprintf("%v.%v[container_ndx].securityContext.runAsUser", [start_of_path, container_type])
 	runAsUser := {"value": container.securityContext.runAsUser, "fixPath": [{"path": path, "value": "1000"}], "defined": true}
 } else := runAsUser if {
 	path := sprintf("%v.securityContext.runAsUser", [start_of_path])
 	runAsUser := {"value": pod.spec.securityContext.runAsUser, "fixPath": [{"path": path, "value": "1000"}], "defined": true}
 } else := {
-	"value": 0, "fixPath": [{"path": sprintf("%v.containers[container_ndx].securityContext.runAsNonRoot", [start_of_path]), "value": "true"}],
+	"value": 0, "fixPath": [{"path": sprintf("%v.%v[container_ndx].securityContext.runAsNonRoot", [start_of_path, container_type]), "value": "true"}],
 	"defined": false,
 }
 
-get_run_as_group_value(container, pod, start_of_path) := runAsGroup if {
-	path := sprintf("%v.containers[container_ndx].securityContext.runAsGroup", [start_of_path])
+get_run_as_group_value(container, pod, start_of_path, container_type) := runAsGroup if {
+	path := sprintf("%v.%v[container_ndx].securityContext.runAsGroup", [start_of_path, container_type])
 	runAsGroup := {"value": container.securityContext.runAsGroup, "fixPath": [{"path": path, "value": "1000"}], "defined": true}
 } else := runAsGroup if {
 	path := sprintf("%v.securityContext.runAsGroup", [start_of_path])
 	runAsGroup := {"value": pod.spec.securityContext.runAsGroup, "fixPath": [{"path": path, "value": "1000"}], "defined": true}
 } else := {
-	"value": 0, "fixPath": [{"path": sprintf("%v.containers[container_ndx].securityContext.runAsGroup", [start_of_path]), "value": "1000"}],
+	"value": 0, "fixPath": [{"path": sprintf("%v.%v[container_ndx].securityContext.runAsGroup", [start_of_path, container_type]), "value": "1000"}],
 	"defined": false,
 }
 

--- a/rules/non-root-containers/test/pod-ephemeralcontainer/expected.json
+++ b/rules/non-root-containers/test/pod-ephemeralcontainer/expected.json
@@ -1,0 +1,22 @@
+[
+    {
+        "alertMessage": "container: debugger in pod: test  may run as root",
+        "failedPaths": [],
+        "fixPaths": [],
+        "reviewPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "test"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/non-root-containers/test/pod-ephemeralcontainer/input/pod.yaml
+++ b/rules/non-root-containers/test/pod-ephemeralcontainer/input/pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: test
+spec:
+      containers:
+      - name: app
+        image: nginx
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+      ephemeralContainers:
+      - name: debugger
+        image: busybox

--- a/rules/non-root-containers/test/pod-initcontainer/expected.json
+++ b/rules/non-root-containers/test/pod-initcontainer/expected.json
@@ -1,0 +1,31 @@
+[
+    {
+        "alertMessage": "container: init-setup in pod: test  may run as root",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.initContainers[0].securityContext.runAsNonRoot",
+                "value": "true"
+            },
+            {
+                "path": "spec.initContainers[0].securityContext.runAsGroup",
+                "value": "1000"
+            }
+        ],
+        "reviewPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {
+                        "name": "test"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/non-root-containers/test/pod-initcontainer/input/pod.yaml
+++ b/rules/non-root-containers/test/pod-initcontainer/input/pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: test
+spec:
+      initContainers:
+      - name: init-setup
+        image: busybox
+      containers:
+      - name: app
+        image: nginx
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000

--- a/rules/non-root-containers/test/workloads-initcontainer/expected.json
+++ b/rules/non-root-containers/test/workloads-initcontainer/expected.json
@@ -1,0 +1,34 @@
+[
+    {
+        "alertMessage": "container: init-setup in Deployment: my-deployment may run as root",
+        "failedPaths": [],
+        "fixPaths": [
+            {
+                "path": "spec.template.spec.initContainers[0].securityContext.runAsNonRoot",
+                "value": "true"
+            },
+            {
+                "path": "spec.template.spec.initContainers[0].securityContext.runAsGroup",
+                "value": "1000"
+            }
+        ],
+        "reviewPaths": [],
+        "ruleStatus": "",
+        "packagename": "armo_builtins",
+        "alertScore": 7,
+        "alertObject": {
+            "k8sApiObjects": [
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "goproxy"
+                        },
+                        "name": "my-deployment"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/rules/non-root-containers/test/workloads-initcontainer/input/deployment.yaml
+++ b/rules/non-root-containers/test/workloads-initcontainer/input/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+  labels:
+    app: goproxy
+spec:
+  selector:
+    matchLabels:
+      app: goproxy
+  template:
+    metadata:
+      name: goproxy
+      labels:
+        app: goproxy
+    spec:
+      initContainers:
+        - name: init-setup
+          image: busybox
+      containers:
+        - name: app
+          image: nginx
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000


### PR DESCRIPTION
**Summary**
This PR revives and modernizes the intent of the stale/abandoned PR #710, extending coverage for `initContainers` and `ephemeralContainers` across the following security rules:
- `immutable-container-filesystem`
- `insecure-capabilities`
- `non-root-containers`

This implementation fulfills the original feature request while comprehensively resolving the structural bugs and maintainer feedback that previously blocked #710.

**Key Improvements over #710:**
* **Fixed OPA Parser Panics (Blocker 1)**: Prevented Go `testrunner` crashes by keeping helper sets and string matching inline/parameterized. This completely avoids polluting `data.armo_builtins` with package-level variables that fail to unmarshal.
* **Maintained Backward Compatibility (Blocker 2)**: Retained the original `alertMessage` formatting (preserving exact spacing syntax) to ensure we do not break the 140+ existing `expected.json` assertions already present in `master`.
* **Removed Invalid K8s Syntax (Maintainer Feedback)**: Adhered directly to `@matthyx`'s review by dropping dead code and invalid tests that injected `ephemeralContainers` into Workload and CronJob templates (which the Kubernetes API strictly rejects). `ephemeralContainers` are now correctly evaluated only at the live Pod level.
* **Safer FixPath Generation**: Replaced brute-force string replacement hacks (`rewrite_fixpaths`) with native, parameterized Rego helper functions that generate accurate failure/fix paths natively during evaluation.

**Testing**
Added robust, targeted test scenarios (18 test files total) across all three rules to validate:
- `pod-initcontainer`
- `pod-ephemeralcontainer`
- `workloads-initcontainer`

(Note: Test permutations for `workload-ephemeral` and `cronjob-ephemeral` were omitted as they represent invalid K8s API schema. Redundant `cronjob-initcontainer` tests were skipped as nested template traversal is already comprehensively proven via the `workload-initcontainer` fixtures.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended immutable filesystem checks to init and ephemeral containers, with read-only remediation guidance where available.
  * Added dangerous-capability detection for init and ephemeral containers across Pods, workloads, and CronJobs.
  * Added non-root execution checks for init and ephemeral containers, including remediation guidance for non-root users and groups.
* **Tests**
  * Added coverage for Pod and Deployment configurations involving init and ephemeral containers, including expected findings and remediation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->