### PR TITLE
fix: verify release artifact checksums

### DIFF
--- a/.github/workflows/create-release-v2.yaml
+++ b/.github/workflows/create-release-v2.yaml
@@ -72,6 +72,13 @@ jobs:
           cd release
           find . -type f \( -name '*.json' -o -name '*.csv' \) | while read f; do mv "$f" "${f%.*}"; done
 
+      - name: Generate SHA-256 checksums
+        run: |
+          cd release
+          find . -type f ! -name 'checksums.txt' -print0 | sort -z | while IFS= read -r -d '' file; do
+            sha256sum "${file#./}"
+          done > checksums.txt
+
       - run: ls -laR
 
       - name: Set outputs

--- a/gitregostore/gitstoreutils.go
+++ b/gitregostore/gitstoreutils.go
@@ -1,6 +1,9 @@
 package gitregostore
 
 import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -31,6 +34,7 @@ const (
 	ControlRuleRelationsFileName      = "ControlID_RuleName.csv"
 	defaultConfigInputsFileName       = "default_config_inputs.json"
 	systemPostureExceptionFileName    = "exceptions.json"
+	checksumsFileName                 = "checksums.txt"
 
 	controlIDRegex                    = `^(?:[a-z]+|[A-Z]+)(?:[\-][v]?(?:[0-9][\.]?)+)(?:[\-]?[0-9][\.]?)+$`
 	earliestTagWithSecurityFrameworks = "v1.0.282-rc.0"
@@ -137,16 +141,45 @@ func (gs *GitRegoStore) setObjects() error {
 }
 
 func (gs *GitRegoStore) setObjectsFromReleaseOnce() error {
+	var checksums map[string]string
+	var err error
+
+	if gs.StripFilesExtension {
+		checksums, err = gs.getReleaseChecksums()
+		if err != nil {
+			return err
+		}
+	}
 
 	for kind, storeSetterMappingFunc := range storeSetterMapping {
-		respStr, err := HttpGetter(gs.httpClient, fmt.Sprintf("%s/%s", gs.URL, gs.stripExtention(kind)))
+		artifactName := gs.stripExtention(kind)
+
+		var respStr string
+		if checksums != nil {
+			respStr, err = gs.getVerifiedArtifact(artifactName, checksums)
+		} else {
+			respStr, err = HttpGetter(
+				gs.httpClient,
+				fmt.Sprintf("%s/%s", gs.URL, artifactName),
+			)
+		}
+
 		if err != nil {
 			return fmt.Errorf("error getting: %s from: '%s' ,error: %s", kind, gs.URL, err)
 		}
+
+		if kind == frameworksJsonFileName && checksums != nil {
+			if err = gs.setFrameworksWithChecksums(respStr, checksums); err != nil {
+				return err
+			}
+			continue
+		}
+
 		if err = storeSetterMappingFunc(gs, respStr); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -155,23 +188,178 @@ func (gs *GitRegoStore) setFrameworks(respStr string) error {
 	if err := JSONDecoder(respStr).Decode(&frameworks); err != nil {
 		return err
 	}
-	// from a certain tag we have security frameworks
+
+	// From a certain tag we have security frameworks.
 	if gs.versionHasSecurityFrameworks() {
-		respStr1, err := HttpGetter(gs.httpClient, fmt.Sprintf("%s/%s", gs.URL, gs.stripExtention(securityFrameworksJsonFileName)))
+		respStr1, err := HttpGetter(
+			gs.httpClient,
+			fmt.Sprintf("%s/%s", gs.URL, gs.stripExtention(securityFrameworksJsonFileName)),
+		)
 		if err != nil {
 			return fmt.Errorf("error getting: %s from: '%s' ,error: %s", securityFrameworksJsonFileName, gs.URL, err)
 		}
+
 		securityFrameworks := []opapolicy.Framework{}
 		if err := JSONDecoder(respStr1).Decode(&securityFrameworks); err != nil {
 			return err
 		}
+
 		frameworks = append(frameworks, securityFrameworks...)
 	}
+
 	gs.frameworksLock.Lock()
 	defer gs.frameworksLock.Unlock()
 
 	gs.Frameworks = frameworks
 	return nil
+}
+
+func (gs *GitRegoStore) setFrameworksWithChecksums(respStr string, checksums map[string]string) error {
+	frameworks := []opapolicy.Framework{}
+	if err := JSONDecoder(respStr).Decode(&frameworks); err != nil {
+		return err
+	}
+
+	// From a certain tag we have security frameworks.
+	if gs.versionHasSecurityFrameworks() {
+		respStr1, err := gs.getVerifiedArtifact(gs.stripExtention(securityFrameworksJsonFileName), checksums)
+		if err != nil {
+			return fmt.Errorf("error getting or verifying %s from: '%s', error: %s", securityFrameworksJsonFileName, gs.URL, err)
+		}
+
+		securityFrameworks := []opapolicy.Framework{}
+		if err := JSONDecoder(respStr1).Decode(&securityFrameworks); err != nil {
+			return err
+		}
+
+		frameworks = append(frameworks, securityFrameworks...)
+	}
+
+	gs.frameworksLock.Lock()
+	defer gs.frameworksLock.Unlock()
+
+	gs.Frameworks = frameworks
+	return nil
+}
+
+func (gs *GitRegoStore) getReleaseChecksums() (map[string]string, error) {
+	respStr, err := HttpGetter(
+		gs.httpClient,
+		fmt.Sprintf("%s/%s", gs.URL, checksumsFileName),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error getting: %s from: '%s', error: %s",
+			checksumsFileName,
+			gs.URL,
+			err,
+		)
+	}
+
+	checksums, err := parseChecksums(respStr)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"invalid %s from: '%s', error: %s",
+			checksumsFileName,
+			gs.URL,
+			err,
+		)
+	}
+
+	return checksums, nil
+}
+
+func (gs *GitRegoStore) getVerifiedArtifact(
+	artifactName string,
+	checksums map[string]string,
+) (string, error) {
+	expectedChecksum, ok := checksums[artifactName]
+	if !ok {
+		return "", fmt.Errorf(
+			"no checksum entry found for artifact %q",
+			artifactName,
+		)
+	}
+
+	respStr, err := HttpGetter(
+		gs.httpClient,
+		fmt.Sprintf("%s/%s", gs.URL, artifactName),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	actualChecksum := sha256.Sum256([]byte(respStr))
+	actualChecksumHex := hex.EncodeToString(actualChecksum[:])
+
+	if !strings.EqualFold(actualChecksumHex, expectedChecksum) {
+		return "", fmt.Errorf(
+			"SHA-256 checksum mismatch for artifact %q: expected %s, got %s",
+			artifactName,
+			expectedChecksum,
+			actualChecksumHex,
+		)
+	}
+
+	return respStr, nil
+}
+
+func parseChecksums(content string) (map[string]string, error) {
+	checksums := make(map[string]string)
+	scanner := bufio.NewScanner(strings.NewReader(content))
+
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf(
+				"malformed checksum entry on line %d",
+				lineNumber,
+			)
+		}
+
+		checksum := fields[0]
+		filename := fields[1]
+
+		if len(checksum) != sha256.Size*2 {
+			return nil, fmt.Errorf(
+				"invalid SHA-256 checksum on line %d for artifact %q",
+				lineNumber,
+				filename,
+			)
+		}
+
+		if _, err := hex.DecodeString(checksum); err != nil {
+			return nil, fmt.Errorf(
+				"invalid SHA-256 checksum on line %d for artifact %q",
+				lineNumber,
+				filename,
+			)
+		}
+
+		if _, exists := checksums[filename]; exists {
+			return nil, fmt.Errorf(
+				"duplicate checksum entry for artifact %q on line %d",
+				filename,
+				lineNumber,
+			)
+		}
+
+		checksums[filename] = strings.ToLower(checksum)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading checksum manifest: %w", err)
+	}
+
+	return checksums, nil
 }
 
 func (gs *GitRegoStore) versionHasSecurityFrameworks() bool {

--- a/gitregostore/gitstoreutils_test.go
+++ b/gitregostore/gitstoreutils_test.go
@@ -1,9 +1,237 @@
 package gitregostore
 
 import (
+	"crypto/sha256"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+func TestParseChecksums(t *testing.T) {
+	validChecksum := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	tests := []struct {
+		name        string
+		content     string
+		want        map[string]string
+		expectError bool
+	}{
+		{
+			name:    "valid checksum manifest",
+			content: fmt.Sprintf("%s  controls\n%s  frameworks\n", validChecksum, validChecksum),
+			want: map[string]string{
+				"controls":   validChecksum,
+				"frameworks": validChecksum,
+			},
+		},
+		{
+			name:        "malformed entry",
+			content:     "not-a-valid-entry",
+			expectError: true,
+		},
+		{
+			name:        "invalid checksum length",
+			content:     "0123456789abcdef  controls",
+			expectError: true,
+		},
+		{
+			name:        "invalid checksum characters",
+			content:     "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz  controls",
+			expectError: true,
+		},
+		{
+			name: "duplicate artifact",
+			content: fmt.Sprintf(
+				"%s  controls\n%s  controls\n",
+				validChecksum,
+				validChecksum,
+			),
+			expectError: true,
+		},
+		{
+			name:    "empty manifest",
+			content: "",
+			want:    map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseChecksums(tt.content)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d checksums, want %d", len(got), len(tt.want))
+			}
+
+			for filename, checksum := range tt.want {
+				if got[filename] != checksum {
+					t.Errorf(
+						"checksum for %q = %q, want %q",
+						filename,
+						got[filename],
+						checksum,
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestGetVerifiedArtifact(t *testing.T) {
+	artifactName := "controls"
+	artifactContent := `{"name":"test-controls"}`
+	checksum := fmt.Sprintf("%x", sha256.Sum256([]byte(artifactContent)))
+
+	tests := []struct {
+		name          string
+		checksums     map[string]string
+		response      string
+		expectedError string
+	}{
+		{
+			name: "matching checksum",
+			checksums: map[string]string{
+				artifactName: checksum,
+			},
+			response: artifactContent,
+		},
+		{
+			name: "mismatching checksum",
+			checksums: map[string]string{
+				artifactName: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			},
+			response:      artifactContent,
+			expectedError: "SHA-256 checksum mismatch",
+		},
+		{
+			name:          "missing checksum entry",
+			checksums:     map[string]string{},
+			response:      artifactContent,
+			expectedError: "no checksum entry found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/controls" {
+					t.Fatalf("unexpected request path: %s", r.URL.Path)
+				}
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			gs := &GitRegoStore{
+				httpClient: server.Client(),
+				URL:        server.URL,
+			}
+
+			got, err := gs.getVerifiedArtifact(artifactName, tt.checksums)
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.expectedError)
+				}
+				if !strings.Contains(err.Error(), tt.expectedError) {
+					t.Fatalf("error = %q, want substring %q", err.Error(), tt.expectedError)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != artifactContent {
+				t.Fatalf("got %q, want %q", got, artifactContent)
+			}
+		})
+	}
+}
+
+func TestGetReleaseChecksums(t *testing.T) {
+	validChecksum := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	tests := []struct {
+		name          string
+		response      string
+		statusCode    int
+		expectedError string
+	}{
+		{
+			name:     "valid manifest",
+			response: fmt.Sprintf("%s  controls\n", validChecksum),
+		},
+		{
+			name:          "malformed manifest",
+			response:      "invalid checksum manifest",
+			expectedError: "invalid checksums.txt",
+		},
+		{
+			name:          "missing manifest",
+			response:      "not found",
+			statusCode:    http.StatusNotFound,
+			expectedError: "error getting: checksums.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/checksums.txt" {
+					t.Fatalf("unexpected request path: %s", r.URL.Path)
+				}
+
+				if tt.statusCode != 0 {
+					http.Error(w, tt.response, tt.statusCode)
+					return
+				}
+
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			gs := &GitRegoStore{
+				httpClient: server.Client(),
+				URL:        server.URL,
+			}
+
+			checksums, err := gs.getReleaseChecksums()
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.expectedError)
+				}
+				if !strings.Contains(err.Error(), tt.expectedError) {
+					t.Fatalf("error = %q, want substring %q", err.Error(), tt.expectedError)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if checksums["controls"] != validChecksum {
+				t.Fatalf("unexpected checksum: %q", checksums["controls"])
+			}
+		})
+	}
+}
 
 func Test_isControlID(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Overview

Verify SHA-256 checksums for artifacts downloaded from RegoLibrary releases.

- Generate `checksums.txt` during releases
- Verify downloaded artifacts against the manifest
- Fail on missing, invalid, or mismatched checksums
- Add tests for checksum parsing and verification

## How to Test

```bash
go test ./...
```

Closes https://github.com/kubescape/kubescape/issues/3735#issue-5360440541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release packages now include a SHA-256 checksum manifest.
  * Artifact downloads can be verified against published checksums when available.
  * Downloads continue using standard retrieval when checksum information is unavailable.

* **Bug Fixes**
  * Improved detection of corrupted or tampered release artifacts through checksum validation.

* **Tests**
  * Added coverage for checksum parsing, verification, malformed manifests, duplicate entries, and HTTP retrieval errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->