### PR TITLE
test: add agent runtime framework contract

### DIFF
--- a/docs/agent-runtime-hardening.md
+++ b/docs/agent-runtime-hardening.md
@@ -50,3 +50,22 @@ security or encryption.
 The CEL companion policies use the same six self-contained controls: C-0297,
 C-0309, and C-0311 through C-0314. Their missing/empty allowlist behavior and
 Docker Hub resolution match the corresponding Rego rules.
+
+## Validation
+
+The focused framework contract check verifies that the published framework
+contains the intended controls, that each control targets file and cluster
+scans, and that its rule matches only the supported Agent Sandbox and Agent
+Substrate resources:
+
+```shell
+go test ./gitregostore -run TestAgentRuntimeFrameworkContract -count=1
+```
+
+The individual rule fixture suite remains the source of truth for policy
+behavior:
+
+```shell
+cd testrunner
+go test -tags=static rego_test.go -run TestAllRules
+```

--- a/gitregostore/agent_runtime_test.go
+++ b/gitregostore/agent_runtime_test.go
@@ -15,6 +15,110 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+type frameworkManifest struct {
+	Name           string                       `json:"name"`
+	ScanningScope  reporthandling.ScanningScope `json:"scanningScope"`
+	ActiveControls []struct {
+		ControlID string `json:"controlID"`
+	} `json:"activeControls"`
+}
+
+type controlManifest struct {
+	ControlID     string                       `json:"controlID"`
+	RulesNames    []string                     `json:"rulesNames"`
+	ScanningScope reporthandling.ScanningScope `json:"scanningScope"`
+}
+
+type agentRuntimeControlContract struct {
+	rule      string
+	resources []string
+}
+
+func TestAgentRuntimeFrameworkContract(t *testing.T) {
+	frameworkFile, err := os.ReadFile(filepath.Join("..", "frameworks", "agent-runtime-hardening.json"))
+	require.NoError(t, err)
+
+	var framework frameworkManifest
+	require.NoError(t, json.Unmarshal(frameworkFile, &framework))
+	require.Equal(t, "AgentRuntimeHardening", framework.Name)
+	require.ElementsMatch(t, []reporthandling.ScanningScopeType{
+		reporthandling.ScopeCluster,
+		reporthandling.ScopeFile,
+	}, framework.ScanningScope.Matches)
+
+	expected := map[string]agentRuntimeControlContract{
+		"C-0297": {"agent-sandbox-hardened-runtime-class", []string{"Sandbox", "SandboxTemplate"}},
+		"C-0309": {"agent-sandbox-service-account-token", []string{"Sandbox", "SandboxTemplate"}},
+		"C-0311": {"agent-sandbox-container-limits", []string{"Sandbox", "SandboxTemplate"}},
+		"C-0312": {"agent-runtime-image-digests", []string{"Sandbox", "SandboxTemplate", "WorkerPool"}},
+		"C-0313": {"agent-runtime-image-registries", []string{"Sandbox", "SandboxTemplate", "WorkerPool"}},
+		"C-0314": {"agent-sandbox-managed-networking", []string{"SandboxTemplate"}},
+		"C-0315": {"agent-sandbox-strict-egress", []string{"SandboxTemplate"}},
+		"C-0316": {"agent-sandbox-claim-overrides", []string{"SandboxTemplate"}},
+		"C-0317": {"worker-pod-resource-ceilings", []string{"WorkerPool"}},
+	}
+
+	actualControls := make(map[string]struct{}, len(framework.ActiveControls))
+	for _, activeControl := range framework.ActiveControls {
+		actualControls[activeControl.ControlID] = struct{}{}
+	}
+	require.Len(t, framework.ActiveControls, len(expected))
+	require.Equal(t, expectedControlIDs(expected), actualControls)
+
+	for controlID, want := range expected {
+		t.Run(controlID, func(t *testing.T) {
+			control := readAgentRuntimeControl(t, controlID)
+			require.ElementsMatch(t, []reporthandling.ScanningScopeType{
+				reporthandling.ScopeCluster,
+				reporthandling.ScopeFile,
+			}, control.ScanningScope.Matches)
+			require.Equal(t, []string{want.rule}, control.RulesNames)
+
+			rule := readAgentRuntimeRule(t, want.rule)
+			actualResources := make([]string, 0)
+			for _, match := range rule.Match {
+				actualResources = append(actualResources, match.Resources...)
+			}
+			require.ElementsMatch(t, want.resources, actualResources)
+		})
+	}
+}
+
+func expectedControlIDs(expected map[string]agentRuntimeControlContract) map[string]struct{} {
+	ids := make(map[string]struct{}, len(expected))
+	for controlID := range expected {
+		ids[controlID] = struct{}{}
+	}
+	return ids
+}
+
+func readAgentRuntimeControl(t *testing.T, controlID string) controlManifest {
+	t.Helper()
+	files, err := filepath.Glob(filepath.Join("..", "controls", "*.json"))
+	require.NoError(t, err)
+	for _, file := range files {
+		contents, err := os.ReadFile(file)
+		require.NoError(t, err)
+		var control controlManifest
+		require.NoError(t, json.Unmarshal(contents, &control))
+		if control.ControlID == controlID {
+			return control
+		}
+	}
+	t.Fatalf("control %q is not present in controls", controlID)
+	return controlManifest{}
+}
+
+func readAgentRuntimeRule(t *testing.T, ruleName string) reporthandling.PolicyRule {
+	t.Helper()
+	contents, err := os.ReadFile(filepath.Join("..", "rules", ruleName, "rule.metadata.json"))
+	require.NoError(t, err)
+	var rule reporthandling.PolicyRule
+	require.NoError(t, json.Unmarshal(contents, &rule))
+	require.Equal(t, ruleName, rule.Name)
+	return rule
+}
+
 // These fixtures must also work after the production processor filters inputs by
 // rule metadata; passing data.json straight to OPA misses missing declarations.
 func TestAgentRuntimeConfiguredInputs(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a focused integration contract for the `AgentRuntimeHardening` framework.

Individual Rego fixtures already validate policy behavior. This test validates the framework composition that users receive through the release artifacts:

- the framework has exactly the intended nine controls
- every control supports both file and cluster scans
- each control points to its expected Rego rule
- each rule matches only the supported `Sandbox`, `SandboxTemplate`, and `WorkerPool` resources

This gives the Agent Runtime work an early CI guard against accidental control removals, duplicate framework entries, or changes to supported resource coverage.

The Agent Runtime Hardening documentation now includes the focused validation command and the full Rego fixture command.

Related to kubescape/kubescape#2557.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added validation guidance covering framework contracts and rule fixture test commands.

- **Tests**
  - Added automated validation for the agent-runtime hardening framework.
  - Verifies framework scope, active controls, rule names, scanning coverage, and matched resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->