### PR TITLE
feat: expose checksum verification errors

### DIFF
--- a/gitregostore/gitstoreutils.go
+++ b/gitregostore/gitstoreutils.go
@@ -37,7 +37,10 @@ const (
 	checksumsFileName                 = "checksums.txt"
 )
 
-var errHTTPNotFound = errors.New("HTTP resource not found")
+var (
+	errHTTPNotFound         = errors.New("HTTP resource not found")
+	ErrChecksumVerification = errors.New("checksum verification failed")
+)
 
 const (
 	controlIDRegex                    = `^(?:[a-z]+|[A-Z]+)(?:[\-][v]?(?:[0-9][\.]?)+)(?:[\-]?[0-9][\.]?)+$`
@@ -205,7 +208,8 @@ func (gs *GitRegoStore) getReleaseChecksums() (map[string]string, error) {
 	checksums, err := parseChecksums(respStr)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"error parsing %s: %w",
+			"%w: error parsing %s: %w",
+			ErrChecksumVerification,
 			checksumsFileName,
 			err,
 		)
@@ -223,7 +227,8 @@ func (gs *GitRegoStore) getVerifiedReleaseArtifact(
 	expectedChecksum, ok := checksums[artifactName]
 	if !ok {
 		return "", fmt.Errorf(
-			"missing checksum for release artifact %q",
+			"%w: missing checksum for release artifact %q",
+			ErrChecksumVerification,
 			artifactName,
 		)
 	}
@@ -243,7 +248,8 @@ func (gs *GitRegoStore) getVerifiedReleaseArtifact(
 
 	if err := verifyChecksum(respStr, expectedChecksum); err != nil {
 		return "", fmt.Errorf(
-			"checksum verification failed for %q: %w",
+			"%w for %q: %w",
+			ErrChecksumVerification,
 			filename,
 			err,
 		)

--- a/gitregostore/gitstoreutils_test.go
+++ b/gitregostore/gitstoreutils_test.go
@@ -573,6 +573,10 @@ func TestGetVerifiedReleaseArtifactChecksumMismatch(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected checksum mismatch error, got nil")
 	}
+
+	if !errors.Is(err, ErrChecksumVerification) {
+		t.Fatalf("expected checksum verification error, got %v", err)
+	}
 }
 
 func TestGetVerifiedReleaseArtifactMissingChecksum(t *testing.T) {
@@ -592,5 +596,30 @@ func TestGetVerifiedReleaseArtifactMissingChecksum(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("expected missing checksum error, got nil")
+	}
+
+	if !errors.Is(err, ErrChecksumVerification) {
+		t.Fatalf("expected checksum verification error, got %v", err)
+	}
+}
+
+func TestGetReleaseChecksumsInvalidManifest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not-a-valid-checksum-entry"))
+	}))
+	defer server.Close()
+
+	gs := &GitRegoStore{
+		URL:        server.URL,
+		httpClient: http.DefaultClient,
+	}
+
+	_, err := gs.getReleaseChecksums()
+	if err == nil {
+		t.Fatal("expected invalid checksum manifest error, got nil")
+	}
+
+	if !errors.Is(err, ErrChecksumVerification) {
+		t.Fatalf("expected checksum verification error, got %v", err)
 	}
 }


### PR DESCRIPTION
 Fixes : : #815 
## Overview

* Adds exported `ErrChecksumVerification`
* Classifies malformed checksum manifests, missing checksums, and SHA-256 mismatches
* Adds `errors.Is()` coverage for checksum verification failures

This provides a stable error contract for consumers such as Kubescape to handle release artifact integrity failures explicitly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checksum verification error handling for release artifacts.
  * Missing, mismatched, or invalid checksum data now produces a consistent verification error, making failures easier to identify and handle reliably.
  * Added coverage for invalid checksum manifests returned by the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->